### PR TITLE
Disable submit button when plugin is not selected

### DIFF
--- a/assets/js/plugin-check-admin.js
+++ b/assets/js/plugin-check-admin.js
@@ -14,8 +14,6 @@
 	}
 
 	// Handle disabling the check it button when a plugin is not selected.
-	pluginsList.addEventListener( 'change', canRunChecks );
-
 	function canRunChecks() {
 		if ( '' === pluginsList.value ) {
 			checkItButton.disabled = true;
@@ -26,6 +24,7 @@
 
 	// Run on page load to test if dropdown is auto populated.
 	canRunChecks();
+	pluginsList.addEventListener( 'change', canRunChecks );
 
 	// When the Check it button is clicked.
 	checkItButton.addEventListener( 'click', ( e ) => {
@@ -33,6 +32,7 @@
 
 		resetResults();
 		checkItButton.disabled = true;
+		pluginsList.disabled = true;
 		spinner.classList.add( 'is-active' );
 
 		getChecksToRun()
@@ -69,6 +69,7 @@
 	function resetForm() {
 		spinner.classList.remove( 'is-active' );
 		checkItButton.disabled = false;
+		pluginsList.disabled = false;
 	}
 
 	/**

--- a/assets/js/plugin-check-admin.js
+++ b/assets/js/plugin-check-admin.js
@@ -13,7 +13,7 @@
 		return;
 	}
 
-	// Handle disabling the check it button when a plugin is not selected.
+	// Handle disabling the Check it button when a plugin is not selected.
 	function canRunChecks() {
 		if ( '' === pluginsList.value ) {
 			checkItButton.disabled = true;

--- a/assets/js/plugin-check-admin.js
+++ b/assets/js/plugin-check-admin.js
@@ -13,6 +13,21 @@
 		return;
 	}
 
+	// Handle disabling the check it button when a plugin is not selected.
+	pluginsList.addEventListener( 'change', canRunChecks );
+
+	function canRunChecks() {
+		if ( '' === pluginsList.value ) {
+			checkItButton.disabled = true;
+		} else {
+			checkItButton.disabled = false;
+		}
+	}
+
+	// Run on page load to test if dropdown is auto populated.
+	canRunChecks();
+
+	// When the Check it button is clicked.
 	checkItButton.addEventListener( 'click', ( e ) => {
 		e.preventDefault();
 


### PR DESCRIPTION
This PR disables the 'Check it' button when a plugin is not selected in the dropdown.

This has been tested and works with the 'Check this plugin' links on the plugins page.

Closes #139 