### PR TITLE
Fix running tests not working unless the repository is cloned to a `plugin-check` directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "lint-php": "wp-env run composer run-script lint",
     "format-php": "wp-env run composer run-script format",
     "pretest-php": "wp-env run composer 'install --no-interaction'",
-    "test-php": "wp-env run phpunit 'phpunit -c /var/www/html/wp-content/plugins/plugin-check/phpunit.xml.dist --verbose'",
-    "test-php-multisite": "wp-env run phpunit 'WP_MULTISITE=1 phpunit -c /var/www/html/wp-content/plugins/plugin-check/tests/phpunit/multisite.xml --verbose'"
+    "test-php": "wp-env run phpunit 'phpunit -c /var/www/html/wp-content/plugins/$(basename $(pwd))/phpunit.xml.dist --verbose'",
+    "test-php-multisite": "wp-env run phpunit 'WP_MULTISITE=1 phpunit -c /var/www/html/wp-content/plugins/$(basename $(pwd))/tests/phpunit/multisite.xml --verbose'"
   }
 }


### PR DESCRIPTION
When having the repository checked out to another folder name than `plugin-check`, the `npm run test-php` and `npm run test-php-multisite` scripts will fail since they have the `plugin-check` path hard-coded.

We should fix that, for example so that the script detects the current folder name ("base name").


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
