### PR TITLE
Do not flag `localhost` usage in comments

### DIFF
--- a/includes/Checker/Checks/Localhost_Check.php
+++ b/includes/Checker/Checks/Localhost_Check.php
@@ -43,7 +43,8 @@ class Localhost_Check extends Abstract_File_Check {
 	 */
 	protected function check_files( Check_Result $result, array $files ) {
 		$php_files = self::filter_files_by_extension( $files, 'php' );
-		$file      = self::file_preg_match( '#https?://(localhost|127.0.0.1)#', $php_files );
+		$file      = self::file_preg_match( '#(?<!://)(?<!\* )https?://(localhost|127.0.0.1)#', $php_files );
+
 		if ( $file ) {
 			$result->add_message(
 				true,

--- a/tests/phpunit/Checker/Checks/Localhost_Check_Tests.php
+++ b/tests/phpunit/Checker/Checks/Localhost_Check_Tests.php
@@ -29,4 +29,16 @@ class Localhost_Check_Tests extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'code', $errors['load.php'][0][0][0] );
 		$this->assertEquals( 'localhost_code_detected', $errors['load.php'][0][0][0]['code'] );
 	}
+
+	public function test_run_without_errors() {
+		$localhost_check = new Localhost_Check();
+		$check_context   = new Check_Context( UNIT_TESTS_PLUGIN_DIR . 'test-plugin-localhost-without-errors/load.php' );
+		$check_result    = new Check_Result( $check_context );
+
+		$localhost_check->run( $check_result );
+
+		$errors = $check_result->get_errors();
+
+		$this->assertEmpty( $errors );
+	}
 }

--- a/tests/phpunit/testdata/plugins/test-plugin-localhost-without-errors/load.php
+++ b/tests/phpunit/testdata/plugins/test-plugin-localhost-without-errors/load.php
@@ -18,5 +18,3 @@
  /*
   * This file contains https://localhost/test-plugin-localhost-with-errors url.
   */
-
-$file = 'https://localhost/test-plugin-localhost-with-errors';


### PR DESCRIPTION
### Description of the Change

In #267, @leoloso reported that the error "Do not use Localhost in your code" also gets triggered when the string "localhost" is used within a comment. This PR updates the corresponding regex to ignore the string "localhost" within comments.

Closes #267

### How to test the Change

1. Download and activate this [helper-plugin.zip](https://github.com/10up/plugin-check/files/12708275/helper-plugin.zip)
2. Go to `/wp-admin/tools.php?page=plugin-check` and check the helper plugin before applying this fix.
3. Verify that the error "Do not use Localhost/127.0.0.1 in your code." appears.
4. Apply this PR and check the helper plugin again.
5. Verify that the error "Do not use Localhost/127.0.0.1 in your code." no longer appears.

### Changelog Entry

> Fixed - “localhost” in comments no longer raises error.

### Credits

Props @nielslange

### Checklist:
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.
