### PR TITLE
Fix PHPCS check when testing a single file plugin

### DIFF
--- a/includes/Checker/Checks/Abstract_PHP_CodeSniffer_Check.php
+++ b/includes/Checker/Checks/Abstract_PHP_CodeSniffer_Check.php
@@ -71,7 +71,7 @@ abstract class Abstract_PHP_CodeSniffer_Check implements Static_Check {
 		// Create the default arguments for PHPCS.
 		$defaults = array(
 			'',
-			$result->plugin()->path( '' ),
+			$result->plugin()->location(),
 			'--report=Json',
 			'--report-width=9999',
 		);

--- a/includes/Plugin_Context.php
+++ b/includes/Plugin_Context.php
@@ -67,4 +67,22 @@ class Plugin_Context {
 	public function url( $relative_path = '/' ) {
 		return plugin_dir_url( $this->main_file ) . ltrim( $relative_path, '/' );
 	}
+
+	/**
+	 * Returns the plugin location.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @return string The plugin file if single file plugin. Or the plugin folder.
+	 */
+	public function location() {
+		$path = $this->path();
+
+		// Return the plugin path and basename if the path matches the plugin directory.
+		if ( WP_PLUGIN_DIR . '/' === $path ) {
+			return $path . $this->basename();
+		}
+
+		return $path;
+	}
 }

--- a/tests/Plugin_Context_Tests.php
+++ b/tests/Plugin_Context_Tests.php
@@ -34,4 +34,15 @@ class Plugin_Context_Tests extends WP_UnitTestCase {
 	public function test_url_with_parameter() {
 		$this->assertSame( WP_PLUGIN_URL . '/' . $this->plugin_name . '/folder/file.css', $this->plugin_context->url( '/folder/file.css' ) );
 	}
+
+	public function test_location() {
+		$this->assertSame( WP_PLUGIN_DIR . '/' . $this->plugin_name . '/', $this->plugin_context->location() );
+	}
+
+	public function test_location_with_single_file_plugin() {
+		$single_file = WP_PLUGIN_DIR . '/single-file-plugin.php';
+		$context     = new Plugin_Context( $single_file );
+
+		$this->assertSame( $single_file, $context->location() );
+	}
 }


### PR DESCRIPTION
Added a `location()` method to the `Plugin_Context` class to return the correct location for running PHPCS sniffs if checking a single file plugin or folder.

- I'm not 100% sure on the method name and open to suggestions.
- Alternatively, the logic could be handled inside the `Abstract_PHP_CodeSniffer_Check` if we think a method is not needed.

Closes #135