### PR TITLE
Plugin Checker Deactivation Causes Error in CLI Command

### DIFF
--- a/includes/CLI/Plugin_Check_Command.php
+++ b/includes/CLI/Plugin_Check_Command.php
@@ -114,11 +114,7 @@ final class Plugin_Check_Command {
 		 */
 		if ( is_plugin_inactive( $this->plugin_context->basename() ) ) {
 			WP_CLI::error(
-				sprintf(
-					// translators: Plugin Checker slug.
-					__( '%s is not active.', 'plugin-check' ),
-					$this->plugin_context->basename()
-				)
+				__( 'Plugin Checker is not active.', 'plugin-check' )
 			);
 		}
 

--- a/includes/CLI/Plugin_Check_Command.php
+++ b/includes/CLI/Plugin_Check_Command.php
@@ -105,6 +105,22 @@ final class Plugin_Check_Command {
 	 * @SuppressWarnings(PHPMD.NPathComplexity)
 	 */
 	public function check( $args, $assoc_args ) {
+		/*
+		 * Bail early if the Plugin Checker is not activated.
+		 *
+		 * If the Plugin Checker is not activated, it will throw an error and
+		 * CLI commands won't be usable.
+		 */
+		if ( is_plugin_inactive( $this->plugin_context->basename() ) ) {
+			WP_CLI::error(
+				sprintf(
+					// translators: Plugin Checker slug.
+					__( '%s is not active.', 'plugin-check' ),
+					$this->plugin_context->basename()
+				)
+			);
+		}
+
 		// Get options based on the CLI arguments.
 		$options = $this->get_options( $assoc_args );
 

--- a/includes/CLI/Plugin_Check_Command.php
+++ b/includes/CLI/Plugin_Check_Command.php
@@ -103,6 +103,7 @@ final class Plugin_Check_Command {
 	 * @throws Exception Throws exception.
 	 *
 	 * @SuppressWarnings(PHPMD.NPathComplexity)
+	 * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
 	 */
 	public function check( $args, $assoc_args ) {
 		/*


### PR DESCRIPTION
During QA testing, it was discovered that if the Plugin Checker is deactivated and the CLI command `npm run wp-env run cli -- wp plugin check {plugin} --require=./wp-content/plugins/plugin-check/cli.php` is executed, it shows an error. The error is related to the behaviour discussed in the following comment on GitHub: https://github.com/10up/plugin-check/issues/194#issuecomment-1647538986. As a result of this finding, the decision was made to throw an error when anyone attempts to use the CLI command while the Plugin Checker is not activated.

**Proposed Solution:**
To address the issue, the possible code changes need to be added to the `cli.php` file. However, due to the `cli.php` file running early in WordPress, certain functions cannot be used there. As a workaround, the necessary code has been added to the `includes/CLI/Plugin_Check_Command.php` file.

**Steps to Reproduce:**
1. Install any plugin that you want to check.
2. Deactivate the "Plugin Checker" from `Admin Panel > Plugins`.
3. Execute the following CLI command:
   ```
   npm run wp-env run cli -- wp plugin check {plugin} --require=./wp-content/plugins/plugin-check/cli.php
   ```
   Replace `{plugin}` with the slug of the plugin you want to check.
4. Observe the error that occurs.

**Expected behaviour:**
After applying the changes from the pull request, the CLI command should display the error message: `Error: plugin-check/plugin-check.php is not active.` when attempting to use it while the Plugin Checker is not activated.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
