### PR TITLE
CLI: add option to exclude directories

### DIFF
--- a/includes/CLI/Plugin_Check_Command.php
+++ b/includes/CLI/Plugin_Check_Command.php
@@ -87,10 +87,14 @@ final class Plugin_Check_Command {
 	 * [--include-experimental]
 	 * : Include experimental checks.
 	 *
+	 * [--exclude-directories=<directories>]
+	 * : Additional directories to exclude from checks
+	 * By default, `.git`, `vendor` and `node_modules` directories are excluded.
+	 *
 	 * ## EXAMPLES
 	 *
 	 *   wp plugin check akismet
-	 *   wp plugin check akismet --checks=escaping
+	 *   wp plugin check akismet --checks=late_escaping
 	 *   wp plugin check akismet --format=json
 	 *
 	 * @subcommand check
@@ -127,6 +131,15 @@ final class Plugin_Check_Command {
 
 		// Create the categories array from CLI arguments.
 		$categories = isset( $options['categories'] ) ? wp_parse_list( $options['categories'] ) : array();
+
+		$excluded_directories = isset( $options['exclude-directories'] ) ? wp_parse_list( $options['exclude-directories'] ) : array();
+
+		add_filter(
+			'wp_plugin_check_ignore_directories',
+			static function ( $dirs ) use ( $excluded_directories ) {
+				return array_unique( array_merge( $dirs, $excluded_directories ) );
+			}
+		);
 
 		// Get the CLI Runner.
 		$runner = Plugin_Request_Utility::get_runner();

--- a/includes/CLI/Plugin_Check_Command.php
+++ b/includes/CLI/Plugin_Check_Command.php
@@ -60,7 +60,7 @@ final class Plugin_Check_Command {
 	 * : The plugin to check. Plugin name.
 	 *
 	 * [--checks=<checks>]
-	 * : Only runs checks provided as an argument in comma-separated values, e.g. enqueued-scripts, escaping. Otherwise runs all checks.
+	 * : Only runs checks provided as an argument in comma-separated values, e.g. i18n_usage, late_escaping. Otherwise runs all checks.
 	 *
 	 * [--format=<format>]
 	 * : Format to display the results. Options are table, csv, and json. The default will be a table.


### PR DESCRIPTION
Successfully tested with `wp plugin check wordpress-seo --exclude-directories=vendor_prefixed,admin`

Fixes #309 
Fixes https://github.com/swissspidy/wp-plugin-check-action/issues/7