### PR TITLE
Validate that every check has at least one category assigned

### DIFF
--- a/includes/Checker/Check.php
+++ b/includes/Checker/Check.php
@@ -55,6 +55,8 @@ interface Check {
 	/**
 	 * Gets the categories for the check.
 	 *
+	 * Every check must have at least one category.
+	 *
 	 * @since n.e.x.t
 	 *
 	 * @return array The categories for the check.

--- a/includes/Checker/Checks/Code_Obfuscation_Check.php
+++ b/includes/Checker/Checks/Code_Obfuscation_Check.php
@@ -48,6 +48,8 @@ class Code_Obfuscation_Check extends Abstract_File_Check {
 	/**
 	 * Gets the categories for the check.
 	 *
+	 * Every check must have at least one category.
+	 *
 	 * @since n.e.x.t
 	 *
 	 * @return array The categories for the check.

--- a/includes/Checker/Checks/Enqueued_Scripts_In_Footer_Check.php
+++ b/includes/Checker/Checks/Enqueued_Scripts_In_Footer_Check.php
@@ -22,6 +22,8 @@ class Enqueued_Scripts_In_Footer_Check extends Abstract_PHP_CodeSniffer_Check {
 	/**
 	 * Gets the categories for the check.
 	 *
+	 * Every check must have at least one category.
+	 *
 	 * @since n.e.x.t
 	 *
 	 * @return array The categories for the check.

--- a/includes/Checker/Checks/Enqueued_Scripts_Size_Check.php
+++ b/includes/Checker/Checks/Enqueued_Scripts_Size_Check.php
@@ -54,6 +54,8 @@ class Enqueued_Scripts_Size_Check extends Abstract_Runtime_Check implements With
 	/**
 	 * Gets the categories for the check.
 	 *
+	 * Every check must have at least one category.
+	 *
 	 * @since n.e.x.t
 	 *
 	 * @return array The categories for the check.

--- a/includes/Checker/Checks/Enqueued_Styles_Scope_Check.php
+++ b/includes/Checker/Checks/Enqueued_Styles_Scope_Check.php
@@ -51,6 +51,8 @@ class Enqueued_Styles_Scope_Check extends Abstract_Runtime_Check implements With
 	/**
 	 * Gets the categories for the check.
 	 *
+	 * Every check must have at least one category.
+	 *
 	 * @since n.e.x.t
 	 *
 	 * @return array The categories for the check.

--- a/includes/Checker/Checks/File_Type_Check.php
+++ b/includes/Checker/Checks/File_Type_Check.php
@@ -49,6 +49,8 @@ class File_Type_Check extends Abstract_File_Check {
 	/**
 	 * Gets the categories for the check.
 	 *
+	 * Every check must have at least one category.
+	 *
 	 * @since n.e.x.t
 	 *
 	 * @return array The categories for the check.

--- a/includes/Checker/Checks/I18n_Usage_Check.php
+++ b/includes/Checker/Checks/I18n_Usage_Check.php
@@ -22,6 +22,8 @@ class I18n_Usage_Check extends Abstract_PHP_CodeSniffer_Check {
 	/**
 	 * Gets the categories for the check.
 	 *
+	 * Every check must have at least one category.
+	 *
 	 * @since n.e.x.t
 	 *
 	 * @return array The categories for the check.

--- a/includes/Checker/Checks/Late_Escaping_Check.php
+++ b/includes/Checker/Checks/Late_Escaping_Check.php
@@ -22,6 +22,8 @@ class Late_Escaping_Check extends Abstract_PHP_CodeSniffer_Check {
 	/**
 	 * Gets the categories for the check.
 	 *
+	 * Every check must have at least one category.
+	 *
 	 * @since n.e.x.t
 	 *
 	 * @return array The categories for the check.

--- a/includes/Checker/Checks/Localhost_Check.php
+++ b/includes/Checker/Checks/Localhost_Check.php
@@ -23,6 +23,8 @@ class Localhost_Check extends Abstract_File_Check {
 	/**
 	 * Gets the categories for the check.
 	 *
+	 * Every check must have at least one category.
+	 *
 	 * @since n.e.x.t
 	 *
 	 * @return array The categories for the check.

--- a/includes/Checker/Checks/No_Unfiltered_Uploads_Check.php
+++ b/includes/Checker/Checks/No_Unfiltered_Uploads_Check.php
@@ -23,6 +23,8 @@ class No_Unfiltered_Uploads_Check extends Abstract_File_Check {
 	/**
 	 * Gets the categories for the check.
 	 *
+	 * Every check must have at least one category.
+	 *
 	 * @since n.e.x.t
 	 *
 	 * @return array The categories for the check.

--- a/includes/Checker/Checks/Performant_WP_Query_Params_Check.php
+++ b/includes/Checker/Checks/Performant_WP_Query_Params_Check.php
@@ -22,6 +22,8 @@ class Performant_WP_Query_Params_Check extends Abstract_PHP_CodeSniffer_Check {
 	/**
 	 * Gets the categories for the check.
 	 *
+	 * Every check must have at least one category.
+	 *
 	 * @since n.e.x.t
 	 *
 	 * @return array The categories for the check.

--- a/includes/Checker/Checks/Plugin_Header_Text_Domain_Check.php
+++ b/includes/Checker/Checks/Plugin_Header_Text_Domain_Check.php
@@ -25,6 +25,8 @@ class Plugin_Header_Text_Domain_Check implements Static_Check {
 	/**
 	 * Gets the categories for the check.
 	 *
+	 * Every check must have at least one category.
+	 *
 	 * @since n.e.x.t
 	 *
 	 * @return array The categories for the check.

--- a/includes/Checker/Checks/Plugin_Readme_Check.php
+++ b/includes/Checker/Checks/Plugin_Readme_Check.php
@@ -23,6 +23,8 @@ class Plugin_Readme_Check extends Abstract_File_Check {
 	/**
 	 * Gets the categories for the check.
 	 *
+	 * Every check must have at least one category.
+	 *
 	 * @since n.e.x.t
 	 *
 	 * @return array The categories for the check.

--- a/includes/Checker/Checks/Plugin_Review_PHPCS_Check.php
+++ b/includes/Checker/Checks/Plugin_Review_PHPCS_Check.php
@@ -22,6 +22,8 @@ class Plugin_Review_PHPCS_Check extends Abstract_PHP_CodeSniffer_Check {
 	/**
 	 * Gets the categories for the check.
 	 *
+	 * Every check must have at least one category.
+	 *
 	 * @since n.e.x.t
 	 *
 	 * @return array The categories for the check.

--- a/includes/Checker/Checks/Plugin_Updater_Check.php
+++ b/includes/Checker/Checks/Plugin_Updater_Check.php
@@ -49,6 +49,8 @@ class Plugin_Updater_Check extends Abstract_File_Check {
 	/**
 	 * Gets the categories for the check.
 	 *
+	 * Every check must have at least one category.
+	 *
 	 * @since n.e.x.t
 	 *
 	 * @return array The categories for the check.

--- a/includes/Checker/Default_Check_Repository.php
+++ b/includes/Checker/Default_Check_Repository.php
@@ -44,7 +44,13 @@ class Default_Check_Repository implements Check_Repository {
 	 */
 	public function register_check( $slug, Check $check ) {
 		if ( ! $check instanceof Runtime_Check && ! $check instanceof Static_Check ) {
-			throw new Exception( __( 'Check must be an instance of Runtime_Check or Static_Check.', 'plugin-check' ) );
+			throw new Exception(
+				sprintf(
+					/* translators: %s: The Check slug. */
+					__( 'Check with slug "%s" must be an instance of Runtime_Check or Static_Check.', 'plugin-check' ),
+					$slug
+				)
+			);
 		}
 
 		if ( isset( $this->runtime_checks[ $slug ] ) || isset( $this->static_checks[ $slug ] ) ) {
@@ -52,6 +58,16 @@ class Default_Check_Repository implements Check_Repository {
 				sprintf(
 					/* translators: %s: The Check slug. */
 					__( 'Check slug "%s" is already in use.', 'plugin-check' ),
+					$slug
+				)
+			);
+		}
+
+		if ( ! $check->get_categories() ) {
+			throw new Exception(
+				sprintf(
+					/* translators: %s: The Check slug. */
+					__( 'Check with slug "%s" has no categories associated with it.', 'plugin-check' ),
 					$slug
 				)
 			);

--- a/tests/phpunit/Checker/Default_Check_Repository_Tests.php
+++ b/tests/phpunit/Checker/Default_Check_Repository_Tests.php
@@ -66,6 +66,13 @@ class Default_Check_Repository_Tests extends WP_UnitTestCase {
 		$this->repository->register_check( 'check', new Runtime_Check() );
 	}
 
+	public function test_register_exception_thrown_for_missing_categories() {
+		$this->expectException( 'Exception' );
+		$this->expectExceptionMessage( 'Check with slug "check" has no categories associated with it.' );
+
+		$this->repository->register_check( 'check', new Check_Without_Category() );
+	}
+
 	public function test_get_checks_returns_all_checks() {
 		$static_check  = new Static_Check();
 		$runtime_check = new Runtime_Check();

--- a/tests/phpunit/Checker/Default_Check_Repository_Tests.php
+++ b/tests/phpunit/Checker/Default_Check_Repository_Tests.php
@@ -7,6 +7,7 @@
 
 use WordPress\Plugin_Check\Checker\Check_Repository;
 use WordPress\Plugin_Check\Checker\Default_Check_Repository;
+use WordPress\Plugin_Check\Test_Data\Check_Without_Category;
 use WordPress\Plugin_Check\Test_Data\Experimental_Runtime_Check;
 use WordPress\Plugin_Check\Test_Data\Experimental_Static_Check;
 use WordPress\Plugin_Check\Test_Data\Invalid_Check;

--- a/tests/phpunit/Checker/Default_Check_Repository_Tests.php
+++ b/tests/phpunit/Checker/Default_Check_Repository_Tests.php
@@ -38,7 +38,7 @@ class Default_Check_Repository_Tests extends WP_UnitTestCase {
 
 	public function test_register_exception_thrown_for_invalid_check() {
 		$this->expectException( 'Exception' );
-		$this->expectExceptionMessage( 'Check must be an instance of Runtime_Check or Static_Check.' );
+		$this->expectExceptionMessage( 'Check with slug "empty_check" must be an instance of Runtime_Check or Static_Check.' );
 
 		$this->repository->register_check( 'empty_check', new Invalid_Check() );
 	}

--- a/tests/phpunit/testdata/Checks/Check_Without_Category.php
+++ b/tests/phpunit/testdata/Checks/Check_Without_Category.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace WordPress\Plugin_Check\Test_Data;
+
+use WordPress\Plugin_Check\Checker\Check_Result;
+use WordPress\Plugin_Check\Checker\Static_Check;
+use WordPress\Plugin_Check\Traits\Stable_Check;
+
+class Check_Without_Category implements Static_Check {
+
+	use Stable_Check;
+
+	public function run( Check_Result $check_result ) {
+		return;
+	}
+
+	public function get_categories() {
+		return array();
+	}
+}

--- a/tests/phpunit/testdata/Checks/Experimental_Runtime_Check.php
+++ b/tests/phpunit/testdata/Checks/Experimental_Runtime_Check.php
@@ -2,6 +2,7 @@
 
 namespace WordPress\Plugin_Check\Test_Data;
 
+use WordPress\Plugin_Check\Checker\Check_Categories;
 use WordPress\Plugin_Check\Checker\Check_Result;
 use WordPress\Plugin_Check\Checker\Runtime_Check;
 use WordPress\Plugin_Check\Traits\Experimental_Check;

--- a/tests/phpunit/testdata/Checks/Experimental_Static_Check.php
+++ b/tests/phpunit/testdata/Checks/Experimental_Static_Check.php
@@ -2,6 +2,7 @@
 
 namespace WordPress\Plugin_Check\Test_Data;
 
+use WordPress\Plugin_Check\Checker\Check_Categories;
 use WordPress\Plugin_Check\Checker\Check_Result;
 use WordPress\Plugin_Check\Checker\Static_Check;
 use WordPress\Plugin_Check\Traits\Experimental_Check;


### PR DESCRIPTION
### Description of the Change

Follow-up to #220 (see #203): Given that we changed the definition of the interface to allow returning multiple categories, we should still ensure every check has at least one category. When using a string, that was mandated by the interface, but because we're now using an array, it technically allows returning an empty array.

This PR ensures at least one category is associated with every check as follows:

* Throw an exception when a registered check doesn't have any categories.
* Document on the method that at least one category will be returned.

### Checklist:
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.
