### PR TITLE
Incorrect display of `readme.txt` instead of `readme.md` in Plugin Readme check

### DIFF
--- a/includes/Checker/Checks/Plugin_Readme_Check.php
+++ b/includes/Checker/Checks/Plugin_Readme_Check.php
@@ -95,14 +95,10 @@ class Plugin_Readme_Check extends Abstract_File_Check {
 		if ( $file ) {
 			$result->add_message(
 				false,
-				sprintf(
-					/* translators: %s: readme file */
-					__( 'The %s appears to contain default text.', 'plugin-check' ),
-					str_replace( $result->plugin()->path( '/' ), '', $file )
-				),
+				__( 'The readme appears to contain default text.', 'plugin-check' ),
 				array(
 					'code' => 'default_readme_text',
-					'file' => $file,
+					'file' => str_replace( $result->plugin()->path(), '', $file ),
 				)
 			);
 		}
@@ -129,14 +125,10 @@ class Plugin_Readme_Check extends Abstract_File_Check {
 		if ( ! preg_match( '/^([a-z0-9\-\+\.]+)(\sor\s([a-z0-9\-\+\.]+))*$/i', $matches[2] ) ) {
 			$result->add_message(
 				false,
-				sprintf(
-					/* translators: %s: readme file */
-					__( 'Your plugin has an invalid license declared. Please update your %s with a valid SPDX license identifier.', 'plugin-check' ),
-					str_replace( $result->plugin()->path( '/' ), '', $file )
-				),
+				__( 'Your plugin has an invalid license declared. Please update your readme with a valid SPDX license identifier.', 'plugin-check' ),
 				array(
 					'code' => 'invalid_license',
-					'file' => $file,
+					'file' => str_replace( $result->plugin()->path(), '', $file ),
 				)
 			);
 		}
@@ -166,7 +158,7 @@ class Plugin_Readme_Check extends Abstract_File_Check {
 				__( "It's recommended not to use 'Stable Tag: trunk'.", 'plugin-check' ),
 				array(
 					'code' => 'trunk_stable_tag',
-					'file' => $file,
+					'file' => str_replace( $result->plugin()->path(), '', $file ),
 				)
 			);
 		}
@@ -180,14 +172,10 @@ class Plugin_Readme_Check extends Abstract_File_Check {
 		) {
 			$result->add_message(
 				false,
-				sprintf(
-					/* translators: %s: readme file */
-					__( 'The Stable Tag in your %s file does not match the version in your main plugin file.', 'plugin-check' ),
-					str_replace( $result->plugin()->path( '/' ), '', $file )
-				),
+				__( 'The Stable Tag in your readme file does not match the version in your main plugin file.', 'plugin-check' ),
 				array(
 					'code' => 'stable_tag_mismatch',
-					'file' => $file,
+					'file' => str_replace( $result->plugin()->path(), '', $file ),
 				)
 			);
 		}

--- a/tests/phpunit/Checker/Checks/Plugin_Readme_Check_Tests.php
+++ b/tests/phpunit/Checker/Checks/Plugin_Readme_Check_Tests.php
@@ -128,4 +128,42 @@ class Plugin_Readme_Check_Tests extends WP_UnitTestCase {
 		$this->assertEquals( 0, $check_result->get_error_count() );
 		$this->assertEquals( 0, $check_result->get_warning_count() );
 	}
+
+	public function test_run_md_with_errors() {
+		$readme_check  = new Plugin_Readme_Check();
+		$check_context = new Check_Context( UNIT_TESTS_PLUGIN_DIR . 'test-plugin-plugin-readme-md-with-errors/load.php' );
+		$check_result  = new Check_Result( $check_context );
+
+		$readme_check->run( $check_result );
+
+		$warnings = $check_result->get_warnings();
+
+		$this->assertNotEmpty( $warnings );
+		$this->assertArrayHasKey( 'readme.md', $warnings );
+		$this->assertEquals( 4, $check_result->get_warning_count() );
+
+		// Check for default text file warning.
+		$this->assertArrayHasKey( 0, $warnings['readme.md'] );
+		$this->assertArrayHasKey( 0, $warnings['readme.md'][0] );
+		$this->assertArrayHasKey( 'code', $warnings['readme.md'][0][0][0] );
+		$this->assertEquals( 'default_readme_text', $warnings['readme.md'][0][0][0]['code'] );
+
+		// Check for invalid license warning.
+		$this->assertArrayHasKey( 0, $warnings['readme.md'] );
+		$this->assertArrayHasKey( 0, $warnings['readme.md'][0] );
+		$this->assertArrayHasKey( 'code', $warnings['readme.md'][0][0][1] );
+		$this->assertEquals( 'invalid_license', $warnings['readme.md'][0][0][1]['code'] );
+
+		// Check for trunk stable tag warning.
+		$this->assertArrayHasKey( 0, $warnings['readme.md'] );
+		$this->assertArrayHasKey( 0, $warnings['readme.md'][0] );
+		$this->assertArrayHasKey( 'code', $warnings['readme.md'][0][0][2] );
+		$this->assertEquals( 'trunk_stable_tag', $warnings['readme.md'][0][0][2]['code'] );
+
+		// Check for stable tag mismatch file warning.
+		$this->assertArrayHasKey( 0, $warnings['readme.md'] );
+		$this->assertArrayHasKey( 0, $warnings['readme.md'][0] );
+		$this->assertArrayHasKey( 'code', $warnings['readme.md'][0][0][3] );
+		$this->assertEquals( 'stable_tag_mismatch', $warnings['readme.md'][0][0][3]['code'] );
+	}
 }

--- a/tests/phpunit/testdata/plugins/test-plugin-plugin-readme-md-with-errors/load.php
+++ b/tests/phpunit/testdata/plugins/test-plugin-plugin-readme-md-with-errors/load.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * Plugin Name: Test Plugin Readme.md check (errors)
+ * Plugin URI: https://github.com/wordpress/plugin-check
+ * Description: Test plugin for the Readme.md check.
+ * Requires at least: 6.0
+ * Requires PHP: 5.6
+ * Version: 1.0.0
+ * Author: WordPress Performance Team
+ * Author URI: https://make.wordpress.org/performance/
+ * License: GPLv2 or later
+ * License URI: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+ * Text Domain: test-plugin-check-errors
+ *
+ * @package test-plugin-check-errors
+ */

--- a/tests/phpunit/testdata/plugins/test-plugin-plugin-readme-md-with-errors/readme.md
+++ b/tests/phpunit/testdata/plugins/test-plugin-plugin-readme-md-with-errors/readme.md
@@ -1,0 +1,13 @@
+
+=== Plugin Check ===
+
+Contributors:      wordpressdotorg
+Requires at least: 6.0
+Tested up to:      6.1
+Requires PHP:      5.6
+Stable tag:        trunk
+License:           Oculus VR Inc. Software Development Kit License
+License URI:       https://www.gnu.org/licenses/gpl-2.0.html
+Tags:              performance, testing, security
+
+Here is a short description of the plugin.


### PR DESCRIPTION
In issue #195, it was allowed to use a `readme.md` file for plugin. However, when someone uses the `readme.md` file and runs the plugin checks, the plugin incorrectly displays `readme.txt` as the file name instead of the actual `readme.md` file.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.
