### PR TITLE
Remove `is_plugin_check` method from `Abstract_Check_Runner` Class

### DIFF
--- a/includes/Checker/Abstract_Check_Runner.php
+++ b/includes/Checker/Abstract_Check_Runner.php
@@ -93,15 +93,6 @@ abstract class Abstract_Check_Runner implements Check_Runner {
 	protected $check_categories;
 
 	/**
-	 * Determines if the current request is intended for the plugin checker.
-	 *
-	 * @since n.e.x.t
-	 *
-	 * @return bool Returns true if the check is for plugin else false.
-	 */
-	abstract public static function is_plugin_check();
-
-	/**
 	 * Returns the plugin parameter based on the request.
 	 *
 	 * @since n.e.x.t


### PR DESCRIPTION
During the QA testing process for the repository hosted at https://github.com/10up/plugin-check/issues/194#issuecomment-1645048406, we have identified a specific error. The code in question involves the usage of abstract static functions in PHP, which is considered discouraged. It has come to our attention that the `Check_Runner` interface already declares this function, making its presence as an abstract method in `Abstract_Check_Runner` unnecessary.

As a result, we propose the removal of the aforementioned method from the `Abstract_Check_Runner` class to adhere to best practices and improve the codebase's maintainability and clarity.

```
CLI: Strict Standards: Static function WordPress\Plugin_Check\Checker\Abstract_Check_Runner::is_plugin_check() should not be abstract in /var/www/html/wp-content/plugins/plugin-check/includes/Checker/Abstract_Check_Runner.php on line 102
```

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
