### PR TITLE
Remove PHP 5.6 from unit test

### DIFF
--- a/.github/workflows/php-test.yml
+++ b/.github/workflows/php-test.yml
@@ -48,7 +48,6 @@ jobs:
       fail-fast: true
       matrix:
         php:
-        - '5.6'
         - '7.0'
         - '7.1'
         - '7.2'


### PR DESCRIPTION
WordPress remove 5.6 support so we should remove it from our unit tests.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
