### PR TITLE
Allow running only checks of certain categories in WP Admin & WP-CLI

### DIFF
--- a/assets/js/plugin-check-admin.js
+++ b/assets/js/plugin-check-admin.js
@@ -16,7 +16,7 @@
 		! pluginsList ||
 		! resultsContainer ||
 		! spinner ||
-		! categoriesList
+		! categoriesList.length
 	) {
 		console.error( 'Missing form elements on page' );
 		return;
@@ -102,10 +102,6 @@
 			'action',
 			pluginCheck.actionSetUpRuntimeEnvironment
 		);
-
-		for ( let i = 0; i < data.categories.length; i++ ) {
-			pluginCheckData.append( 'categories[]', data.categories[ i ] );
-		}
 
 		for ( let i = 0; i < data.checks.length; i++ ) {
 			pluginCheckData.append( 'checks[]', data.checks[ i ] );

--- a/assets/js/plugin-check-admin.js
+++ b/assets/js/plugin-check-admin.js
@@ -5,11 +5,19 @@
 	const pluginsList = document.getElementById(
 		'plugin-check__plugins-dropdown'
 	);
-	const categoriesList = document.querySelectorAll( 'input[name=categories]' );
+	const categoriesList = document.querySelectorAll(
+		'input[name=categories]'
+	);
 	const templates = {};
 
 	// Return early if the elements cannot be found on the page.
-	if ( ! checkItButton || ! pluginsList || ! resultsContainer || ! spinner || ! categoriesList ) {
+	if (
+		! checkItButton ||
+		! pluginsList ||
+		! resultsContainer ||
+		! spinner ||
+		! categoriesList
+	) {
 		console.error( 'Missing form elements on page' );
 		return;
 	}
@@ -169,7 +177,10 @@
 
 		for ( let i = 0; i < categoriesList.length; i++ ) {
 			if ( categoriesList[ i ].checked ) {
-				pluginCheckData.append( 'categories[]', categoriesList[ i ].value );
+				pluginCheckData.append(
+					'categories[]',
+					categoriesList[ i ].value
+				);
 			}
 		}
 

--- a/assets/js/plugin-check-admin.js
+++ b/assets/js/plugin-check-admin.js
@@ -9,7 +9,7 @@
 	const templates = {};
 
 	// Return early if the elements cannot be found on the page.
-	if ( ! checkItButton || ! pluginsList || ! resultsContainer || ! spinner ) {
+	if ( ! checkItButton || ! pluginsList || ! resultsContainer || ! spinner || ! categoriesList ) {
 		console.error( 'Missing form elements on page' );
 		return;
 	}
@@ -95,9 +95,9 @@
 			pluginCheck.actionSetUpRuntimeEnvironment
 		);
 
-			for ( let i = 0; i < data.categories.length; i++ ) {
-				pluginCheckData.append( 'categories[]', data.categories[ i ] );
-			}
+		for ( let i = 0; i < data.categories.length; i++ ) {
+			pluginCheckData.append( 'categories[]', data.categories[ i ] );
+		}
 
 		for ( let i = 0; i < data.checks.length; i++ ) {
 			pluginCheckData.append( 'checks[]', data.checks[ i ] );
@@ -168,7 +168,7 @@
 		pluginCheckData.append( 'action', pluginCheck.actionGetChecksToRun );
 
 		for ( let i = 0; i < categoriesList.length; i++ ) {
-			if ( categoriesList[i].checked ) {
+			if ( categoriesList[ i ].checked ) {
 				pluginCheckData.append( 'categories[]', categoriesList[ i ].value );
 			}
 		}

--- a/assets/js/plugin-check-admin.js
+++ b/assets/js/plugin-check-admin.js
@@ -5,6 +5,7 @@
 	const pluginsList = document.getElementById(
 		'plugin-check__plugins-dropdown'
 	);
+	const categoriesList = document.querySelectorAll( 'input[name=categories]' );
 	const templates = {};
 
 	// Return early if the elements cannot be found on the page.
@@ -34,6 +35,9 @@
 		checkItButton.disabled = true;
 		pluginsList.disabled = true;
 		spinner.classList.add( 'is-active' );
+		for ( let i = 0; i < categoriesList.length; i++ ) {
+			categoriesList[ i ].disabled = true;
+		}
 
 		getChecksToRun()
 			.then( setUpEnvironment )
@@ -70,6 +74,9 @@
 		spinner.classList.remove( 'is-active' );
 		checkItButton.disabled = false;
 		pluginsList.disabled = false;
+		for ( let i = 0; i < categoriesList.length; i++ ) {
+			categoriesList[ i ].disabled = false;
+		}
 	}
 
 	/**
@@ -87,6 +94,10 @@
 			'action',
 			pluginCheck.actionSetUpRuntimeEnvironment
 		);
+
+			for ( let i = 0; i < data.categories.length; i++ ) {
+				pluginCheckData.append( 'categories[]', data.categories[ i ] );
+			}
 
 		for ( let i = 0; i < data.checks.length; i++ ) {
 			pluginCheckData.append( 'checks[]', data.checks[ i ] );
@@ -155,6 +166,12 @@
 		pluginCheckData.append( 'nonce', pluginCheck.nonce );
 		pluginCheckData.append( 'plugin', pluginsList.value );
 		pluginCheckData.append( 'action', pluginCheck.actionGetChecksToRun );
+
+		for ( let i = 0; i < categoriesList.length; i++ ) {
+			if ( categoriesList[i].checked ) {
+				pluginCheckData.append( 'categories[]', categoriesList[ i ].value );
+			}
+		}
 
 		return fetch( ajaxurl, {
 			method: 'POST',

--- a/includes/Admin/Admin_AJAX.php
+++ b/includes/Admin/Admin_AJAX.php
@@ -108,12 +108,17 @@ final class Admin_AJAX {
 			);
 		}
 
-		$checks = filter_input( INPUT_POST, 'checks', FILTER_DEFAULT, FILTER_FORCE_ARRAY );
-		$plugin = filter_input( INPUT_POST, 'plugin', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
+		$categories = filter_input( INPUT_POST, 'categories', FILTER_DEFAULT, FILTER_FORCE_ARRAY );
+		$categories = is_null( $categories ) ? array() : $categories;
+		$checks     = filter_input( INPUT_POST, 'checks', FILTER_DEFAULT, FILTER_FORCE_ARRAY );
+		$checks     = is_null( $checks ) ? array() : $checks;
+		$plugin     = filter_input( INPUT_POST, 'plugin', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
 
 		try {
 			$runner->set_check_slugs( $checks );
 			$runner->set_plugin( $plugin );
+			$runner->filter_checks_by_specific_categories( $categories );
+
 			$checks_to_run = $runner->get_checks_to_run();
 		} catch ( Exception $error ) {
 			wp_send_json_error(
@@ -189,10 +194,12 @@ final class Admin_AJAX {
 			wp_send_json_error( $valid_request, 403 );
 		}
 
-		$checks = filter_input( INPUT_POST, 'checks', FILTER_DEFAULT, FILTER_FORCE_ARRAY );
-		$checks = is_null( $checks ) ? array() : $checks;
-		$plugin = filter_input( INPUT_POST, 'plugin', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
-		$runner = Plugin_Request_Utility::get_runner();
+		$categories = filter_input( INPUT_POST, 'categories', FILTER_DEFAULT, FILTER_FORCE_ARRAY );
+		$categories = is_null( $categories ) ? array() : $categories;
+		$checks     = filter_input( INPUT_POST, 'checks', FILTER_DEFAULT, FILTER_FORCE_ARRAY );
+		$checks     = is_null( $checks ) ? array() : $checks;
+		$plugin     = filter_input( INPUT_POST, 'plugin', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
+		$runner     = Plugin_Request_Utility::get_runner();
 
 		if ( is_null( $runner ) ) {
 			$runner = new AJAX_Runner();
@@ -221,8 +228,9 @@ final class Admin_AJAX {
 
 		wp_send_json_success(
 			array(
-				'plugin' => $plugin_basename,
-				'checks' => array_keys( $checks_to_run ),
+				'plugin'     => $plugin_basename,
+				'checks'     => array_keys( $checks_to_run ),
+				'categories' => $categories,
 			)
 		);
 	}

--- a/includes/Admin/Admin_AJAX.php
+++ b/includes/Admin/Admin_AJAX.php
@@ -108,16 +108,12 @@ final class Admin_AJAX {
 			);
 		}
 
-		$categories = filter_input( INPUT_POST, 'categories', FILTER_DEFAULT, FILTER_FORCE_ARRAY );
-		$categories = is_null( $categories ) ? array() : $categories;
-		$checks     = filter_input( INPUT_POST, 'checks', FILTER_DEFAULT, FILTER_FORCE_ARRAY );
-		$checks     = is_null( $checks ) ? array() : $checks;
-		$plugin     = filter_input( INPUT_POST, 'plugin', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
+		$checks = filter_input( INPUT_POST, 'checks', FILTER_DEFAULT, FILTER_FORCE_ARRAY );
+		$plugin = filter_input( INPUT_POST, 'plugin', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
 
 		try {
 			$runner->set_check_slugs( $checks );
 			$runner->set_plugin( $plugin );
-			$runner->filter_checks_by_specific_categories( $categories );
 
 			$checks_to_run = $runner->get_checks_to_run();
 		} catch ( Exception $error ) {
@@ -216,6 +212,7 @@ final class Admin_AJAX {
 		try {
 			$runner->set_check_slugs( $checks );
 			$runner->set_plugin( $plugin );
+			$runner->set_categories( $categories );
 
 			$plugin_basename = $runner->get_plugin_basename();
 			$checks_to_run   = $runner->get_checks_to_run();
@@ -228,9 +225,8 @@ final class Admin_AJAX {
 
 		wp_send_json_success(
 			array(
-				'plugin'     => $plugin_basename,
-				'checks'     => array_keys( $checks_to_run ),
-				'categories' => $categories,
+				'plugin' => $plugin_basename,
+				'checks' => array_keys( $checks_to_run ),
 			)
 		);
 	}

--- a/includes/Admin/Admin_Page.php
+++ b/includes/Admin/Admin_Page.php
@@ -158,8 +158,7 @@ final class Admin_Page {
 
 		$selected_plugin_basename = filter_input( INPUT_GET, 'plugin', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
 
-		$check_categories = new Check_Categories();
-		$categories       = $check_categories->get_categories();
+		$categories = Check_Categories::get_categories();
 
 		require WP_PLUGIN_CHECK_PLUGIN_DIR_PATH . 'templates/admin-page.php';
 	}

--- a/includes/Admin/Admin_Page.php
+++ b/includes/Admin/Admin_Page.php
@@ -7,6 +7,8 @@
 
 namespace WordPress\Plugin_Check\Admin;
 
+use WordPress\Plugin_Check\Checker\Check_Categories;
+
 /**
  * Class is handling admin tools page functionality.
  *
@@ -150,11 +152,14 @@ final class Admin_Page {
 	 * @since n.e.x.t
 	 */
 	public function render_page() {
-		global $available_plugins, $selected_plugin_basename;
+		global $available_plugins, $selected_plugin_basename, $categories;
 
 		$available_plugins = $this->get_available_plugins();
 
 		$selected_plugin_basename = filter_input( INPUT_GET, 'plugin', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
+
+		$check_categories = new Check_Categories();
+		$categories       = $check_categories->get_categories();
 
 		require WP_PLUGIN_CHECK_PLUGIN_DIR_PATH . 'templates/admin-page.php';
 	}

--- a/includes/CLI/Plugin_Check_Command.php
+++ b/includes/CLI/Plugin_Check_Command.php
@@ -72,6 +72,9 @@ final class Plugin_Check_Command {
 	 *   - json
 	 * ---
 	 *
+	 * [--categories]
+	 * : Limit displayed results to include only specific categories Checks.
+	 *
 	 * [--fields=<fields>]
 	 * : Limit displayed results to a subset of fields provided.
 	 *
@@ -109,6 +112,9 @@ final class Plugin_Check_Command {
 		$plugin = isset( $args[0] ) ? $args[0] : '';
 		$checks = wp_parse_list( $options['checks'] );
 
+		// Create the categories array from CLI arguments.
+		$categories = isset( $options['categories'] ) ? wp_parse_list( $options['categories'] ) : array();
+
 		// Get the CLI Runner.
 		$runner = Plugin_Request_Utility::get_runner();
 
@@ -129,6 +135,7 @@ final class Plugin_Check_Command {
 			$runner->set_experimental_flag( $options['include-experimental'] );
 			$runner->set_check_slugs( $checks );
 			$runner->set_plugin( $plugin );
+			$runner->filter_checks_by_specific_categories( $categories );
 
 			$checks_to_run = $runner->get_checks_to_run();
 		} catch ( Exception $error ) {

--- a/includes/CLI/Plugin_Check_Command.php
+++ b/includes/CLI/Plugin_Check_Command.php
@@ -135,7 +135,7 @@ final class Plugin_Check_Command {
 			$runner->set_experimental_flag( $options['include-experimental'] );
 			$runner->set_check_slugs( $checks );
 			$runner->set_plugin( $plugin );
-			$runner->filter_checks_by_specific_categories( $categories );
+			$runner->set_categories( $categories );
 
 			$checks_to_run = $runner->get_checks_to_run();
 		} catch ( Exception $error ) {

--- a/includes/Checker/AJAX_Runner.php
+++ b/includes/Checker/AJAX_Runner.php
@@ -86,4 +86,18 @@ class AJAX_Runner extends Abstract_Check_Runner {
 	protected function get_include_experimental_param() {
 		return false;
 	}
+
+	/**
+	 * Returns an array of categories for filtering the checks.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @return array An array of categories for filtering the checks.
+	 */
+	protected function get_categories_param() {
+		$categories = filter_input( INPUT_POST, 'categories', FILTER_DEFAULT, FILTER_FORCE_ARRAY );
+		$categories = is_null( $categories ) ? array() : $categories;
+
+		return $categories;
+	}
 }

--- a/includes/Checker/Abstract_Check_Runner.php
+++ b/includes/Checker/Abstract_Check_Runner.php
@@ -15,6 +15,8 @@ use WordPress\Plugin_Check\Utilities\Plugin_Request_Utility;
  * Abstract Check Runner class.
  *
  * @since n.e.x.t
+ *
+ * @SuppressWarnings(PHPMD.ExcessiveClassComplexity)
  */
 abstract class Abstract_Check_Runner implements Check_Runner {
 
@@ -203,7 +205,11 @@ abstract class Abstract_Check_Runner implements Check_Runner {
 		if ( $this->initialized_early ) {
 			if ( $include_experimental !== $this->get_include_experimental_param() ) {
 				throw new Exception(
-					__( 'Invalid flag: The include-experimental flag does not match the original request parameter.', 'plugin-check' )
+					sprintf(
+						/* translators: %s: include-experimental */
+						__( 'Invalid flag: The %s flag does not match the original request parameter.', 'plugin-check' ),
+						'include-experimental'
+					)
 				);
 			}
 		}
@@ -223,7 +229,11 @@ abstract class Abstract_Check_Runner implements Check_Runner {
 	final public function filter_checks_by_specific_categories( $categories ) {
 		if ( $categories !== $this->get_categories_param() ) {
 			throw new Exception(
-				__( 'Invalid flag: The include-experimental flag does not match the original request parameter.', 'plugin-check' )
+				sprintf(
+					/* translators: %s: categories */
+					__( 'Invalid categories: The %s does not match the original request parameter.', 'plugin-check' ),
+					'categories'
+				)
 			);
 		}
 		$this->check_categories = $categories;

--- a/includes/Checker/Abstract_Check_Runner.php
+++ b/includes/Checker/Abstract_Check_Runner.php
@@ -207,7 +207,7 @@ abstract class Abstract_Check_Runner implements Check_Runner {
 				throw new Exception(
 					sprintf(
 						/* translators: %s: include-experimental */
-						__( 'Invalid flag: The %s flag does not match the original request parameter.', 'plugin-check' ),
+						__( 'Invalid flag: The %s value does not match the original request parameter.', 'plugin-check' ),
 						'include-experimental'
 					)
 				);
@@ -226,15 +226,17 @@ abstract class Abstract_Check_Runner implements Check_Runner {
 	 *
 	 * @throws Exception Thrown if the getegories does not match the original request parameter.
 	 */
-	final public function filter_checks_by_specific_categories( $categories ) {
-		if ( $categories !== $this->get_categories_param() ) {
-			throw new Exception(
-				sprintf(
-					/* translators: %s: categories */
-					__( 'Invalid categories: The %s flag does not match the original request parameter.', 'plugin-check' ),
-					'categories'
-				)
-			);
+	final public function set_categories( $categories ) {
+		if ( $this->initialized_early ) {
+			if ( $categories !== $this->get_categories_param() ) {
+				throw new Exception(
+					sprintf(
+						/* translators: %s: categories */
+						__( 'Invalid categories: The %s value does not match the original request parameter.', 'plugin-check' ),
+						'categories'
+					)
+				);
+			}
 		}
 		$this->check_categories = $categories;
 	}
@@ -378,10 +380,9 @@ abstract class Abstract_Check_Runner implements Check_Runner {
 		$checks = $this->check_repository->get_checks( $check_flags, $check_slugs );
 
 		// Filters the checks by specific categories.
-		$get_categories = $this->get_categories();
-		if ( $get_categories ) {
-			$check_categories = new Check_Categories();
-			$checks           = $check_categories->filter_checks_by_categories( $checks, $get_categories );
+		$categories = $this->get_categories();
+		if ( $categories ) {
+			$checks = Check_Categories::filter_checks_by_categories( $checks, $categories );
 		}
 
 		return $checks;
@@ -444,7 +445,7 @@ abstract class Abstract_Check_Runner implements Check_Runner {
 	 *
 	 * @return bool True if experimental checks are included. False if not.
 	 */
-	final public function get_include_experimental() {
+	final protected function get_include_experimental() {
 		if ( null !== $this->include_experimental ) {
 			return $this->include_experimental;
 		}
@@ -459,7 +460,7 @@ abstract class Abstract_Check_Runner implements Check_Runner {
 	 *
 	 * @return array An array of categories.
 	 */
-	final public function get_categories() {
+	final protected function get_categories() {
 		if ( null !== $this->check_categories ) {
 			return $this->check_categories;
 		}

--- a/includes/Checker/Abstract_Check_Runner.php
+++ b/includes/Checker/Abstract_Check_Runner.php
@@ -231,7 +231,7 @@ abstract class Abstract_Check_Runner implements Check_Runner {
 			throw new Exception(
 				sprintf(
 					/* translators: %s: categories */
-					__( 'Invalid categories: The %s does not match the original request parameter.', 'plugin-check' ),
+					__( 'Invalid categories: The %s flag does not match the original request parameter.', 'plugin-check' ),
 					'categories'
 				)
 			);

--- a/includes/Checker/CLI_Runner.php
+++ b/includes/Checker/CLI_Runner.php
@@ -103,4 +103,24 @@ class CLI_Runner extends Abstract_Check_Runner {
 
 		return false;
 	}
+
+	/**
+	 * Returns an array of categories for filtering the checks.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @return array An array of categories.
+	 */
+	protected function get_categories_param() {
+		$categories = array();
+
+		foreach ( $_SERVER['argv'] as $value ) {
+			if ( false !== strpos( $value, '--categories=' ) ) {
+				$categories = explode( ',', str_replace( '--categories=', '', $value ) );
+				break;
+			}
+		}
+
+		return $categories;
+	}
 }

--- a/includes/Checker/CLI_Runner.php
+++ b/includes/Checker/CLI_Runner.php
@@ -81,7 +81,7 @@ class CLI_Runner extends Abstract_Check_Runner {
 
 		foreach ( $_SERVER['argv'] as $value ) {
 			if ( false !== strpos( $value, '--checks=' ) ) {
-				$checks = explode( ',', str_replace( '--checks=', '', $value ) );
+				$checks = wp_parse_list( str_replace( '--checks=', '', $value ) );
 				break;
 			}
 		}
@@ -116,7 +116,7 @@ class CLI_Runner extends Abstract_Check_Runner {
 
 		foreach ( $_SERVER['argv'] as $value ) {
 			if ( false !== strpos( $value, '--categories=' ) ) {
-				$categories = explode( ',', str_replace( '--categories=', '', $value ) );
+				$categories = wp_parse_list( str_replace( '--categories=', '', $value ) );
 				break;
 			}
 		}

--- a/templates/admin-page.php
+++ b/templates/admin-page.php
@@ -33,6 +33,27 @@
 
 				<input type="submit" value="<?php esc_attr_e( 'Check it!', 'plugin-check' ); ?>" id="plugin-check__submit" class="button button-primary" />
 				<span id="plugin-check__spinner" class="spinner" style="float: none;"></span>
+				<h4><?php esc_attr_e( 'Categories', 'plugin-check' ); ?></h4>
+				<?php
+				if ( ! empty( $categories ) ) {
+				?>
+				<table>
+				<?php
+				foreach ( $categories as $category ) { ?>
+					<tr>
+						<td>
+							<fieldset>
+								<legend class="screen-reader-text"><?php esc_html_e( $category ); ?></legend>
+								<label for="<?php echo esc_attr( $category ); ?>">
+									<input type="checkbox" id="<?php echo esc_attr( $category ); ?>" name="categories" value="<?php echo esc_attr( $category ); ?>" checked="checked" />
+									<?php esc_html_e( ucfirst( str_replace( '_', ' ', $category ) ) ); ?>
+								</label>
+							</fieldset>
+						</td>
+					</tr>
+				<?php } ?>
+				</table>
+				<?php } ?>
 			</form>
 
 		<?php } else { ?>

--- a/tests/phpunit/Checker/Default_Check_Repository_Tests.php
+++ b/tests/phpunit/Checker/Default_Check_Repository_Tests.php
@@ -7,6 +7,13 @@
 
 use WordPress\Plugin_Check\Checker\Check_Repository;
 use WordPress\Plugin_Check\Checker\Default_Check_Repository;
+use WordPress\Plugin_Check\Test_Data\Category_Check_Five;
+use WordPress\Plugin_Check\Test_Data\Category_Check_Four;
+use WordPress\Plugin_Check\Test_Data\Category_Check_One;
+use WordPress\Plugin_Check\Test_Data\Category_Check_Seven;
+use WordPress\Plugin_Check\Test_Data\Category_Check_Six;
+use WordPress\Plugin_Check\Test_Data\Category_Check_Three;
+use WordPress\Plugin_Check\Test_Data\Category_Check_Two;
 use WordPress\Plugin_Check\Test_Data\Experimental_Runtime_Check;
 use WordPress\Plugin_Check\Test_Data\Experimental_Static_Check;
 use WordPress\Plugin_Check\Test_Data\Invalid_Check;

--- a/tests/phpunit/Checker/Default_Check_Repository_Tests.php
+++ b/tests/phpunit/Checker/Default_Check_Repository_Tests.php
@@ -7,13 +7,6 @@
 
 use WordPress\Plugin_Check\Checker\Check_Repository;
 use WordPress\Plugin_Check\Checker\Default_Check_Repository;
-use WordPress\Plugin_Check\Test_Data\Category_Check_Five;
-use WordPress\Plugin_Check\Test_Data\Category_Check_Four;
-use WordPress\Plugin_Check\Test_Data\Category_Check_One;
-use WordPress\Plugin_Check\Test_Data\Category_Check_Seven;
-use WordPress\Plugin_Check\Test_Data\Category_Check_Six;
-use WordPress\Plugin_Check\Test_Data\Category_Check_Three;
-use WordPress\Plugin_Check\Test_Data\Category_Check_Two;
 use WordPress\Plugin_Check\Test_Data\Experimental_Runtime_Check;
 use WordPress\Plugin_Check\Test_Data\Experimental_Static_Check;
 use WordPress\Plugin_Check\Test_Data\Invalid_Check;


### PR DESCRIPTION
<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #206

**WP Admin screen:**
<img width="426" alt="Screenshot 2023-07-12 at 2 51 02 PM" src="https://github.com/10up/plugin-check/assets/10103365/a00a186a-7c0e-4f11-b858-b920e95fd0d7">

**WP_CLI command**
`npm run wp-env run cli -- wp plugin check {plugin} --require=./wp-content/plugins/plugin-check/cli.php --categories=security,general`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
