### PR TITLE
Modify how PHPCS availability is checked

### DIFF
--- a/inc/class-phpcs.php
+++ b/inc/class-phpcs.php
@@ -120,7 +120,7 @@ class PHPCS {
 	 * @return string|WP_Error|null
 	 */
 	public function run( $path, array $args = array() ) {
-		if ( ! is_executable( $this->phpcs ) ) {
+		if ( ! file_exists( $this->phpcs ) ) {
 			return new \WP_Error(
 				'missing_dependency',
 				'PHP Code Sniffer is not available. Try running <code>composer install</code> first.'

--- a/readme.txt
+++ b/readme.txt
@@ -42,6 +42,10 @@ This plugin checker is not perfect, and never will be. It is only a tool to help
 
 == Changelog ==
 
+= [0.2.1] 2023-09-?? =
+
+* Fix - Ensure that the PHPCS check runs even when the PHPCS binary is not executable. Props @bordoni, @shawn-digitalpoint, @mrfoxtalbot [#254](https://github.com/10up/plugin-check/pull/254)
+
 = [0.2.0] 2023-09-18 =
 
 * Feature - Enable modification of the PHP Binary path used by the plugin with `PLUGIN_CHECK_PHP_BIN` constant.


### PR DESCRIPTION
### Description of the Change

A couple of users were reporting problems with the PHPCS tests not running properly, so we made changes to avoid the `is_executable`, now it only checks for the presence of the binary file.

Resolves #254

### Changelog Entry

* Ensure that the PHPCS check runs even when the PHPCS binary is not executable.
