### PR TITLE
Create Minimal_Theme_Preparation

### DIFF
--- a/includes/Checker/Preparations/Use_Minimal_Theme_Preparation.php
+++ b/includes/Checker/Preparations/Use_Minimal_Theme_Preparation.php
@@ -1,0 +1,139 @@
+<?php
+/**
+ * Class WordPress\Plugin_Check\Checker\Preparations\Use_Minimal_Theme_Preparation
+ *
+ * @package plugin-check
+ */
+
+namespace WordPress\Plugin_Check\Checker\Preparations;
+
+use WordPress\Plugin_Check\Checker\Preparation;
+use Exception;
+
+/**
+ * Class for the preparation step to force usage of a minimal theme.
+ *
+ * This ensures the plugin is checked as much in isolation as possible.
+ *
+ * @since n.e.x.t
+ */
+class Use_Minimal_Theme_Preparation implements Preparation {
+
+	/**
+	 * Theme slug / directory name.
+	 *
+	 * @since n.e.x.t
+	 * @var string
+	 */
+	protected $theme_slug;
+
+	/**
+	 * Absolute path to themes root directory.
+	 *
+	 * @since n.e.x.t
+	 * @var string
+	 */
+	protected $themes_dir;
+
+	/**
+	 * Sets the theme slug and themes root directory.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param string $theme_slug Slug of the theme to enforce.
+	 * @param string $themes_dir Optional. Absolute path to themes root directory, if not the regular wp-content/themes.
+	 */
+	public function __construct( $theme_slug, $themes_dir = '' ) {
+		$this->theme_slug = $theme_slug;
+		$this->themes_dir = $themes_dir;
+	}
+
+	/**
+	 * Runs this preparation step for the environment and returns a cleanup function.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @return callable Cleanup function to revert any changes made here.
+	 *
+	 * @throws Exception Thrown when preparation fails.
+	 */
+	public function prepare() {
+		// Override the theme slug and name.
+		add_filter( 'template', array( $this, 'get_theme_slug' ) );
+		add_filter( 'stylesheet', array( $this, 'get_theme_slug' ) );
+		add_filter( 'pre_option_template', array( $this, 'get_theme_slug' ) );
+		add_filter( 'pre_option_stylesheet', array( $this, 'get_theme_slug' ) );
+		add_filter( 'pre_option_current_theme', array( $this, 'get_theme_name' ) );
+
+		// Override the theme directory.
+		add_filter( 'pre_option_template_root', array( $this, 'get_theme_root' ) );
+		add_filter( 'pre_option_stylesheet_root', array( $this, 'get_theme_root' ) );
+
+		// Register the custom themes directory if relevant.
+		if ( ! empty( $this->themes_dir ) ) {
+			register_theme_directory( $this->themes_dir );
+		}
+
+		// Return the cleanup function.
+		return function() {
+			global $wp_theme_directories;
+
+			remove_filter( 'template', array( $this, 'get_theme_slug' ) );
+			remove_filter( 'stylesheet', array( $this, 'get_theme_slug' ) );
+			remove_filter( 'pre_option_template', array( $this, 'get_theme_slug' ) );
+			remove_filter( 'pre_option_stylesheet', array( $this, 'get_theme_slug' ) );
+			remove_filter( 'pre_option_current_theme', array( $this, 'get_theme_name' ) );
+
+			remove_filter( 'pre_option_template_root', array( $this, 'get_theme_root' ) );
+			remove_filter( 'pre_option_stylesheet_root', array( $this, 'get_theme_root' ) );
+
+			if ( ! empty( $this->themes_dir ) ) {
+				$index = array_search( untrailingslashit( $this->themes_dir ), $wp_theme_directories, true );
+				if ( false !== $index ) {
+					array_splice( $wp_theme_directories, $index, 1 );
+					$wp_theme_directories = array_values( $wp_theme_directories );
+				}
+			}
+		};
+	}
+
+	/**
+	 * Gets the theme slug.
+	 *
+	 * Used as a filter callback.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @return string The theme slug.
+	 */
+	public function get_theme_slug() {
+		return $this->theme_slug;
+	}
+
+	/**
+	 * Gets the theme name.
+	 *
+	 * Used as a filter callback.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @return string The theme name.
+	 */
+	public function get_theme_name() {
+		$theme = wp_get_theme( $this->theme_slug, $this->themes_dir );
+		return $theme->display( 'Name' );
+	}
+
+	/**
+	 * Gets the theme root.
+	 *
+	 * Used as a filter callback.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @return string The theme root.
+	 */
+	public function get_theme_root() {
+		return get_raw_theme_root( $this->theme_slug, true );
+	}
+}

--- a/includes/Checker/Preparations/Use_Minimal_Theme_Preparation.php
+++ b/includes/Checker/Preparations/Use_Minimal_Theme_Preparation.php
@@ -72,6 +72,9 @@ class Use_Minimal_Theme_Preparation implements Preparation {
 		// Register the custom themes directory if relevant.
 		if ( ! empty( $this->themes_dir ) ) {
 			register_theme_directory( $this->themes_dir );
+
+			// Force new directory scan to ensure the new theme directory is available.
+			search_theme_directories( true );
 		}
 
 		// Return the cleanup function.

--- a/includes/Checker/Preparations/Use_Minimal_Theme_Preparation.php
+++ b/includes/Checker/Preparations/Use_Minimal_Theme_Preparation.php
@@ -95,11 +95,11 @@ class Use_Minimal_Theme_Preparation implements Preparation {
 				if ( false !== $index ) {
 					array_splice( $wp_theme_directories, $index, 1 );
 					$wp_theme_directories = array_values( $wp_theme_directories );
+
+					// Force new directory scan to remove the test theme directory.
+					search_theme_directories( true );
 				}
 			}
-
-			// Force new directory scan to remove the test theme directory.
-			search_theme_directories( true );
 		};
 	}
 

--- a/includes/Checker/Preparations/Use_Minimal_Theme_Preparation.php
+++ b/includes/Checker/Preparations/Use_Minimal_Theme_Preparation.php
@@ -53,6 +53,8 @@ class Use_Minimal_Theme_Preparation implements Preparation {
 	 *
 	 * @since n.e.x.t
 	 *
+	 * @global array $wp_theme_directories
+	 *
 	 * @return callable Cleanup function to revert any changes made here.
 	 *
 	 * @throws Exception Thrown when preparation fails.

--- a/includes/Checker/Preparations/Use_Minimal_Theme_Preparation.php
+++ b/includes/Checker/Preparations/Use_Minimal_Theme_Preparation.php
@@ -73,7 +73,7 @@ class Use_Minimal_Theme_Preparation implements Preparation {
 		if ( ! empty( $this->themes_dir ) ) {
 			register_theme_directory( $this->themes_dir );
 
-			// Force new directory scan to ensure the new theme directory is available.
+			// Force new directory scan to ensure the test theme directory is available.
 			search_theme_directories( true );
 		}
 
@@ -97,6 +97,9 @@ class Use_Minimal_Theme_Preparation implements Preparation {
 					$wp_theme_directories = array_values( $wp_theme_directories );
 				}
 			}
+
+			// Force new directory scan to remove the test theme directory.
+			search_theme_directories( true );
 		};
 	}
 

--- a/plugin-check.php
+++ b/plugin-check.php
@@ -78,5 +78,4 @@ function wp_plugin_check_display_composer_autoload_notice() {
 	echo '</p></div>';
 }
 
-
 wp_plugin_check_load();

--- a/test-content/themes/wp-empty-theme/comments.php
+++ b/test-content/themes/wp-empty-theme/comments.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * The template for displaying comments
+ *
+ * @package wp-empty-theme
+ * @link https://developer.wordpress.org/themes/basics/template-hierarchy/
+ */
+
+if ( post_password_required() ) {
+	return;
+}
+
+?>
+
+<div id="comments" class="comments-area default-max-width <?php echo get_option( 'show_avatars' ) ? 'show-avatars' : ''; ?>">
+	<?php
+	if ( have_comments() ) {
+		?>
+		<h2 class="comments-title">
+			<?php
+			if ( '1' === get_comments_number() ) {
+				esc_html_e( '1 comment', 'wp-empty-theme' );
+			} else {
+				printf(
+					/* translators: %s: Comment count number. */
+					esc_html( _nx( '%s comment', '%s comments', get_comments_number(), 'Comments title', 'wp-empty-theme' ) ),
+					esc_html( number_format_i18n( get_comments_number() ) )
+				);
+			}
+			?>
+		</h2><!-- .comments-title -->
+
+		<ol class="comment-list">
+			<?php
+			wp_list_comments(
+				array(
+					'avatar_size' => 60,
+					'style'       => 'ol',
+					'short_ping'  => true,
+				)
+			);
+			?>
+		</ol><!-- .comment-list -->
+
+		<?php
+		the_comments_pagination(
+			array(
+				'before_page_number' => esc_html__( 'Page', 'wp-empty-theme' ) . ' ',
+				'mid_size'           => 0,
+				'prev_text'          => sprintf(
+					'<span class="nav-prev-text">%s</span>',
+					esc_html__( 'Older comments', 'wp-empty-theme' )
+				),
+				'next_text'          => sprintf(
+					'<span class="nav-next-text">%s</span>',
+					esc_html__( 'Newer comments', 'wp-empty-theme' )
+				),
+			)
+		);
+
+		if ( ! comments_open() ) {
+			?>
+			<p class="no-comments"><?php esc_html_e( 'Comments are closed.', 'wp-empty-theme' ); ?></p>
+			<?php
+		}
+	}
+
+	comment_form(
+		array(
+			'logged_in_as'       => null,
+			'title_reply'        => esc_html__( 'Leave a comment', 'wp-empty-theme' ),
+			'title_reply_before' => '<h2 id="reply-title" class="comment-reply-title">',
+			'title_reply_after'  => '</h2>',
+		)
+	);
+	?>
+</div><!-- #comments -->

--- a/test-content/themes/wp-empty-theme/footer.php
+++ b/test-content/themes/wp-empty-theme/footer.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * The template for displaying the footer
+ *
+ * @package wp-empty-theme
+ * @link https://developer.wordpress.org/themes/basics/template-files/#template-partials
+ */
+
+?>
+			</main><!-- #main -->
+		</div><!-- #primary -->
+	</div><!-- #content -->
+
+	<footer id="colophon" class="site-footer" role="contentinfo">
+		<div class="site-info">
+			<div class="site-name">
+				<?php
+				if ( get_bloginfo( 'name' ) ) {
+					if ( is_front_page() && ! is_paged() ) {
+						bloginfo( 'name' );
+					} else {
+						?>
+						<a href="<?php echo esc_url( home_url( '/' ) ); ?>"><?php bloginfo( 'name' ); ?></a>
+						<?php
+					}
+				}
+				?>
+			</div><!-- .site-name -->
+			<div class="powered-by">
+				<?php
+				printf(
+					/* translators: %s: WordPress. */
+					esc_html__( 'Proudly powered by %s.', 'wp-empty-theme' ),
+					'<a href="' . esc_url( __( 'https://wordpress.org/', 'wp-empty-theme' ) ) . '">WordPress</a>'
+				);
+				?>
+			</div><!-- .powered-by -->
+		</div><!-- .site-info -->
+	</footer><!-- #colophon -->
+
+</div><!-- #page -->
+
+<?php wp_footer(); ?>
+
+</body>
+</html>

--- a/test-content/themes/wp-empty-theme/functions.php
+++ b/test-content/themes/wp-empty-theme/functions.php
@@ -1,0 +1,161 @@
+<?php
+/**
+ * Functions and definitions
+ *
+ * @package wp-empty-theme
+ * @link https://developer.wordpress.org/themes/basics/theme-functions/
+ */
+
+// This theme requires WordPress 5.3 or later.
+if ( version_compare( $GLOBALS['wp_version'], '5.3', '<' ) ) {
+	require get_template_directory() . '/inc/back-compat.php';
+}
+
+if ( ! function_exists( 'wp_empty_theme_setup' ) ) {
+	/**
+	 * Sets up theme defaults and registers support for various WordPress features.
+	 *
+	 * Note that this function is hooked into the after_setup_theme hook, which
+	 * runs before the init hook. The init hook is too late for some features, such
+	 * as indicating support for post thumbnails.
+	 */
+	function wp_empty_theme_setup() {
+		/*
+		 * Make theme available for translation.
+		 * Translations can be filed in the /languages/ directory.
+		 */
+		load_theme_textdomain( 'wp-empty-theme', get_template_directory() . '/languages' );
+
+		// Add default posts and comments RSS feed links to head.
+		add_theme_support( 'automatic-feed-links' );
+
+		/*
+		 * Let WordPress manage the document title.
+		 * This theme does not use a hard-coded <title> tag in the document head,
+		 * WordPress will provide it for us.
+		 */
+		add_theme_support( 'title-tag' );
+
+		/**
+		 * Add post-formats support.
+		 */
+		add_theme_support(
+			'post-formats',
+			array(
+				'link',
+				'aside',
+				'gallery',
+				'image',
+				'quote',
+				'status',
+				'video',
+				'audio',
+				'chat',
+			)
+		);
+
+		/*
+		 * Enable support for Post Thumbnails on posts and pages.
+		 *
+		 * @link https://developer.wordpress.org/themes/functionality/featured-images-post-thumbnails/
+		 */
+		add_theme_support( 'post-thumbnails' );
+		set_post_thumbnail_size( 1568, 9999 );
+
+		/*
+		 * Switch default core markup for search form, comment form, and comments
+		 * to output valid HTML5.
+		 */
+		add_theme_support(
+			'html5',
+			array(
+				'comment-form',
+				'comment-list',
+				'gallery',
+				'caption',
+				'style',
+				'script',
+				'navigation-widgets',
+			)
+		);
+
+		/*
+		 * Add support for core custom logo.
+		 *
+		 * @link https://codex.wordpress.org/Theme_Logo
+		 */
+		$logo_width  = 300;
+		$logo_height = 100;
+
+		add_theme_support(
+			'custom-logo',
+			array(
+				'height'               => $logo_height,
+				'width'                => $logo_width,
+				'flex-width'           => true,
+				'flex-height'          => true,
+				'unlink-homepage-logo' => true,
+			)
+		);
+
+		// Add theme support for selective refresh for widgets.
+		add_theme_support( 'customize-selective-refresh-widgets' );
+
+		// Add support for full and wide align images.
+		add_theme_support( 'align-wide' );
+
+		// Add support for editor styles.
+		add_theme_support( 'editor-styles' );
+
+		// Add support for responsive embedded content.
+		add_theme_support( 'responsive-embeds' );
+	}
+}
+add_action( 'after_setup_theme', 'wp_empty_theme_setup' );
+
+/**
+ * Sets the content width in pixels, based on the theme's design and stylesheet.
+ *
+ * Priority 0 to make it available to lower priority callbacks.
+ *
+ * @global int $content_width Content width.
+ */
+function wp_empty_theme_content_width() {
+	// This variable is intended to be overruled from themes.
+	// Open WPCS issue: {@link https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/1043}.
+	// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
+	$GLOBALS['content_width'] = 750;
+}
+add_action( 'after_setup_theme', 'wp_empty_theme_content_width', 0 );
+
+/**
+ * Prints the minimum theme stylesheet with WP-required directives.
+ */
+function wp_empty_theme_print_min_style() {
+	$css = file_get_contents( get_stylesheet_directory() . '/min-style.css' );
+	?>
+	<style type="text/css">
+		<?php echo $css; // phpcs:ignore WordPress.Security.EscapeOutput ?>
+	</style>
+	<?php
+}
+add_action( 'wp_head', 'wp_empty_theme_print_min_style', 2 );
+
+/**
+ * Enqueues scripts and styles.
+ */
+function wp_empty_theme_scripts() {
+	// Threaded comment reply styles.
+	// This is the only script loaded by the theme, since it's effectively a
+	// required default for WordPress themes.
+	if ( is_singular() && comments_open() && get_option( 'thread_comments' ) ) {
+		wp_enqueue_script( 'comment-reply' );
+	}
+}
+add_action( 'wp_enqueue_scripts', 'wp_empty_theme_scripts' );
+
+// Enhance the theme by hooking into WordPress.
+require get_template_directory() . '/inc/template-functions.php';
+
+// Custom template tags for the theme.
+require get_template_directory() . '/inc/template-tags.php';

--- a/test-content/themes/wp-empty-theme/header.php
+++ b/test-content/themes/wp-empty-theme/header.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * The template for displaying the header
+ *
+ * @package wp-empty-theme
+ * @link https://developer.wordpress.org/themes/basics/template-files/#template-partials
+ */
+
+?>
+<!doctype html>
+<html <?php language_attributes(); ?>>
+<head>
+	<meta charset="<?php bloginfo( 'charset' ); ?>" />
+	<meta name="viewport" content="width=device-width, initial-scale=1" />
+	<?php wp_head(); ?>
+</head>
+
+<body <?php body_class(); ?>>
+<?php wp_body_open(); ?>
+
+<div id="page" class="site">
+	<a class="skip-link screen-reader-text" href="#content"><?php esc_html_e( 'Skip to content', 'wp-empty-theme' ); ?></a>
+
+	<header id="masthead" class="site-header" role="banner">
+		<div class="site-branding">
+			<?php
+			if ( has_custom_logo() ) {
+				?>
+				<div class="site-logo"><?php the_custom_logo(); ?></div>
+				<?php
+			}
+
+			if ( get_bloginfo( 'name', 'display' ) ) {
+				?>
+				<p class="site-title">
+					<a href="<?php echo esc_url( home_url( '/' ) ); ?>"><?php bloginfo( 'name' ); ?></a>
+				</p>
+				<?php
+			}
+
+			if ( get_bloginfo( 'description', 'display' ) ) {
+				?>
+				<p class="site-description">
+					<?php bloginfo( 'description' ); ?>
+				</p>
+				<?php
+			}
+			?>
+		</div><!-- .site-branding -->
+	</header><!-- #masthead -->
+
+	<div id="content" class="site-content">
+		<div id="primary" class="content-area">
+			<main id="main" class="site-main" role="main">

--- a/test-content/themes/wp-empty-theme/inc/back-compat.php
+++ b/test-content/themes/wp-empty-theme/inc/back-compat.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * Back compat functionality
+ *
+ * Prevents the theme from running on WordPress versions prior to 5.3,
+ * since this theme is not meant to be backward compatible beyond that and
+ * relies on many newer functions and markup changes introduced in 5.3.
+ *
+ * @package wp-empty-theme
+ */
+
+/**
+ * Display upgrade notice on theme switch.
+ */
+function wp_empty_theme_switch_theme() {
+	add_action( 'admin_notices', 'wp_empty_theme_upgrade_notice' );
+}
+add_action( 'after_switch_theme', 'wp_empty_theme_switch_theme' );
+
+/**
+ * Adds a message for unsuccessful theme switch.
+ *
+ * Prints an update nag after an unsuccessful attempt to switch to
+ * the theme on WordPress versions prior to 5.3.
+ *
+ * @global string $wp_version WordPress version.
+ */
+function wp_empty_theme_upgrade_notice() {
+	echo '<div class="error"><p>';
+	printf(
+		/* translators: %s: WordPress Version. */
+		esc_html__( 'This theme requires WordPress 5.3 or newer. You are running version %s. Please upgrade.', 'wp-empty-theme' ),
+		esc_html( $GLOBALS['wp_version'] )
+	);
+	echo '</p></div>';
+}
+
+/**
+ * Prevents the Customizer from being loaded on WordPress versions prior to 5.3.
+ *
+ * @global string $wp_version WordPress version.
+ */
+function wp_empty_theme_customize() {
+	wp_die(
+		sprintf(
+			/* translators: %s: WordPress Version. */
+			esc_html__( 'This theme requires WordPress 5.3 or newer. You are running version %s. Please upgrade.', 'wp-empty-theme' ),
+			esc_html( $GLOBALS['wp_version'] )
+		),
+		'',
+		array(
+			'back_link' => true,
+		)
+	);
+}
+add_action( 'load-customize.php', 'wp_empty_theme_customize' );
+
+/**
+ * Prevents the Theme Preview from being loaded on WordPress versions prior to 5.3.
+ *
+ * @global string $wp_version WordPress version.
+ */
+function wp_empty_theme_preview() {
+	if ( isset( $_GET['preview'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
+		wp_die(
+			sprintf(
+				/* translators: %s: WordPress Version. */
+				esc_html__( 'This theme requires WordPress 5.3 or newer. You are running version %s. Please upgrade.', 'wp-empty-theme' ),
+				esc_html( $GLOBALS['wp_version'] )
+			)
+		);
+	}
+}
+add_action( 'template_redirect', 'wp_empty_theme_preview' );

--- a/test-content/themes/wp-empty-theme/inc/template-functions.php
+++ b/test-content/themes/wp-empty-theme/inc/template-functions.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * Functions which enhance the theme by hooking into WordPress
+ *
+ * @package wp-empty-theme
+ */
+
+/**
+ * Adds custom class to the array of posts classes.
+ *
+ * @param array $classes An array of CSS classes.
+ * @return array
+ */
+function wp_empty_theme_post_classes( $classes ) {
+	$classes[] = 'entry';
+
+	return $classes;
+}
+add_filter( 'post_class', 'wp_empty_theme_post_classes', 10, 3 );
+
+/**
+ * Add a pingback url auto-discovery header for single posts, pages, or attachments.
+ */
+function wp_empty_theme_pingback_header() {
+	if ( is_singular() && pings_open() ) {
+		echo '<link rel="pingback" href="', esc_url( get_bloginfo( 'pingback_url' ) ), '">';
+	}
+}
+add_action( 'wp_head', 'wp_empty_theme_pingback_header' );
+
+/**
+ * Creates continue reading text.
+ */
+function wp_empty_theme_continue_reading_text() {
+	$continue_reading = sprintf(
+		/* translators: %s: Name of current post. */
+		esc_html__( 'Continue reading %s', 'wp-empty-theme' ),
+		the_title( '<span class="screen-reader-text">', '</span>', false )
+	);
+
+	return $continue_reading;
+}
+
+/**
+ * Creates the continue reading link for excerpt.
+ */
+function wp_empty_theme_continue_reading_link_excerpt() {
+	if ( ! is_admin() ) {
+		return '&hellip; <a class="more-link" href="' . esc_url( get_permalink() ) . '">' . wp_empty_theme_continue_reading_text() . '</a>';
+	}
+}
+add_filter( 'excerpt_more', 'wp_empty_theme_continue_reading_link_excerpt' );
+
+/**
+ * Creates the continue reading link.
+ */
+function wp_empty_theme_continue_reading_link() {
+	if ( ! is_admin() ) {
+		return '<div class="more-link-container"><a class="more-link" href="' . esc_url( get_permalink() ) . '#more-' . esc_attr( get_the_ID() ) . '">' . wp_empty_theme_continue_reading_text() . '</a></div>';
+	}
+}
+add_filter( 'the_content_more_link', 'wp_empty_theme_continue_reading_link' );

--- a/test-content/themes/wp-empty-theme/inc/template-tags.php
+++ b/test-content/themes/wp-empty-theme/inc/template-tags.php
@@ -1,0 +1,151 @@
+<?php
+/**
+ * Custom template tags for this theme
+ *
+ * @package wp-empty-theme
+ */
+
+if ( ! function_exists( 'wp_empty_theme_posted_on' ) ) {
+	/**
+	 * Prints HTML with meta information for the current post-date/time.
+	 */
+	function wp_empty_theme_posted_on() {
+		$time_string = '<time class="entry-date published updated" datetime="%1$s">%2$s</time>';
+
+		$time_string = sprintf(
+			$time_string,
+			esc_attr( get_the_date( DATE_W3C ) ),
+			esc_html( get_the_date() )
+		);
+		echo '<span class="posted-on">';
+		printf(
+			/* translators: %s: Publish date. */
+			esc_html__( 'Published %s', 'wp-empty-theme' ),
+			$time_string // phpcs:ignore WordPress.Security.EscapeOutput
+		);
+		echo '</span>';
+	}
+}
+
+if ( ! function_exists( 'wp_empty_theme_posted_by' ) ) {
+	/**
+	 * Prints HTML with meta information about theme author.
+	 */
+	function wp_empty_theme_posted_by() {
+		if ( ! get_the_author_meta( 'description' ) && post_type_supports( get_post_type(), 'author' ) ) {
+			echo '<span class="byline">';
+			printf(
+				/* translators: %s: Author name. */
+				esc_html__( 'By %s', 'wp-empty-theme' ),
+				'<a href="' . esc_url( get_author_posts_url( get_the_author_meta( 'ID' ) ) ) . '" rel="author">' . esc_html( get_the_author() ) . '</a>'
+			);
+			echo '</span>';
+		}
+	}
+}
+
+if ( ! function_exists( 'wp_empty_theme_entry_meta_footer' ) ) {
+	/**
+	 * Prints HTML with meta information for the categories, tags and comments.
+	 * Footer entry meta is displayed differently in archives and single posts.
+	 */
+	function wp_empty_theme_entry_meta_footer() {
+
+		// Early exit if not a post.
+		if ( 'post' !== get_post_type() ) {
+			return;
+		}
+
+		// Hide meta information on pages.
+		if ( ! is_single() ) {
+
+			if ( is_sticky() ) {
+				echo '<p>' . esc_html_x( 'Featured post', 'Label for sticky posts', 'wp-empty-theme' ) . '</p>';
+			}
+
+			// Posted on.
+			wp_empty_theme_posted_on();
+
+			// Edit post link.
+			edit_post_link(
+				sprintf(
+					/* translators: %s: Name of current post. Only visible to screen readers. */
+					esc_html__( 'Edit %s', 'wp-empty-theme' ),
+					'<span class="screen-reader-text">' . get_the_title() . '</span>'
+				),
+				'<span class="edit-link">',
+				'</span><br>'
+			);
+
+			if ( has_category() || has_tag() ) {
+
+				echo '<div class="post-taxonomies">';
+
+				/* translators: Used between list items, there is a space after the comma. */
+				$categories_list = get_the_category_list( __( ', ', 'wp-empty-theme' ) );
+				if ( $categories_list ) {
+					printf(
+						/* translators: %s: List of categories. */
+						'<span class="cat-links">' . esc_html__( 'Categorized as %s', 'wp-empty-theme' ) . ' </span>',
+						$categories_list // phpcs:ignore WordPress.Security.EscapeOutput
+					);
+				}
+
+				/* translators: Used between list items, there is a space after the comma. */
+				$tags_list = get_the_tag_list( '', __( ', ', 'wp-empty-theme' ) );
+				if ( $tags_list ) {
+					printf(
+						/* translators: %s: List of tags. */
+						'<span class="tags-links">' . esc_html__( 'Tagged %s', 'wp-empty-theme' ) . '</span>',
+						$tags_list // phpcs:ignore WordPress.Security.EscapeOutput
+					);
+				}
+				echo '</div>';
+			}
+		} else {
+
+			echo '<div class="posted-by">';
+			// Posted on.
+			wp_empty_theme_posted_on();
+			// Posted by.
+			wp_empty_theme_posted_by();
+			// Edit post link.
+			edit_post_link(
+				sprintf(
+					/* translators: %s: Name of current post. Only visible to screen readers. */
+					esc_html__( 'Edit %s', 'wp-empty-theme' ),
+					'<span class="screen-reader-text">' . get_the_title() . '</span>'
+				),
+				'<span class="edit-link">',
+				'</span>'
+			);
+			echo '</div>';
+
+			if ( has_category() || has_tag() ) {
+
+				echo '<div class="post-taxonomies">';
+
+				/* translators: Used between list items, there is a space after the comma. */
+				$categories_list = get_the_category_list( __( ', ', 'wp-empty-theme' ) );
+				if ( $categories_list ) {
+					printf(
+						/* translators: %s: List of categories. */
+						'<span class="cat-links">' . esc_html__( 'Categorized as %s', 'wp-empty-theme' ) . ' </span>',
+						$categories_list // phpcs:ignore WordPress.Security.EscapeOutput
+					);
+				}
+
+				/* translators: Used between list items, there is a space after the comma. */
+				$tags_list = get_the_tag_list( '', __( ', ', 'wp-empty-theme' ) );
+				if ( $tags_list ) {
+					printf(
+						/* translators: %s: List of tags. */
+						'<span class="tags-links">' . esc_html__( 'Tagged %s', 'wp-empty-theme' ) . '</span>',
+						$tags_list // phpcs:ignore WordPress.Security.EscapeOutput
+					);
+				}
+				echo '</div>';
+			}
+		}
+	}
+}

--- a/test-content/themes/wp-empty-theme/index.php
+++ b/test-content/themes/wp-empty-theme/index.php
@@ -1,0 +1,153 @@
+<?php
+/**
+ * The main template file
+ *
+ * @package wp-empty-theme
+ * @link https://developer.wordpress.org/themes/basics/template-hierarchy/
+ */
+
+get_header();
+?>
+
+<?php
+if ( is_home() && ! is_front_page() && ! empty( single_post_title( '', false ) ) ) {
+	?>
+	<header class="page-header alignwide">
+		<h1 class="page-title"><?php single_post_title(); ?></h1>
+	</header><!-- .page-header -->
+	<?php
+} elseif ( is_search() ) {
+	?>
+	<header class="page-header alignwide">
+		<h1 class="page-title">
+			<?php
+			printf(
+				/* translators: %s: Search term. */
+				esc_html__( 'Results for "%s"', 'wp-empty-theme' ),
+				esc_html( get_search_query() )
+			);
+			?>
+		</h1>
+	</header><!-- .page-header -->
+	<?php
+} elseif ( is_archive() ) {
+	?>
+	<header class="page-header alignwide">
+		<?php the_archive_title( '<h1 class="page-title">', '</h1>' ); ?>
+		<?php the_archive_description( '<p class="page-description">', '</p>' ); ?>
+	</header><!-- .page-header -->
+	<?php
+} elseif ( is_404() ) {
+	?>
+	<header class="page-header alignwide">
+		<h1 class="page-title"><?php esc_html_e( 'Nothing here', 'wp-empty-theme' ); ?></h1>
+	</header><!-- .page-header -->
+	<?php
+}
+?>
+
+<?php
+if ( have_posts() ) {
+
+	// Load posts loop.
+	while ( have_posts() ) {
+		the_post();
+
+		?>
+		<article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
+
+			<header class="entry-header alignwide">
+				<?php
+				if ( is_singular() ) {
+					the_title( '<h1 class="entry-title">', '</h1>' );
+				} else {
+					the_title( sprintf( '<h2 class="entry-title default-max-width"><a href="%s">', esc_url( get_permalink() ) ), '</a></h2>' );
+				}
+				?>
+				<?php
+				if ( ! post_password_required() && ! is_attachment() && has_post_thumbnail() ) {
+					?>
+					<figure class="post-thumbnail">
+						<?php the_post_thumbnail( 'post-thumbnail' ); ?>
+					</figure><!-- .post-thumbnail -->
+					<?php
+				}
+				?>
+			</header><!-- .entry-header -->
+
+			<div class="entry-content">
+				<?php
+				the_content();
+
+				wp_link_pages(
+					array(
+						'before'   => '<nav class="page-links" aria-label="' . esc_attr__( 'Page', 'wp-empty-theme' ) . '">',
+						'after'    => '</nav>',
+						/* translators: %: Page number. */
+						'pagelink' => esc_html__( 'Page %', 'wp-empty-theme' ),
+					)
+				);
+				?>
+			</div><!-- .entry-content -->
+
+			<footer class="entry-footer default-max-width">
+				<?php wp_empty_theme_entry_meta_footer(); ?>
+			</footer><!-- .entry-footer -->
+
+		</article><!-- #post-<?php the_ID(); ?> -->
+		<?php
+	}
+
+	if ( is_singular() ) {
+		if ( comments_open() || get_comments_number() ) {
+			comments_template();
+		}
+
+		the_post_navigation(
+			array(
+				'next_text' => '<p class="meta-nav">' . esc_html__( 'Next post', 'wp-empty-theme' ) . '</p><p class="post-title">%title</p>',
+				'prev_text' => '<p class="meta-nav">' . esc_html__( 'Previous post', 'wp-empty-theme' ) . '</p><p class="post-title">%title</p>',
+			)
+		);
+	} else {
+		the_posts_pagination(
+			array(
+				'before_page_number' => esc_html__( 'Page', 'wp-empty-theme' ) . ' ',
+				'mid_size'           => 0,
+				'prev_text'          => sprintf(
+					'<span class="nav-prev-text">%s</span>',
+					wp_kses(
+						__( 'Newer <span class="nav-short">posts</span>', 'wp-empty-theme' ),
+						array(
+							'span' => array(
+								'class' => array(),
+							),
+						)
+					)
+				),
+				'next_text'          => sprintf(
+					'<span class="nav-next-text">%s</span>',
+					wp_kses(
+						__( 'Older <span class="nav-short">posts</span>', 'wp-empty-theme' ),
+						array(
+							'span' => array(
+								'class' => array(),
+							),
+						)
+					)
+				),
+			)
+		);
+	}
+} else {
+	?>
+	<div class="page-content default-max-width">
+		<p><?php esc_html_e( 'It seems we can&rsquo;t find what you&rsquo;re looking for. Perhaps searching can help.', 'wp-empty-theme' ); ?></p>
+		<?php get_search_form(); ?>
+	</div>
+	<?php
+}
+?>
+
+<?php
+get_footer();

--- a/test-content/themes/wp-empty-theme/min-style.css
+++ b/test-content/themes/wp-empty-theme/min-style.css
@@ -1,0 +1,148 @@
+:root {
+	--global--spacing-horizontal: 25px;
+
+	--responsive--spacing-horizontal: calc(2 * var(--global--spacing-horizontal) * 0.6);
+	--responsive--aligndefault-width: calc(100vw - var(--responsive--spacing-horizontal));
+	--responsive--alignwide-width: calc(100vw - var(--responsive--spacing-horizontal));
+	--responsive--alignfull-width: 100%;
+	--responsive--alignright-margin: var(--global--spacing-horizontal);
+	--responsive--alignleft-margin: var(--global--spacing-horizontal);
+}
+
+@media only screen and (min-width: 482px) {
+
+	:root {
+		--responsive--aligndefault-width: min(calc(100vw - 4 * var(--global--spacing-horizontal)), 610px);
+		--responsive--alignwide-width: calc(100vw - 4 * var(--global--spacing-horizontal));
+		--responsive--alignright-margin: calc(0.5 * (100vw - var(--responsive--aligndefault-width)));
+		--responsive--alignleft-margin: calc(0.5 * (100vw - var(--responsive--aligndefault-width)));
+	}
+}
+@media only screen and (min-width: 822px) {
+
+	:root {
+		--responsive--aligndefault-width: min(calc(100vw - 8 * var(--global--spacing-horizontal)), 610px);
+		--responsive--alignwide-width: min(calc(100vw - 8 * var(--global--spacing-horizontal)), 1240px);
+	}
+}
+
+img {
+	height: auto;
+	max-width: 100%;
+	vertical-align: middle;
+}
+
+/**
+ * Extends
+ */
+.post-thumbnail,
+.entry-content .wp-audio-shortcode,
+.entry-content > *:not(.alignwide):not(.alignfull):not(.alignleft):not(.alignright):not(.wp-block-separator):not(.woocommerce),
+*[class*=inner-container] > *:not(.entry-content):not(.alignwide):not(.alignfull):not(.alignleft):not(.alignright):not(.wp-block-separator):not(.woocommerce),
+.default-max-width {
+	max-width: var(--responsive--aligndefault-width);
+	margin-left: auto;
+	margin-right: auto;
+}
+
+.widget-area,
+.pagination,
+.comments-pagination,
+.post-navigation,
+.site-footer,
+.site-header,
+.alignwide,
+.wide-max-width {
+	max-width: var(--responsive--alignwide-width);
+	margin-left: auto;
+	margin-right: auto;
+}
+
+.alignfull,
+.wp-block-group .wp-block-group__inner-container > *.alignfull,
+.full-max-width {
+	max-width: var(--responsive--alignfull-width);
+	width: var(--responsive--alignfull-width);
+	margin-left: auto;
+	margin-right: auto;
+}
+
+@media only screen and (min-width: 482px) {
+
+	.alignfull,
+	.full-max-width {
+		max-width: var(--responsive--alignfull-width);
+		width: auto;
+		margin-left: auto;
+		margin-right: auto;
+	}
+}
+
+.entry-header .post-thumbnail,
+.singular .post-thumbnail,
+.alignfull [class*=inner-container] > .alignwide,
+.alignwide [class*=inner-container] > .alignwide {
+	margin-left: auto;
+	margin-right: auto;
+	width: var(--responsive--alignwide-width);
+	max-width: var(--responsive--alignfull-width);
+}
+
+@media only screen and (min-width: 482px) {
+
+	.entry-content > .alignleft {
+
+		/*rtl:ignore*/
+		margin-left: var(--responsive--alignleft-margin);
+
+		/*rtl:ignore*/
+		margin-right: var(--global--spacing-horizontal);
+	}
+}
+@media only screen and (min-width: 482px) {
+
+	.entry-content > .alignright {
+
+		/*rtl:ignore*/
+		margin-left: var(--global--spacing-horizontal);
+
+		/*rtl:ignore*/
+		margin-right: var(--responsive--alignright-margin);
+	}
+}
+
+.screen-reader-text {
+	border: 0;
+	clip: rect(1px, 1px, 1px, 1px);
+	-webkit-clip-path: inset(50%);
+	clip-path: inset(50%);
+	height: 1px;
+	margin: -1px;
+	overflow: hidden;
+	padding: 0;
+	position: absolute !important;
+	width: 1px;
+	word-wrap: normal !important;
+	word-break: normal;
+}
+
+.skip-link:focus {
+	background-color: #f1f1f1;
+	border-radius: 3px;
+	box-shadow: 0 0 2px 2px rgba(0, 0, 0, 0.6);
+	clip: auto !important;
+	-webkit-clip-path: none;
+	clip-path: none;
+	color: #21759b;
+	display: block;
+	font-size: 0.875rem;
+	font-weight: 700;
+	height: auto;
+	left: 5px;
+	line-height: normal;
+	padding: 15px 23px 14px;
+	text-decoration: none;
+	top: 5px;
+	width: auto;
+	z-index: 100000;
+}

--- a/test-content/themes/wp-empty-theme/searchform.php
+++ b/test-content/themes/wp-empty-theme/searchform.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * The searchform.php template.
+ *
+ * @package wp-empty-theme
+ * @link https://developer.wordpress.org/reference/functions/wp_unique_id/
+ * @link https://developer.wordpress.org/reference/functions/get_search_form/
+ */
+
+$wp_empty_theme_unique_id = wp_unique_id( 'search-form-' );
+?>
+<form role="search" method="get" class="search-form" action="<?php echo esc_url( home_url( '/' ) ); ?>">
+	<label for="<?php echo esc_attr( $wp_empty_theme_unique_id ); ?>">
+		<?php esc_html_e( 'Search', 'wp-empty-theme' ); ?>
+	</label>
+	<input type="search" id="<?php echo esc_attr( $wp_empty_theme_unique_id ); ?>" class="search-field" value="<?php echo get_search_query(); ?>" name="s" />
+	<input type="submit" class="search-submit" value="<?php echo esc_attr_x( 'Search', 'submit button', 'wp-empty-theme' ); ?>" />
+</form>

--- a/test-content/themes/wp-empty-theme/style.css
+++ b/test-content/themes/wp-empty-theme/style.css
@@ -1,0 +1,15 @@
+/*
+Theme Name: WP Empty Theme
+Theme URI: https://team.git.corp.google.com/dev-web-ecosystem/wp-empty-theme
+Author: Felix Arntz, Google
+Author URI: https://opensource.google.com
+Description: "Empty" WordPress theme for testing a barebones WordPress site, as a reference point to compare actual themes and plugins to.
+Requires at least: 5.3
+Tested up to: 5.8
+Requires PHP: 5.6
+Version: 1.0
+License: GNU General Public License v2 or later
+License URI: http://www.gnu.org/licenses/gpl-2.0.html
+Text Domain: wp-empty-theme
+Tags: one-column, accessibility-ready, custom-logo, featured-images, threaded-comments, translation-ready
+*/

--- a/tests/Checker/Preparations/Use_Minimal_Theme_Preparation_Tests.php
+++ b/tests/Checker/Preparations/Use_Minimal_Theme_Preparation_Tests.php
@@ -9,37 +9,45 @@ use WordPress\Plugin_Check\Checker\Preparation;
 use WordPress\Plugin_Check\Checker\Preparations\Use_Minimal_Theme_Preparation;
 
 class Use_Minimal_Theme_Preparation_Tests extends WP_UnitTestCase {
+	protected $theme_slug;
+	protected $theme_dir;
+
 	public function set_up() {
 		parent::set_up();
 
 		$this->theme_slug = 'wp-empty-theme';
 		$this->theme_dir  = WP_PLUGIN_DIR . '/' . basename( TESTS_PLUGIN_DIR ) . '/test-content/themes';
-
-		$this->preparation = new Use_Minimal_Theme_Preparation( $this->theme_slug, $this->theme_dir );
-
-		$this->cleanup = $this->preparation->prepare();
-	}
-
-	public function tear_down() {
-		parent::tear_down();
-
-		// Run the cleanup function.
-		( $this->cleanup )();
-	}
-
-	public function test_implements_preparation_interface() {
-		$this->assertInstanceOf( Preparation::class, $this->preparation );
 	}
 
 	public function test_get_theme_slug() {
-		$this->assertSame( $this->theme_slug, $this->preparation->get_theme_slug() );
+		$preparation = new Use_Minimal_Theme_Preparation( $this->theme_slug, $this->theme_dir );
+
+		$this->assertSame( $this->theme_slug, $preparation->get_theme_slug() );
+	}
+
+	public function test_prepare() {
+		$preparation = new Use_Minimal_Theme_Preparation( $this->theme_slug, $this->theme_dir );
+		$cleanup     = $preparation->prepare();
+		$cleanup();
+
+		$this->assertIsCallable( $cleanup );
 	}
 
 	public function test_get_theme_name() {
-		$this->assertSame( 'WP Empty Theme', $this->preparation->get_theme_name() );
+		$preparation = new Use_Minimal_Theme_Preparation( $this->theme_slug, $this->theme_dir );
+		$cleanup     = $preparation->prepare();
+		$theme_name  = $preparation->get_theme_name();
+		$cleanup();
+
+		$this->assertSame( 'WP Empty Theme', $theme_name );
 	}
 
 	public function test_get_theme_root() {
-		$this->assertSame( str_replace( WP_CONTENT_DIR, '', $this->theme_dir ), $this->preparation->get_theme_root() );
+		$preparation = new Use_Minimal_Theme_Preparation( $this->theme_slug, $this->theme_dir );
+		$cleanup     = $preparation->prepare();
+		$theme_root  = $preparation->get_theme_root();
+		$cleanup();
+
+		$this->assertSame( str_replace( WP_CONTENT_DIR, '', $this->theme_dir ), $theme_root );
 	}
 }

--- a/tests/Checker/Preparations/Use_Minimal_Theme_Preparation_Tests.php
+++ b/tests/Checker/Preparations/Use_Minimal_Theme_Preparation_Tests.php
@@ -9,12 +9,14 @@ use WordPress\Plugin_Check\Checker\Preparation;
 use WordPress\Plugin_Check\Checker\Preparations\Use_Minimal_Theme_Preparation;
 
 class Use_Minimal_Theme_Preparation_Tests extends WP_UnitTestCase {
+	protected $theme_name;
 	protected $theme_slug;
 	protected $theme_dir;
 
 	public function set_up() {
 		parent::set_up();
 
+		$this->theme_name = 'WP Empty Theme';
 		$this->theme_slug = 'wp-empty-theme';
 		$this->theme_dir  = WP_PLUGIN_DIR . '/' . basename( TESTS_PLUGIN_DIR ) . '/test-content/themes';
 	}
@@ -28,9 +30,15 @@ class Use_Minimal_Theme_Preparation_Tests extends WP_UnitTestCase {
 	public function test_prepare() {
 		$preparation = new Use_Minimal_Theme_Preparation( $this->theme_slug, $this->theme_dir );
 		$cleanup     = $preparation->prepare();
-		$cleanup();
 
 		$this->assertIsCallable( $cleanup );
+		$this->assertSame( $this->theme_slug, get_option( 'template' ) );
+		$this->assertSame( $this->theme_slug, get_option( 'stylesheet' ) );
+		$this->assertSame( $this->theme_name, get_option( 'current_theme' ) );
+		$this->assertSame( str_replace( WP_CONTENT_DIR, '', $this->theme_dir ), get_option( 'template_root' ) );
+		$this->assertSame( str_replace( WP_CONTENT_DIR, '', $this->theme_dir ), get_option( 'stylesheet_root' ) );
+
+		$cleanup();
 	}
 
 	public function test_get_theme_name() {
@@ -39,7 +47,7 @@ class Use_Minimal_Theme_Preparation_Tests extends WP_UnitTestCase {
 		$theme_name  = $preparation->get_theme_name();
 		$cleanup();
 
-		$this->assertSame( 'WP Empty Theme', $theme_name );
+		$this->assertSame( $this->theme_name, $theme_name );
 	}
 
 	public function test_get_theme_root() {

--- a/tests/Checker/Preparations/Use_Minimal_Theme_Preparation_Tests.php
+++ b/tests/Checker/Preparations/Use_Minimal_Theme_Preparation_Tests.php
@@ -18,7 +18,7 @@ class Use_Minimal_Theme_Preparation_Tests extends WP_UnitTestCase {
 
 		$this->theme_name = 'WP Empty Theme';
 		$this->theme_slug = 'wp-empty-theme';
-		$this->theme_dir  = WP_PLUGIN_DIR . '/' . basename( TESTS_PLUGIN_DIR ) . '/test-content/themes';
+		$this->theme_dir  = TESTS_PLUGIN_DIR . '/test-content/themes';
 	}
 
 	public function test_get_theme_slug() {
@@ -28,15 +28,20 @@ class Use_Minimal_Theme_Preparation_Tests extends WP_UnitTestCase {
 	}
 
 	public function test_prepare() {
-		$preparation = new Use_Minimal_Theme_Preparation( $this->theme_slug, $this->theme_dir );
-		$cleanup     = $preparation->prepare();
+		$preparation     = new Use_Minimal_Theme_Preparation( $this->theme_slug, $this->theme_dir );
+		$cleanup         = $preparation->prepare();
+		$template        = get_option( 'template' );
+		$stylesheet      = get_option( 'stylesheet' );
+		$current_theme   = get_option( 'current_theme' );
+		$template_root   = get_option( 'template_root' );
+		$stylesheet_root = get_option( 'stylesheet_root' );
 
 		$this->assertIsCallable( $cleanup );
-		$this->assertSame( $this->theme_slug, get_option( 'template' ) );
-		$this->assertSame( $this->theme_slug, get_option( 'stylesheet' ) );
-		$this->assertSame( $this->theme_name, get_option( 'current_theme' ) );
-		$this->assertSame( str_replace( WP_CONTENT_DIR, '', $this->theme_dir ), get_option( 'template_root' ) );
-		$this->assertSame( str_replace( WP_CONTENT_DIR, '', $this->theme_dir ), get_option( 'stylesheet_root' ) );
+		$this->assertSame( $this->theme_slug, $template );
+		$this->assertSame( $this->theme_slug, $stylesheet );
+		$this->assertSame( $this->theme_name, $current_theme );
+		$this->assertSame( str_replace( WP_CONTENT_DIR, '', $this->theme_dir ), $template_root );
+		$this->assertSame( str_replace( WP_CONTENT_DIR, '', $this->theme_dir ), $stylesheet_root );
 
 		$cleanup();
 	}

--- a/tests/Checker/Preparations/Use_Minimal_Theme_Preparation_Tests.php
+++ b/tests/Checker/Preparations/Use_Minimal_Theme_Preparation_Tests.php
@@ -1,11 +1,10 @@
 <?php
 /**
- * Tests for the Check_Context class.
+ * Tests for the Use_Minimal_Theme_Preparation class.
  *
  * @package plugin-check
  */
 
-use WordPress\Plugin_Check\Checker\Preparation;
 use WordPress\Plugin_Check\Checker\Preparations\Use_Minimal_Theme_Preparation;
 
 class Use_Minimal_Theme_Preparation_Tests extends WP_UnitTestCase {

--- a/tests/Checker/Preparations/Use_Minimal_Theme_Preparation_Tests.php
+++ b/tests/Checker/Preparations/Use_Minimal_Theme_Preparation_Tests.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Tests for the Check_Context class.
+ *
+ * @package plugin-check
+ */
+
+use WordPress\Plugin_Check\Checker\Preparation;
+use WordPress\Plugin_Check\Checker\Preparations\Use_Minimal_Theme_Preparation;
+
+class Use_Minimal_Theme_Preparation_Tests extends WP_UnitTestCase {
+	public function set_up() {
+		parent::set_up();
+
+		$this->theme_slug = 'wp-empty-theme';
+		$this->theme_dir  = WP_PLUGIN_DIR . '/' . basename( TESTS_PLUGIN_DIR ) . '/test-content/themes';
+
+		$this->preparation = new Use_Minimal_Theme_Preparation( $this->theme_slug, $this->theme_dir );
+
+		$this->cleanup = $this->preparation->prepare();
+	}
+
+	public function tear_down() {
+		parent::tear_down();
+
+		// Run the cleanup function.
+		($this->cleanup)();
+	}
+
+	public function test_implements_preparation_interface() {
+		$this->assertInstanceOf( Preparation::class, $this->preparation );
+	}
+
+	public function test_get_theme_slug() {
+		$this->assertSame( $this->theme_slug, $this->preparation->get_theme_slug() );
+	}
+
+	public function test_get_theme_name() {
+		$this->assertSame( 'WP Empty Theme', $this->preparation->get_theme_name() );
+	}
+
+	public function test_get_theme_root() {
+		$this->assertSame( $this->theme_dir, $this->preparation->get_theme_root() );
+	}
+}

--- a/tests/Checker/Preparations/Use_Minimal_Theme_Preparation_Tests.php
+++ b/tests/Checker/Preparations/Use_Minimal_Theme_Preparation_Tests.php
@@ -34,6 +34,7 @@ class Use_Minimal_Theme_Preparation_Tests extends WP_UnitTestCase {
 		$current_theme   = get_option( 'current_theme' );
 		$template_root   = get_option( 'template_root' );
 		$stylesheet_root = get_option( 'stylesheet_root' );
+		$cleanup();
 
 		$this->assertIsCallable( $cleanup );
 		$this->assertSame( $this->theme_slug, $template );
@@ -41,8 +42,6 @@ class Use_Minimal_Theme_Preparation_Tests extends WP_UnitTestCase {
 		$this->assertSame( $this->theme_name, $current_theme );
 		$this->assertSame( str_replace( WP_CONTENT_DIR, '', $this->theme_dir ), $template_root );
 		$this->assertSame( str_replace( WP_CONTENT_DIR, '', $this->theme_dir ), $stylesheet_root );
-
-		$cleanup();
 	}
 
 	public function test_get_theme_name() {

--- a/tests/Checker/Preparations/Use_Minimal_Theme_Preparation_Tests.php
+++ b/tests/Checker/Preparations/Use_Minimal_Theme_Preparation_Tests.php
@@ -24,7 +24,7 @@ class Use_Minimal_Theme_Preparation_Tests extends WP_UnitTestCase {
 		parent::tear_down();
 
 		// Run the cleanup function.
-		($this->cleanup)();
+		( $this->cleanup )();
 	}
 
 	public function test_implements_preparation_interface() {
@@ -40,6 +40,6 @@ class Use_Minimal_Theme_Preparation_Tests extends WP_UnitTestCase {
 	}
 
 	public function test_get_theme_root() {
-		$this->assertSame( $this->theme_dir, $this->preparation->get_theme_root() );
+		$this->assertSame( str_replace( WP_CONTENT_DIR, '', $this->theme_dir ), $this->preparation->get_theme_root() );
 	}
 }


### PR DESCRIPTION
Adds the `Minimal_Theme_Preparation` class and `wp-empty-theme` theme.

- Addresses acceptance criteria in #39 
- While writing test the `get_theme_root()` method was failing. Looking into this the [`get_raw_theme_root()`](https://developer.wordpress.org/reference/functions/get_raw_theme_root/) function calls the [`get_theme_roots()`](https://developer.wordpress.org/reference/functions/get_theme_roots/) function which uses the `theme_roots` transient to search for a valid theme root based on the theme slug. Tests were failing because the `theme_roots` transient wasn't being updated when registering the new theme directory with `register_theme_directory()` in the prepare method. I've included a [`search_theme_directories( true );`](https://developer.wordpress.org/reference/functions/search_theme_directories/) function call after registering the theme directory in the prepare method in order to force update this transient.

Closes #39 