### PR TITLE
Update composer autoload notice

### DIFF
--- a/plugin-check.php
+++ b/plugin-check.php
@@ -72,11 +72,10 @@ function wp_plugin_check_display_php_version_notice() {
  */
 function wp_plugin_check_display_composer_autoload_notice() {
 	echo '<div class="notice notice-error"><p>';
-	echo wp_kses(
-		__( 'Composer autoload files are missing. Please run <code>composer install</code>.', 'plugin-check' ),
-		array(
-			'code' => array(),
-		)
+	printf(
+		/* translators: composer command. */
+		esc_html__( 'Your installation of the Plugin Check plugin is incomplete. Please run %s.', 'plugin-check' ),
+		'<code>composer install</code>'
 	);
 	echo '</p></div>';
 }


### PR DESCRIPTION
In this PR i have update composer notice.
- Remove `<code>composer install</code>` from the translation because we don't want to translate it.
- Add plugin name so end user know which plugin need the `composer install`
- Use simple `printf` instead `kses` function.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).