### PR TITLE
Create a way to remove certain readme warnings, contributors_ignored.

### DIFF
--- a/checks/readme.php
+++ b/checks/readme.php
@@ -1,6 +1,7 @@
 <?php
 namespace WordPressdotorg\Plugin_Check\Checks;
 use WordPressdotorg\Plugin_Check\{Error, Guideline_Violation, Message, Notice, Warning};
+use WordPressdotorg\Plugin_Directory\Readme\Parser;
 
 class Readme extends Check_Base {
 	/**
@@ -76,13 +77,31 @@ class Readme extends Check_Base {
 	}
 
 	function check_for_warnings() {
-		if ( ! empty( $this->readme->warnings ) ) {
+		$warnings = $this->readme->warnings ?? [];
+		$warning_keys = array_keys( $this->readme->warnings );
+		$ignored_warnings = [
+			'contributor_ignored'
+		];
+
+		/**
+		 * Filter the list of ignored readme parser warnings.
+		 *
+		 * @since 0.2.2
+		 *
+		 * @param array  $ignored_warnings Array of ignored warning keys.
+		 * @param Parser $readme The readme object.
+		 */
+		$ignored_warnings = apply_filters( 'plugin_check_readme_warnings_ignored', $ignored_warnings, $this->readme );
+
+		$warning_keys = array_diff( $warning_keys, $ignored_warnings );
+
+		if ( ! empty( $warning_keys ) ) {
 			return new Warning(
 				'readme_parser_warnings',
 				sprintf(
 					/* translators: %1$s: list of warnings */
 					__( 'The following readme parser warnings were detected: %1$s', 'plugin-check' ),
-					esc_html( implode( ', ',  array_keys( $this->readme->warnings ) ) )
+					esc_html( implode( ', ', $warning_keys ) )
 				)
 			);
 		}

--- a/checks/readme.php
+++ b/checks/readme.php
@@ -78,7 +78,7 @@ class Readme extends Check_Base {
 
 	function check_for_warnings() {
 		$warnings = $this->readme->warnings ?? [];
-		$warning_keys = array_keys( $this->readme->warnings );
+		$warning_keys = array_keys( $warnings );
 		$ignored_warnings = [
 			'contributor_ignored'
 		];

--- a/checks/readme.php
+++ b/checks/readme.php
@@ -91,7 +91,7 @@ class Readme extends Check_Base {
 		 * @param array  $ignored_warnings Array of ignored warning keys.
 		 * @param Parser $readme The readme object.
 		 */
-		$ignored_warnings = apply_filters( 'plugin_check_readme_warnings_ignored', $ignored_warnings, $this->readme );
+		$ignored_warnings = (array) apply_filters( 'plugin_check_readme_warnings_ignored', $ignored_warnings, $this->readme );
 
 		$warning_keys = array_diff( $warning_keys, $ignored_warnings );
 

--- a/readme.txt
+++ b/readme.txt
@@ -44,7 +44,8 @@ This plugin checker is not perfect, and never will be. It is only a tool to help
 
 = [0.2.2] 2023-09-TBD =
 
-* Fix - Remove extra period on the end of the sentence for Phar warning. Props @bordoni, @pixolin. [#275](https://github.com/10up/plugin-check/pull/265)
+* Fix - Prevent problems with Readme parser warning related to `contributor_ignored` for when running the check outside of WP.org. Props @bordoni, @dev4press. [#276](https://github.com/10up/plugin-check/pull/276)
+* Fix - Remove extra period on the end of the sentence for Phar warning. Props @bordoni, @pixolin. [#275](https://github.com/10up/plugin-check/pull/275)
 
 = [0.2.1] 2023-09-22 =
 


### PR DESCRIPTION
### Description of the Change
A Couple of users mentioned that they are seeing problems on their reports related to a warning on their `readme.txt`.

After doing some digging on the readme parser I realized that this is a warning that should only be active on WordPress.org, so I add a filter to allow us to enable it on that environment but by default it's now ignored.