### PR TITLE
Fix context class test stability

### DIFF
--- a/tests/Checker/Check_Context_Tests.php
+++ b/tests/Checker/Check_Context_Tests.php
@@ -11,8 +11,8 @@ class Check_Context_Tests extends WP_UnitTestCase {
 	public function set_up() {
 		parent::set_up();
 
-		$this->plugin_name   = basename( dirname( __DIR__ ) );
-		$this->check_context = new Check_Context( $this->plugin_name . '/plugin-check.php' );
+		$this->plugin_name   = basename( TESTS_PLUGIN_DIR );
+		$this->check_context = new Check_Context( WP_PLUGIN_DIR . '/' . $this->plugin_name . '/plugin-check.php' );
 	}
 
 	public function test_basename() {
@@ -20,11 +20,11 @@ class Check_Context_Tests extends WP_UnitTestCase {
 	}
 
 	public function test_path() {
-		$this->assertSame( $this->plugin_name . '/', $this->check_context->path() );
+		$this->assertSame( WP_PLUGIN_DIR . '/' . $this->plugin_name . '/', $this->check_context->path() );
 	}
 
 	public function test_path_with_parameter() {
-		$this->assertSame( $this->plugin_name . '/another/folder', $this->check_context->path( '/another/folder' ) );
+		$this->assertSame( WP_PLUGIN_DIR . '/' . $this->plugin_name . '/another/folder', $this->check_context->path( '/another/folder' ) );
 	}
 
 	public function test_url() {

--- a/tests/Plugin_Context_Tests.php
+++ b/tests/Plugin_Context_Tests.php
@@ -11,8 +11,8 @@ class Plugin_Context_Tests extends WP_UnitTestCase {
 	public function set_up() {
 		parent::set_up();
 
-		$this->plugin_name    = basename( dirname( __DIR__ ) );
-		$this->plugin_context = new Plugin_Context( $this->plugin_name . '/plugin-check.php' );
+		$this->plugin_name    = basename( TESTS_PLUGIN_DIR );
+		$this->plugin_context = new Plugin_Context( WP_PLUGIN_DIR . '/' . $this->plugin_name . '/plugin-check.php' );
 	}
 
 	public function test_basename() {
@@ -20,11 +20,11 @@ class Plugin_Context_Tests extends WP_UnitTestCase {
 	}
 
 	public function test_path() {
-		$this->assertSame( $this->plugin_name . '/', $this->plugin_context->path() );
+		$this->assertSame( WP_PLUGIN_DIR . '/' . $this->plugin_name . '/', $this->plugin_context->path() );
 	}
 
 	public function test_path_with_parameter() {
-		$this->assertSame( $this->plugin_name . '/another/folder', $this->plugin_context->path( '/another/folder' ) );
+		$this->assertSame( WP_PLUGIN_DIR . '/' . $this->plugin_name . '/another/folder', $this->plugin_context->path( '/another/folder' ) );
 	}
 
 	public function test_url() {


### PR DESCRIPTION
Addresses comments in https://github.com/10up/plugin-check/pull/47#discussion_r1055676303

- Makes use of the `TESTS_PLUGIN_DIR` constant when creating instances of the `Plugin_Context` and `Check_Context` classes in unit tests. `TESTS_PLUGIN_DIR` is equal to `/var/www/html/wp-content/plugins/plugin-check/`.
- This is similar to how the classes are instantiated using the `__FILE__` constant (seen in [`plugin-check.php` file](https://github.com/10up/plugin-check/blob/trunk/plugin-check.php#L45) and creates the same expected full path, e.g `/var/www/html/wp-content/plugins/plugin-check/`
- Tests are then updated to use the full path by prefixing expected strings with `WP_PLUGIN_DIR . '\'`