### PR TITLE
Add screenshot of WP Admin to `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ After having the plugin activated, you can analyze any other plugin installed on
     * Note that by default when using WP-CLI, only static checks can be executed. In order to also include runtime checks, a workaround is currently necessary using the `--require` argument of WP-CLI, to manually load the `cli.php` file within the plugin checker directory before WordPress is loaded. For example: `wp plugin check hello.php --require=./wp-content/plugins/plugin-check/cli.php`
 
 <img alt="WordPress plugin checker UI in WP Admin" src="https://github.com/10up/plugin-check/assets/3531426/19d0c1ce-8c37-4efd-b8c6-d252e6ce29c9">
+<em>Screenshot of the plugin checker's UI in WP Admin</em>
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ After having the plugin activated, you can analyze any other plugin installed on
 * To check a plugin using WP-CLI, please use the `wp plugin check` command. For example, to check the "Hello Dolly" plugin: `wp plugin check hello.php`
     * Note that by default when using WP-CLI, only static checks can be executed. In order to also include runtime checks, a workaround is currently necessary using the `--require` argument of WP-CLI, to manually load the `cli.php` file within the plugin checker directory before WordPress is loaded. For example: `wp plugin check hello.php --require=./wp-content/plugins/plugin-check/cli.php`
 
-<img width="1280" height="720" alt="WordPress plugin checker UI in WP Admin" src="https://github.com/10up/plugin-check/assets/3531426/19d0c1ce-8c37-4efd-b8c6-d252e6ce29c9">
+<img alt="WordPress plugin checker UI in WP Admin" src="https://github.com/10up/plugin-check/assets/3531426/19d0c1ce-8c37-4efd-b8c6-d252e6ce29c9">
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ After having the plugin activated, you can analyze any other plugin installed on
 * To check a plugin using WP-CLI, please use the `wp plugin check` command. For example, to check the "Hello Dolly" plugin: `wp plugin check hello.php`
     * Note that by default when using WP-CLI, only static checks can be executed. In order to also include runtime checks, a workaround is currently necessary using the `--require` argument of WP-CLI, to manually load the `cli.php` file within the plugin checker directory before WordPress is loaded. For example: `wp plugin check hello.php --require=./wp-content/plugins/plugin-check/cli.php`
 
+<img width="1280" height="720" alt="WordPress plugin checker UI in WP Admin" src="https://github.com/10up/plugin-check/assets/3531426/19d0c1ce-8c37-4efd-b8c6-d252e6ce29c9">
+
 ## Contributing
 
 To set up the repository locally, you will need to clone this GitHub repository (or a fork of it) and then install the relevant dependencies:


### PR DESCRIPTION
### Description of the Change
This PR simply adds a screenshot of the WP Admin interface to the `README.md` to make it a bit more appealing. Having a visual idea of the UI also may help understanding.

See [the branch](https://github.com/10up/plugin-check/tree/add/readme-screenshot#how-to-use) for what it looks like.


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
