### PR TITLE
Refactoring and Code Duplication Reduction for `Plugin_Readme_Check` and `Trademarks_Check`

### DIFF
--- a/includes/Checker/Checks/Abstract_PHP_CodeSniffer_Check.php
+++ b/includes/Checker/Checks/Abstract_PHP_CodeSniffer_Check.php
@@ -61,8 +61,6 @@ abstract class Abstract_PHP_CodeSniffer_Check implements Static_Check {
 	 *
 	 * @throws Exception Thrown when the check fails with a critical error (unrelated to any errors detected as part of
 	 *                   the check).
-	 *
-	 * @SuppressWarnings(PHPMD.NPathComplexity)
 	 */
 	final public function run( Check_Result $result ) {
 		// Include the PHPCS autoloader.
@@ -127,25 +125,15 @@ abstract class Abstract_PHP_CodeSniffer_Check implements Static_Check {
 			}
 
 			foreach ( $file_results['messages'] as $file_message ) {
-				if ( strtoupper( $file_message['type'] ) === 'ERROR' ) {
-					$this->add_result_error_for_file(
-						$result,
-						$file_message['message'],
-						$file_message['source'],
-						$file_name,
-						$file_message['line'],
-						$file_message['column']
-					);
-				} else {
-					$this->add_result_warning_for_file(
-						$result,
-						$file_message['message'],
-						$file_message['source'],
-						$file_name,
-						$file_message['line'],
-						$file_message['column']
-					);
-				}
+				$this->add_result_message_for_file(
+					$result,
+					strtoupper( $file_message['type'] ) === 'ERROR',
+					$file_message['message'],
+					$file_message['source'],
+					$file_name,
+					$file_message['line'],
+					$file_message['column']
+				);
 			}
 		}
 	}

--- a/includes/Checker/Checks/Abstract_PHP_CodeSniffer_Check.php
+++ b/includes/Checker/Checks/Abstract_PHP_CodeSniffer_Check.php
@@ -11,6 +11,7 @@ use Exception;
 use PHP_CodeSniffer\Runner;
 use WordPress\Plugin_Check\Checker\Check_Result;
 use WordPress\Plugin_Check\Checker\Static_Check;
+use WordPress\Plugin_Check\Traits\Amend_Check_Result;
 use WordPress\Plugin_Check\Utilities\Plugin_Request_Utility;
 
 /**
@@ -19,6 +20,8 @@ use WordPress\Plugin_Check\Utilities\Plugin_Request_Utility;
  * @since n.e.x.t
  */
 abstract class Abstract_PHP_CodeSniffer_Check implements Static_Check {
+
+	use Amend_Check_Result;
 
 	/**
 	 * List of allowed PHPCS arguments.
@@ -58,6 +61,8 @@ abstract class Abstract_PHP_CodeSniffer_Check implements Static_Check {
 	 *
 	 * @throws Exception Thrown when the check fails with a critical error (unrelated to any errors detected as part of
 	 *                   the check).
+	 *
+	 * @SuppressWarnings(PHPMD.NPathComplexity)
 	 */
 	final public function run( Check_Result $result ) {
 		// Include the PHPCS autoloader.
@@ -122,16 +127,25 @@ abstract class Abstract_PHP_CodeSniffer_Check implements Static_Check {
 			}
 
 			foreach ( $file_results['messages'] as $file_message ) {
-				$result->add_message(
-					strtoupper( $file_message['type'] ) === 'ERROR',
-					$file_message['message'],
-					array(
-						'code'   => $file_message['source'],
-						'file'   => $file_name,
-						'line'   => $file_message['line'],
-						'column' => $file_message['column'],
-					)
-				);
+				if ( strtoupper( $file_message['type'] ) === 'ERROR' ) {
+					$this->add_result_error_for_file(
+						$result,
+						$file_message['message'],
+						$file_message['source'],
+						$file_name,
+						$file_message['line'],
+						$file_message['column']
+					);
+				} else {
+					$this->add_result_warning_for_file(
+						$result,
+						$file_message['message'],
+						$file_message['source'],
+						$file_name,
+						$file_message['line'],
+						$file_message['column']
+					);
+				}
 			}
 		}
 	}

--- a/includes/Checker/Checks/Code_Obfuscation_Check.php
+++ b/includes/Checker/Checks/Code_Obfuscation_Check.php
@@ -98,7 +98,11 @@ class Code_Obfuscation_Check extends Abstract_File_Check {
 		if ( $obfuscated_file ) {
 			$this->add_result_error_for_file(
 				$result,
-				__( 'Code Obfuscation tools are not permitted. Detected: Zend Guard', 'plugin-check' ),
+				sprintf(
+					/* translators: %s: tool name */
+					__( 'Code Obfuscation tools are not permitted. Detected: %s', 'plugin-check' ),
+					__( 'Zend Guard', 'plugin-check' )
+				),
 				'obfuscated_code_detected',
 				$obfuscated_file
 			);
@@ -118,7 +122,11 @@ class Code_Obfuscation_Check extends Abstract_File_Check {
 		if ( $obfuscated_file ) {
 			$this->add_result_error_for_file(
 				$result,
-				__( 'Code Obfuscation tools are not permitted. Detected: Source Guardian', 'plugin-check' ),
+				sprintf(
+					/* translators: %s: tool name */
+					__( 'Code Obfuscation tools are not permitted. Detected: %s', 'plugin-check' ),
+					__( 'Source Guardian', 'plugin-check' )
+				),
 				'obfuscated_code_detected',
 				$obfuscated_file
 			);
@@ -138,7 +146,11 @@ class Code_Obfuscation_Check extends Abstract_File_Check {
 		if ( $obfuscated_file ) {
 			$this->add_result_error_for_file(
 				$result,
-				__( 'Code Obfuscation tools are not permitted. Detected: ionCube', 'plugin-check' ),
+				sprintf(
+					/* translators: %s: tool name */
+					__( 'Code Obfuscation tools are not permitted. Detected: %s', 'plugin-check' ),
+					__( 'ionCube', 'plugin-check' )
+				),
 				'obfuscated_code_detected',
 				$obfuscated_file
 			);

--- a/includes/Checker/Checks/Code_Obfuscation_Check.php
+++ b/includes/Checker/Checks/Code_Obfuscation_Check.php
@@ -10,6 +10,7 @@ namespace WordPress\Plugin_Check\Checker\Checks;
 use Exception;
 use WordPress\Plugin_Check\Checker\Check_Categories;
 use WordPress\Plugin_Check\Checker\Check_Result;
+use WordPress\Plugin_Check\Traits\Amend_Check_Result;
 use WordPress\Plugin_Check\Traits\Stable_Check;
 
 /**
@@ -19,6 +20,7 @@ use WordPress\Plugin_Check\Traits\Stable_Check;
  */
 class Code_Obfuscation_Check extends Abstract_File_Check {
 
+	use Amend_Check_Result;
 	use Stable_Check;
 
 	const TYPE_ZEND           = 1;
@@ -94,7 +96,12 @@ class Code_Obfuscation_Check extends Abstract_File_Check {
 	protected function look_for_zendguard( Check_Result $result, array $php_files ) {
 		$obfuscated_file = self::file_preg_match( '/(<\?php \@Zend;)|(This file was encoded by)/', $php_files );
 		if ( $obfuscated_file ) {
-			$this->add_result_error_for_file( $result, $obfuscated_file, 'Zend Guard' );
+			$this->add_result_error_for_file(
+				$result,
+				__( 'Code Obfuscation tools are not permitted. Detected: Zend Guard', 'plugin-check' ),
+				'obfuscated_code_detected',
+				$obfuscated_file
+			);
 		}
 	}
 
@@ -109,7 +116,12 @@ class Code_Obfuscation_Check extends Abstract_File_Check {
 	protected function look_for_sourceguardian( Check_Result $result, array $php_files ) {
 		$obfuscated_file = self::file_preg_match( "/(sourceguardian\.com)|(function_exists\('sg_load'\))|(\$__x=)/", $php_files );
 		if ( $obfuscated_file ) {
-			$this->add_result_error_for_file( $result, $obfuscated_file, 'Source Guardian' );
+			$this->add_result_error_for_file(
+				$result,
+				__( 'Code Obfuscation tools are not permitted. Detected: Source Guardian', 'plugin-check' ),
+				'obfuscated_code_detected',
+				$obfuscated_file
+			);
 		}
 	}
 
@@ -124,31 +136,12 @@ class Code_Obfuscation_Check extends Abstract_File_Check {
 	protected function look_for_ioncube( Check_Result $result, array $php_files ) {
 		$obfuscated_file = self::file_str_contains( $php_files, 'ionCube' );
 		if ( $obfuscated_file ) {
-			$this->add_result_error_for_file( $result, $obfuscated_file, 'ionCube' );
+			$this->add_result_error_for_file(
+				$result,
+				__( 'Code Obfuscation tools are not permitted. Detected: ionCube', 'plugin-check' ),
+				'obfuscated_code_detected',
+				$obfuscated_file
+			);
 		}
-	}
-
-	/**
-	 * Amends the given result with an error for the given obfuscated file and tool name.
-	 *
-	 * @since n.e.x.t
-	 *
-	 * @param Check_Result $result          The check result to amend, including the plugin context to check.
-	 * @param string       $obfuscated_file Absolute path to the obfuscated file found.
-	 * @param string       $tool_name       Human-readable name of the tool detected for obfuscation.
-	 */
-	private function add_result_error_for_file( Check_Result $result, $obfuscated_file, $tool_name ) {
-		$result->add_message(
-			true,
-			sprintf(
-				/* translators: %s: tool name */
-				__( 'Code Obfuscation tools are not permitted. Detected: %s', 'plugin-check' ),
-				$tool_name
-			),
-			array(
-				'code' => 'obfuscated_code_detected',
-				'file' => str_replace( $result->plugin()->path(), '', $obfuscated_file ),
-			)
-		);
 	}
 }

--- a/includes/Checker/Checks/Enqueued_Scripts_Size_Check.php
+++ b/includes/Checker/Checks/Enqueued_Scripts_Size_Check.php
@@ -12,6 +12,7 @@ use WordPress\Plugin_Check\Checker\Check_Categories;
 use WordPress\Plugin_Check\Checker\Check_Result;
 use WordPress\Plugin_Check\Checker\Preparations\Demo_Posts_Creation_Preparation;
 use WordPress\Plugin_Check\Checker\With_Shared_Preparations;
+use WordPress\Plugin_Check\Traits\Amend_Check_Result;
 use WordPress\Plugin_Check\Traits\Stable_Check;
 use WordPress\Plugin_Check\Traits\URL_Aware;
 
@@ -22,8 +23,9 @@ use WordPress\Plugin_Check\Traits\URL_Aware;
  */
 class Enqueued_Scripts_Size_Check extends Abstract_Runtime_Check implements With_Shared_Preparations {
 
-	use URL_Aware;
+	use Amend_Check_Result;
 	use Stable_Check;
+	use URL_Aware;
 
 	/**
 	 * Threshold for script size to surface a warning for.
@@ -231,18 +233,16 @@ class Enqueued_Scripts_Size_Check extends Abstract_Runtime_Check implements With
 
 		if ( $plugin_script_size > $this->threshold_size ) {
 			foreach ( $plugin_scripts as $plugin_script ) {
-				$result->add_message(
-					false,
+				$this->add_result_warning_for_file(
+					$result,
 					sprintf(
 						'This script has a size of %1$s which in combination with the other scripts enqueued on %2$s exceeds the script size threshold of %3$s.',
 						size_format( $plugin_script['size'] ),
 						$url,
 						size_format( $this->threshold_size )
 					),
-					array(
-						'code' => 'EnqueuedScriptsSize.ScriptSizeGreaterThanThreshold',
-						'file' => $plugin_script['path'],
-					)
+					'EnqueuedScriptsSize.ScriptSizeGreaterThanThreshold',
+					$plugin_script['path']
 				);
 			}
 		}

--- a/includes/Checker/Checks/Enqueued_Styles_Scope_Check.php
+++ b/includes/Checker/Checks/Enqueued_Styles_Scope_Check.php
@@ -12,6 +12,7 @@ use WordPress\Plugin_Check\Checker\Check_Categories;
 use WordPress\Plugin_Check\Checker\Check_Result;
 use WordPress\Plugin_Check\Checker\Preparations\Demo_Posts_Creation_Preparation;
 use WordPress\Plugin_Check\Checker\With_Shared_Preparations;
+use WordPress\Plugin_Check\Traits\Amend_Check_Result;
 use WordPress\Plugin_Check\Traits\Stable_Check;
 use WordPress\Plugin_Check\Traits\URL_Aware;
 
@@ -22,8 +23,9 @@ use WordPress\Plugin_Check\Traits\URL_Aware;
  */
 class Enqueued_Styles_Scope_Check extends Abstract_Runtime_Check implements With_Shared_Preparations {
 
-	use URL_Aware;
+	use Amend_Check_Result;
 	use Stable_Check;
+	use URL_Aware;
 
 	/**
 	 * List of viewable post types.
@@ -134,13 +136,11 @@ class Enqueued_Styles_Scope_Check extends Abstract_Runtime_Check implements With
 			$url_count = count( $urls );
 			foreach ( $this->plugin_styles as $plugin_style ) {
 				if ( isset( $plugin_style['count'] ) && ( $url_count === $plugin_style['count'] ) ) {
-					$result->add_message(
-						false,
+					$this->add_result_warning_for_file(
+						$result,
 						__( 'This style is being loaded in all contexts.', 'plugin-check' ),
-						array(
-							'code' => 'EnqueuedStylesScope.StyleLoadedInAllContext',
-							'file' => $plugin_style['path'],
-						)
+						'EnqueuedStylesScope',
+						$plugin_style['path']
 					);
 				}
 			}

--- a/includes/Checker/Checks/File_Type_Check.php
+++ b/includes/Checker/Checks/File_Type_Check.php
@@ -164,21 +164,13 @@ class File_Type_Check extends Abstract_File_Check {
 			// Only use an error in production, otherwise a warning.
 			$is_error = ( ! defined( 'WP_DEBUG' ) || ! WP_DEBUG ) && 'production' === wp_get_environment_type();
 			foreach ( $vcs_directories as $dir ) {
-				if ( $is_error ) {
-					$this->add_result_error_for_file(
-						$result,
-						__( 'Version control checkouts should not be present.', 'plugin-check' ),
-						'vcs_present',
-						str_replace( $result->plugin()->path(), '', $dir )
-					);
-				} else {
-					$this->add_result_warning_for_file(
-						$result,
-						__( 'Version control checkouts should not be present.', 'plugin-check' ),
-						'vcs_present',
-						str_replace( $result->plugin()->path(), '', $dir )
-					);
-				}
+				$this->add_result_message_for_file(
+					$result,
+					$is_error,
+					__( 'Version control checkouts should not be present.', 'plugin-check' ),
+					'vcs_present',
+					str_replace( $result->plugin()->path(), '', $dir )
+				);
 			}
 		}
 	}

--- a/includes/Checker/Checks/File_Type_Check.php
+++ b/includes/Checker/Checks/File_Type_Check.php
@@ -169,7 +169,7 @@ class File_Type_Check extends Abstract_File_Check {
 					$is_error,
 					__( 'Version control checkouts should not be present.', 'plugin-check' ),
 					'vcs_present',
-					str_replace( $result->plugin()->path(), '', $dir )
+					$dir
 				);
 			}
 		}

--- a/includes/Checker/Checks/Localhost_Check.php
+++ b/includes/Checker/Checks/Localhost_Check.php
@@ -9,6 +9,7 @@ namespace WordPress\Plugin_Check\Checker\Checks;
 
 use WordPress\Plugin_Check\Checker\Check_Categories;
 use WordPress\Plugin_Check\Checker\Check_Result;
+use WordPress\Plugin_Check\Traits\Amend_Check_Result;
 use WordPress\Plugin_Check\Traits\Stable_Check;
 
 /**
@@ -18,6 +19,7 @@ use WordPress\Plugin_Check\Traits\Stable_Check;
  */
 class Localhost_Check extends Abstract_File_Check {
 
+	use Amend_Check_Result;
 	use Stable_Check;
 
 	/**
@@ -45,13 +47,11 @@ class Localhost_Check extends Abstract_File_Check {
 		$php_files = self::filter_files_by_extension( $files, 'php' );
 		$file      = self::file_preg_match( '#https?://(localhost|127.0.0.1)#', $php_files );
 		if ( $file ) {
-			$result->add_message(
-				true,
+			$this->add_result_error_for_file(
+				$result,
 				__( 'Do not use Localhost/127.0.0.1 in your code.', 'plugin-check' ),
-				array(
-					'code' => 'localhost_code_detected',
-					'file' => $file,
-				)
+				'localhost_code_detected',
+				$file
 			);
 		}
 	}

--- a/includes/Checker/Checks/No_Unfiltered_Uploads_Check.php
+++ b/includes/Checker/Checks/No_Unfiltered_Uploads_Check.php
@@ -9,6 +9,7 @@ namespace WordPress\Plugin_Check\Checker\Checks;
 
 use WordPress\Plugin_Check\Checker\Check_Categories;
 use WordPress\Plugin_Check\Checker\Check_Result;
+use WordPress\Plugin_Check\Traits\Amend_Check_Result;
 use WordPress\Plugin_Check\Traits\Stable_Check;
 
 /**
@@ -18,6 +19,7 @@ use WordPress\Plugin_Check\Traits\Stable_Check;
  */
 class No_Unfiltered_Uploads_Check extends Abstract_File_Check {
 
+	use Amend_Check_Result;
 	use Stable_Check;
 
 	/**
@@ -45,13 +47,11 @@ class No_Unfiltered_Uploads_Check extends Abstract_File_Check {
 		$php_files = self::filter_files_by_extension( $files, 'php' );
 		$file      = self::file_str_contains( $php_files, 'ALLOW_UNFILTERED_UPLOADS' );
 		if ( $file ) {
-			$result->add_message(
-				true,
+			$this->add_result_error_for_file(
+				$result,
 				__( 'ALLOW_UNFILTERED_UPLOADS is not permitted.', 'plugin-check' ),
-				array(
-					'code' => 'allow_unfiltered_uploads_detected',
-					'file' => $file,
-				)
+				'allow_unfiltered_uploads_detected',
+				$file
 			);
 		}
 	}

--- a/includes/Checker/Checks/Plugin_Header_Text_Domain_Check.php
+++ b/includes/Checker/Checks/Plugin_Header_Text_Domain_Check.php
@@ -11,6 +11,7 @@ use Exception;
 use WordPress\Plugin_Check\Checker\Check_Categories;
 use WordPress\Plugin_Check\Checker\Check_Result;
 use WordPress\Plugin_Check\Checker\Static_Check;
+use WordPress\Plugin_Check\Traits\Amend_Check_Result;
 use WordPress\Plugin_Check\Traits\Stable_Check;
 
 /**
@@ -20,6 +21,7 @@ use WordPress\Plugin_Check\Traits\Stable_Check;
  */
 class Plugin_Header_Text_Domain_Check implements Static_Check {
 
+	use Amend_Check_Result;
 	use Stable_Check;
 
 	/**
@@ -60,18 +62,16 @@ class Plugin_Header_Text_Domain_Check implements Static_Check {
 			! empty( $plugin_header['TextDomain'] ) &&
 			$plugin_slug !== $plugin_header['TextDomain']
 		) {
-			$result->add_message(
-				false,
+			$this->add_result_warning_for_file(
+				$result,
 				sprintf(
 					/* translators: 1: plugin header text domain, 2: plugin slug */
 					__( 'The TextDomain header in the plugin file does not match the slug. Found "%1$s", expected "%2$s".', 'plugin-check' ),
 					esc_html( $plugin_header['TextDomain'] ),
 					esc_html( $plugin_slug )
 				),
-				array(
-					'code' => 'textdomain_mismatch',
-					'file' => $plugin_main_file,
-				)
+				'textdomain_mismatch',
+				$plugin_main_file
 			);
 		}
 	}

--- a/includes/Checker/Checks/Plugin_Updater_Check.php
+++ b/includes/Checker/Checks/Plugin_Updater_Check.php
@@ -10,6 +10,7 @@ namespace WordPress\Plugin_Check\Checker\Checks;
 use Exception;
 use WordPress\Plugin_Check\Checker\Check_Categories;
 use WordPress\Plugin_Check\Checker\Check_Result;
+use WordPress\Plugin_Check\Traits\Amend_Check_Result;
 use WordPress\Plugin_Check\Traits\Stable_Check;
 
 /**
@@ -19,6 +20,7 @@ use WordPress\Plugin_Check\Traits\Stable_Check;
  */
 class Plugin_Updater_Check extends Abstract_File_Check {
 
+	use Amend_Check_Result;
 	use Stable_Check;
 
 	const TYPE_PLUGIN_UPDATE_URI_HEADER = 1;
@@ -111,7 +113,6 @@ class Plugin_Updater_Check extends Abstract_File_Check {
 		if ( ! empty( $plugin_header['UpdateURI'] ) ) {
 			$this->add_result_error_for_file(
 				$result,
-				true,
 				__( 'Plugin Updater detected. Use of the Update URI header is not helpful in plugins hosted on WordPress.org.', 'plugin-check' ),
 				'plugin_updater_detected',
 				$plugin_main_file
@@ -135,7 +136,6 @@ class Plugin_Updater_Check extends Abstract_File_Check {
 			foreach ( $plugin_update_files as $file ) {
 				$this->add_result_error_for_file(
 					$result,
-					true,
 					sprintf(
 						/* translators: %s: The match updater file name. */
 						__( 'Plugin Updater detected. These are not permitted in WordPress.org hosted plugins. Detected: %s', 'plugin-check' ),
@@ -173,7 +173,6 @@ class Plugin_Updater_Check extends Abstract_File_Check {
 			if ( $updater_file ) {
 				$this->add_result_error_for_file(
 					$result,
-					true,
 					sprintf(
 						/* translators: %s: The match updater string. */
 						__( 'Plugin Updater detected. These are not permitted in WordPress.org hosted plugins. Detected: %s', 'plugin-check' ),
@@ -206,9 +205,8 @@ class Plugin_Updater_Check extends Abstract_File_Check {
 			$matches      = array();
 			$updater_file = self::file_preg_match( $regex, $php_files, $matches );
 			if ( $updater_file ) {
-				$this->add_result_error_for_file(
+				$this->add_result_warning_for_file(
 					$result,
-					false,
 					sprintf(
 						/* translators: %s: The match file name. */
 						__( 'Detected code which may be altering WordPress update routines. Detected: %s', 'plugin-check' ),
@@ -219,27 +217,5 @@ class Plugin_Updater_Check extends Abstract_File_Check {
 				);
 			}
 		}
-	}
-
-	/**
-	 * Amends the given result with an error for the given obfuscated file and tool name.
-	 *
-	 * @since n.e.x.t
-	 *
-	 * @param Check_Result $result       The check result to amend, including the plugin context to check.
-	 * @param bool         $error        Whether it is an error message.
-	 * @param string       $message      Error message for updater.
-	 * @param string       $code         Violation code according to the message.
-	 * @param string       $updater_file Absolute path to the updater file found.
-	 */
-	private function add_result_error_for_file( Check_Result $result, $error, $message, $code, $updater_file ) {
-		$result->add_message(
-			$error,
-			$message,
-			array(
-				'code' => $code,
-				'file' => str_replace( $result->plugin()->path(), '', $updater_file ),
-			)
-		);
 	}
 }

--- a/includes/Traits/Amend_Check_Result.php
+++ b/includes/Traits/Amend_Check_Result.php
@@ -31,7 +31,7 @@ trait Amend_Check_Result {
 	 */
 	protected function add_result_message_for_file( Check_Result $result, $error, $message, $code, $file, $line = 0, $column = 0 ) {
 		$result->add_message(
-			$error ? true : false,
+			(bool) $error,
 			$message,
 			array(
 				'code'   => $code,

--- a/includes/Traits/Amend_Check_Result.php
+++ b/includes/Traits/Amend_Check_Result.php
@@ -10,27 +10,28 @@ namespace WordPress\Plugin_Check\Traits;
 use WordPress\Plugin_Check\Checker\Check_Result;
 
 /**
- * Trait for check result.
+ * Trait for amending check results.
  *
  * @since n.e.x.t
  */
 trait Amend_Check_Result {
 
 	/**
-	 * Amends the given result with an error for the given file, code, and message.
+	 * Amends the given result with a message for the specified file, including error information.
 	 *
 	 * @since n.e.x.t
 	 *
 	 * @param Check_Result $result  The check result to amend, including the plugin context to check.
+	 * @param bool         $error   Whether it is an error or notice.
 	 * @param string       $message Error message.
 	 * @param string       $code    Error code.
-	 * @param string       $file    Absolute path to the file found.
-	 * @param int          $line    The line on which the message occurred. Default 0 (unknown line).
-	 * @param int          $column  The column on which the message occurred. Default 0 (unknown column).
+	 * @param string       $file    Absolute path to the file where the issue was found.
+	 * @param int          $line    The line on which the message occurred. Default is 0 (unknown line).
+	 * @param int          $column  The column on which the message occurred. Default is 0 (unknown column).
 	 */
-	protected function add_result_error_for_file( Check_Result $result, $message, $code, $file, $line = 0, $column = 0 ) {
+	protected function add_result_message_for_file( Check_Result $result, $error, $message, $code, $file, $line = 0, $column = 0 ) {
 		$result->add_message(
-			true,
+			$error ? true : false,
 			$message,
 			array(
 				'code'   => $code,
@@ -42,27 +43,34 @@ trait Amend_Check_Result {
 	}
 
 	/**
-	 * Amends the given result with a warning for the given file, code, and message.
+	 * Amends the given result with an error message for the specified file.
 	 *
 	 * @since n.e.x.t
 	 *
 	 * @param Check_Result $result  The check result to amend, including the plugin context to check.
 	 * @param string       $message Error message.
 	 * @param string       $code    Error code.
-	 * @param string       $file    Absolute path to the file found.
-	 * @param int          $line    The line on which the message occurred. Default 0 (unknown line).
-	 * @param int          $column  The column on which the message occurred. Default 0 (unknown column).
+	 * @param string       $file    Absolute path to the file where the error was found.
+	 * @param int          $line    The line on which the error occurred. Default is 0 (unknown line).
+	 * @param int          $column  The column on which the error occurred. Default is 0 (unknown column).
+	 */
+	protected function add_result_error_for_file( Check_Result $result, $message, $code, $file, $line = 0, $column = 0 ) {
+		$this->add_result_message_for_file( $result, true, $message, $code, $file, $line, $column );
+	}
+
+	/**
+	 * Amends the given result with a warning message for the specified file.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param Check_Result $result  The check result to amend, including the plugin context to check.
+	 * @param string       $message Error message.
+	 * @param string       $code    Error code.
+	 * @param string       $file    Absolute path to the file where the warning was found.
+	 * @param int          $line    The line on which the warning occurred. Default is 0 (unknown line).
+	 * @param int          $column  The column on which the warning occurred. Default is 0 (unknown column).
 	 */
 	protected function add_result_warning_for_file( Check_Result $result, $message, $code, $file, $line = 0, $column = 0 ) {
-		$result->add_message(
-			false,
-			$message,
-			array(
-				'code'   => $code,
-				'file'   => str_replace( $result->plugin()->path(), '', $file ),
-				'line'   => $line,
-				'column' => $column,
-			)
-		);
+		$this->add_result_message_for_file( $result, false, $message, $code, $file, $line, $column );
 	}
 }

--- a/includes/Traits/Amend_Check_Result.php
+++ b/includes/Traits/Amend_Check_Result.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * Trait WordPress\Plugin_Check\Traits\Amend_Check_Result
+ *
+ * @package plugin-check
+ */
+
+namespace WordPress\Plugin_Check\Traits;
+
+use WordPress\Plugin_Check\Checker\Check_Result;
+
+/**
+ * Trait for check result.
+ *
+ * @since n.e.x.t
+ */
+trait Amend_Check_Result {
+
+	/**
+	 * Amends the given result with an error for the given file, code, and message.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param Check_Result $result  The check result to amend, including the plugin context to check.
+	 * @param string       $message Error message.
+	 * @param string       $code    Error code.
+	 * @param string       $file    Absolute path to the file found.
+	 * @param int          $line    The line on which the message occurred. Default 0 (unknown line).
+	 * @param int          $column  The column on which the message occurred. Default 0 (unknown column).
+	 */
+	protected function add_result_error_for_file( Check_Result $result, $message, $code, $file, $line = 0, $column = 0 ) {
+		$result->add_message(
+			true,
+			$message,
+			array(
+				'code'   => $code,
+				'file'   => str_replace( $result->plugin()->path(), '', $file ),
+				'line'   => $line,
+				'column' => $column,
+			)
+		);
+	}
+
+	/**
+	 * Amends the given result with a warning for the given file, code, and message.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param Check_Result $result  The check result to amend, including the plugin context to check.
+	 * @param string       $message Error message.
+	 * @param string       $code    Error code.
+	 * @param string       $file    Absolute path to the file found.
+	 * @param int          $line    The line on which the message occurred. Default 0 (unknown line).
+	 * @param int          $column  The column on which the message occurred. Default 0 (unknown column).
+	 */
+	protected function add_result_warning_for_file( Check_Result $result, $message, $code, $file, $line = 0, $column = 0 ) {
+		$result->add_message(
+			false,
+			$message,
+			array(
+				'code'   => $code,
+				'file'   => str_replace( $result->plugin()->path(), '', $file ),
+				'line'   => $line,
+				'column' => $column,
+			)
+		);
+	}
+}

--- a/includes/Traits/Find_Readme.php
+++ b/includes/Traits/Find_Readme.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Trait WordPress\Plugin_Check\Traits\Find_Readme
+ *
+ * @package plugin-check
+ */
+
+namespace WordPress\Plugin_Check\Traits;
+
+/**
+ * Trait for find readme.
+ *
+ * @since n.e.x.t
+ */
+trait Find_Readme {
+
+	/**
+	 * Filter the given array of files for readme files (readme.txt or readme.md).
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param array  $files                Array of file files to be filtered.
+	 * @param string $plugin_relative_path Plugin relative path.
+	 * @return array An array containing readme.txt or readme.md files, or an empty array if none are found.
+	 */
+	protected function filter_files_for_readme( array $files, $plugin_relative_path ) {
+		// Find the readme file.
+		$readme_list = self::filter_files_by_regex( $files, '/readme\.(txt|md)$/i' );
+
+		// Filter the readme files located at root.
+		$potential_readme_files = array_filter(
+			$readme_list,
+			function ( $file ) use ( $plugin_relative_path ) {
+				$file = str_replace( $plugin_relative_path, '', $file );
+				return ! str_contains( $file, '/' );
+			}
+		);
+
+		// If the readme file does not exist, then return empty array.
+		if ( empty( $potential_readme_files ) ) {
+			return array();
+		}
+
+		// Find the .txt versions of the readme files.
+		$readme_txt = array_filter(
+			$potential_readme_files,
+			function ( $file ) {
+				return preg_match( '/^readme\.txt$/i', basename( $file ) );
+			}
+		);
+
+		return $readme_txt ? $readme_txt : $potential_readme_files;
+	}
+}

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -19,4 +19,4 @@ parameters:
       message: '/^Function str_contains not found.$/'
       paths:
         - includes/Checker/Checks/Abstract_File_Check.php
-        - includes/Checker/Checks/Trademarks_Check.php
+        - includes/Traits/Find_Readme.php


### PR DESCRIPTION
Closes #286

This pull request introduces two trait classes, which enable us to eliminate code duplications and reuse them throughout the codebase:
1. `Amend_Check_Result`
2. `Find_Readme`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).