### PR TITLE
Fix Runtime Checks in CLI

### DIFF
--- a/includes/Checker/Abstract_Check_Runner.php
+++ b/includes/Checker/Abstract_Check_Runner.php
@@ -178,13 +178,19 @@ abstract class Abstract_Check_Runner implements Check_Runner {
 		$preparations = $this->get_shared_preparations( $checks );
 		$cleanups     = array();
 
+		// Prepare the universal runtime preparations if required.
+		$cleanups[] = $this->prepare();
+
+		// Prepare all shared preparations.
 		foreach ( $preparations as $preparation ) {
 			$instance   = new $preparation['class']( ...$preparation['args'] );
 			$cleanups[] = $instance->prepare();
 		}
 
+		// Run checks and return the results.
 		$results = $this->get_checks_instance()->run_checks( $checks );
 
+		// Cleanup all preparations.
 		if ( ! empty( $cleanups ) ) {
 			foreach ( $cleanups as $cleanup ) {
 				$cleanup();

--- a/includes/Checker/Abstract_Check_Runner.php
+++ b/includes/Checker/Abstract_Check_Runner.php
@@ -178,19 +178,13 @@ abstract class Abstract_Check_Runner implements Check_Runner {
 		$preparations = $this->get_shared_preparations( $checks );
 		$cleanups     = array();
 
-		// Prepare the universal runtime preparations if required.
-		$cleanups[] = $this->prepare();
-
-		// Prepare all shared preparations.
 		foreach ( $preparations as $preparation ) {
 			$instance   = new $preparation['class']( ...$preparation['args'] );
 			$cleanups[] = $instance->prepare();
 		}
 
-		// Run checks and return the results.
 		$results = $this->get_checks_instance()->run_checks( $checks );
 
-		// Cleanup all preparations.
 		if ( ! empty( $cleanups ) ) {
 			foreach ( $cleanups as $cleanup ) {
 				$cleanup();

--- a/includes/Checker/Runtime_Environment_Setup.php
+++ b/includes/Checker/Runtime_Environment_Setup.php
@@ -24,6 +24,9 @@ class Runtime_Environment_Setup {
 
 		require_once ABSPATH . '/wp-admin/includes/upgrade.php';
 
+		// Get the existing active plugins.
+		$active_plugins = get_option( 'active_plugins' );
+
 		// Set the new prefix.
 		$old_prefix = $wpdb->set_prefix( 'wppc_' );
 
@@ -35,6 +38,9 @@ class Runtime_Environment_Setup {
 				'demo@plugincheck.test',
 				false
 			);
+
+			// Activate the same plugins in the test environment.
+			update_option( 'active_plugins', $active_plugins );
 		}
 
 		// Restore the old prefix.

--- a/includes/Utilities/Plugin_Request_Utility.php
+++ b/includes/Utilities/Plugin_Request_Utility.php
@@ -128,7 +128,7 @@ class Plugin_Request_Utility {
 	 */
 	public static function destroy_runner() {
 		// Run the cleanup functions.
-		if ( isset( self::$cleanup ) ) {
+		if ( null !== self::$cleanup ) {
 			call_user_func( self::$cleanup );
 		}
 

--- a/includes/Utilities/Plugin_Request_Utility.php
+++ b/includes/Utilities/Plugin_Request_Utility.php
@@ -93,7 +93,14 @@ class Plugin_Request_Utility {
 
 		foreach ( $runners as $runner ) {
 			if ( $runner->is_plugin_check() ) {
-				static::$runner = $runner;
+				add_action(
+					'muplugins_loaded',
+					function() use ( $runner ) {
+						static::$cleanup = $runner->prepare();
+						static::$runner  = $runner;
+					}
+				);
+
 				break;
 			}
 		}
@@ -120,6 +127,11 @@ class Plugin_Request_Utility {
 	 * @since n.e.x.t
 	 */
 	public static function destroy_runner() {
+		// Run the cleanup functions.
+		if ( isset( self::$cleanup ) ) {
+			call_user_func( self::$cleanup );
+		}
+
 		static::$runner = null;
 	}
 }

--- a/includes/Utilities/Plugin_Request_Utility.php
+++ b/includes/Utilities/Plugin_Request_Utility.php
@@ -31,7 +31,7 @@ class Plugin_Request_Utility {
 	 * The universal runtime preparation cleanups if applied.
 	 *
 	 * @since n.e.x.t
-	 * @var callable
+	 * @var callable|null
 	 */
 	protected static $cleanup;
 

--- a/includes/Utilities/Plugin_Request_Utility.php
+++ b/includes/Utilities/Plugin_Request_Utility.php
@@ -93,14 +93,7 @@ class Plugin_Request_Utility {
 
 		foreach ( $runners as $runner ) {
 			if ( $runner->is_plugin_check() ) {
-				add_action(
-					'muplugins_loaded',
-					function() use ( $runner ) {
-						static::$cleanup = $runner->prepare();
-						static::$runner  = $runner;
-					}
-				);
-
+				static::$runner = $runner;
 				break;
 			}
 		}
@@ -127,11 +120,6 @@ class Plugin_Request_Utility {
 	 * @since n.e.x.t
 	 */
 	public static function destroy_runner() {
-		// Run the cleanup functions.
-		if ( isset( self::$cleanup ) ) {
-			call_user_func( self::$cleanup );
-		}
-
 		static::$runner = null;
 	}
 }

--- a/tests/Utilities/Plugin_Request_Utility_Tests.php
+++ b/tests/Utilities/Plugin_Request_Utility_Tests.php
@@ -11,13 +11,6 @@ use WordPress\Plugin_Check\Checker\AJAX_Runner;
 
 class Plugin_Request_Utility_Tests extends WP_UnitTestCase {
 
-	public function tear_down() {
-		// Force reset the database prefix after runner prepare method called.
-		global $wpdb, $table_prefix;
-		$wpdb->set_prefix( $table_prefix );
-		parent::tear_down();
-	}
-
 	public function test_get_plugin_basename_from_input() {
 		$plugin = Plugin_Request_Utility::get_plugin_basename_from_input( 'plugin-check' );
 
@@ -47,9 +40,6 @@ class Plugin_Request_Utility_Tests extends WP_UnitTestCase {
 		);
 
 		Plugin_Request_Utility::initialize_runner();
-
-		do_action( 'muplugins_loaded' );
-
 		$runner = Plugin_Request_Utility::get_runner();
 
 		unset( $_SERVER['argv'] );
@@ -63,17 +53,12 @@ class Plugin_Request_Utility_Tests extends WP_UnitTestCase {
 		$_REQUEST['plugin'] = 'plugin-check';
 
 		Plugin_Request_Utility::initialize_runner();
-
-		do_action( 'muplugins_loaded' );
-
 		$runner = Plugin_Request_Utility::get_runner();
 
 		$this->assertInstanceOf( AJAX_Runner::class, $runner );
 	}
 
 	public function test_destroy_runner_with_cli() {
-		global $wpdb, $table_prefix, $wp_actions;
-
 		$_SERVER['argv'] = array(
 			'wp',
 			'plugin',
@@ -91,34 +76,19 @@ class Plugin_Request_Utility_Tests extends WP_UnitTestCase {
 			}
 		);
 
-		$muplugins_loaded = $wp_actions['muplugins_loaded'];
-		unset( $wp_actions['muplugins_loaded'] );
-
 		Plugin_Request_Utility::initialize_runner();
-
-		do_action( 'muplugins_loaded' );
-
-		// Determine if one of the Universal_Runtume_Preparation was run.
-		$prepared = has_filter( 'option_active_plugins' );
+		$runner = Plugin_Request_Utility::get_runner();
 
 		Plugin_Request_Utility::destroy_runner();
-
-		// Determine if the cleanup function was run.
-		$cleanup = ! has_filter( 'option_active_plugins' );
-		$runner  = Plugin_Request_Utility::get_runner();
+		$destroyed = Plugin_Request_Utility::get_runner();
 
 		unset( $_SERVER['argv'] );
-		$wp_actions['muplugins_loaded'] = $muplugins_loaded;
-		$wpdb->set_prefix( $table_prefix );
 
-		$this->assertTrue( $prepared );
-		$this->assertTrue( $cleanup );
-		$this->assertNull( $runner );
+		$this->assertInstanceOf( CLI_Runner::class, $runner );
+		$this->assertNull( $destroyed );
 	}
 
 	public function test_destroy_runner_with_ajax() {
-		global $wpdb, $table_prefix, $wp_actions;
-
 		add_filter( 'wp_doing_ajax', '__return_true' );
 		$_REQUEST['action'] = 'plugin_check_run_checks';
 		$_REQUEST['plugin'] = 'plugin-check';
@@ -133,28 +103,14 @@ class Plugin_Request_Utility_Tests extends WP_UnitTestCase {
 			}
 		);
 
-		$muplugins_loaded = $wp_actions['muplugins_loaded'];
-		unset( $wp_actions['muplugins_loaded'] );
-
 		Plugin_Request_Utility::initialize_runner();
-
-		do_action( 'muplugins_loaded' );
-
-		// Determine if one of the Universal_Runtume_Preparation was run.
-		$prepared = has_filter( 'option_active_plugins' );
+		$runner = Plugin_Request_Utility::get_runner();
 
 		Plugin_Request_Utility::destroy_runner();
+		$destroyed = Plugin_Request_Utility::get_runner();
 
-		// Determine if the cleanup function was run.
-		$cleanup = ! has_filter( 'option_active_plugins' );
-		$runner  = Plugin_Request_Utility::get_runner();
-
-		$wpdb->set_prefix( $table_prefix );
-		$wp_actions['muplugins_loaded'] = $muplugins_loaded;
-
-		$this->assertTrue( $prepared );
-		$this->assertTrue( $cleanup );
-		$this->assertNull( $runner );
+		$this->assertInstanceOf( AJAX_Runner::class, $runner );
+		$this->assertNull( $destroyed );
 	}
 
 	public function test_destroy_runner_with_no_runner() {


### PR DESCRIPTION
This resolves both the database errors and runtime checks not being run via the CLI. I've taken the shortest approach to resolve this for now but we can discuss if we want to alter/expand on this approach based on other issues.

The runtime checks did not run as the plugin was not active in the test database tables. The `update_option` in the `Runtime_Environment_Setup` fixes this.

The database errors were caused by the `Universal_Runtime_Preparations` being run ahead of the Runtime Environment being setup. As the Runtime Environment is setup manually late in the process I've opted to calling the `Universal_Runtime_Preparations` within the runners `run()` method. We may however want to review this alongside #128 to see if the `Runtime_Environment_Setup` can be run earlier in the process.

closes #134, closes #133