### PR TITLE
CLI: Add `--exclude-checks` support

### DIFF
--- a/includes/CLI/Plugin_Check_Command.php
+++ b/includes/CLI/Plugin_Check_Command.php
@@ -62,6 +62,10 @@ final class Plugin_Check_Command {
 	 * [--checks=<checks>]
 	 * : Only runs checks provided as an argument in comma-separated values, e.g. i18n_usage, late_escaping. Otherwise runs all checks.
 	 *
+	 * [--exclude-checks=<checks>]
+	 * : Exclude checks provided as an argument in comma-separated values, e.g. i18n_usage, late_escaping.
+	 * Applies after evaluating `--checks`.
+	 *
 	 * [--format=<format>]
 	 * : Format to display the results. Options are table, csv, and json. The default will be a table.
 	 * ---

--- a/includes/Checker/AJAX_Runner.php
+++ b/includes/Checker/AJAX_Runner.php
@@ -83,13 +83,13 @@ class AJAX_Runner extends Abstract_Check_Runner {
 	}
 
 	/**
-	 * Returns an array of Check slugs to ignore based on the request.
+	 * Returns an array of Check slugs to exclude based on the request.
 	 *
 	 * @since n.e.x.t
 	 *
-	 * @return array An array of Check slugs to ignore.
+	 * @return array An array of Check slugs to exclude.
 	 */
-	protected function get_check_ignore_slugs_param() {
+	protected function get_check_exclude_slugs_param() {
 		$checks = filter_input( INPUT_POST, 'ignore-checks', FILTER_DEFAULT, FILTER_FORCE_ARRAY );
 		$checks = is_null( $checks ) ? array() : $checks;
 

--- a/includes/Checker/AJAX_Runner.php
+++ b/includes/Checker/AJAX_Runner.php
@@ -90,7 +90,7 @@ class AJAX_Runner extends Abstract_Check_Runner {
 	 * @return array An array of Check slugs to exclude.
 	 */
 	protected function get_check_exclude_slugs_param() {
-		$checks = filter_input( INPUT_POST, 'ignore-checks', FILTER_DEFAULT, FILTER_FORCE_ARRAY );
+		$checks = filter_input( INPUT_POST, 'exclude-checks', FILTER_DEFAULT, FILTER_FORCE_ARRAY );
 		$checks = is_null( $checks ) ? array() : $checks;
 
 		return $checks;

--- a/includes/Checker/AJAX_Runner.php
+++ b/includes/Checker/AJAX_Runner.php
@@ -83,6 +83,20 @@ class AJAX_Runner extends Abstract_Check_Runner {
 	}
 
 	/**
+	 * Returns an array of Check slugs to ignore based on the request.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @return array An array of Check slugs to ignore.
+	 */
+	protected function get_check_ignore_slugs_param() {
+		$checks = filter_input( INPUT_POST, 'ignore-checks', FILTER_DEFAULT, FILTER_FORCE_ARRAY );
+		$checks = is_null( $checks ) ? array() : $checks;
+
+		return $checks;
+	}
+
+	/**
 	 * Returns the include experimental parameter based on the request.
 	 *
 	 * @since n.e.x.t

--- a/includes/Checker/Abstract_Check_Runner.php
+++ b/includes/Checker/Abstract_Check_Runner.php
@@ -179,11 +179,11 @@ abstract class Abstract_Check_Runner implements Check_Runner {
 	}
 
 	/**
-	 * Sets the check slugs to be ignored.
+	 * Sets the check slugs to be excluded.
 	 *
 	 * @since n.e.x.t
 	 *
-	 * @param array $check_slugs An array of check slugs to be ignored.
+	 * @param array $check_slugs An array of check slugs to be excluded.
 	 *
 	 * @throws Exception Thrown if the checks do not match those in the original request.
 	 */
@@ -192,7 +192,7 @@ abstract class Abstract_Check_Runner implements Check_Runner {
 			// Compare the check slugs to see if there was an error.
 			if ( $check_slugs !== $this->get_check_exclude_slugs_param() ) {
 				throw new Exception(
-					__( 'Invalid checks: The checks to ignore do not match the original request.', 'plugin-check' )
+					__( 'Invalid checks: The checks to exclude do not match the original request.', 'plugin-check' )
 				);
 			}
 		}

--- a/includes/Checker/Abstract_Check_Runner.php
+++ b/includes/Checker/Abstract_Check_Runner.php
@@ -410,7 +410,7 @@ abstract class Abstract_Check_Runner implements Check_Runner {
 
 		$collection = $this->check_repository->get_checks( $check_flags )
 			->include( $check_slugs ) // Ensures only the checks with the given slugs are included.
-			->exclude( $excluded_checks ); // Exclude provided checks from list
+			->exclude( $excluded_checks ); // Exclude provided checks from list.
 
 		// Filters the checks by specific categories.
 		$categories = $this->get_categories();

--- a/includes/Checker/Abstract_Check_Runner.php
+++ b/includes/Checker/Abstract_Check_Runner.php
@@ -37,12 +37,12 @@ abstract class Abstract_Check_Runner implements Check_Runner {
 	protected $check_slugs;
 
 	/**
-	 * The check slugs to ignore.
+	 * The check slugs to exclude.
 	 *
 	 * @since n.e.x.t
 	 * @var array
 	 */
-	protected $check_ignore_slugs;
+	protected $check_exclude_slugs;
 
 	/**
 	 * The plugin parameter.
@@ -117,14 +117,15 @@ abstract class Abstract_Check_Runner implements Check_Runner {
 	 * @return array An array of Check slugs.
 	 */
 	abstract protected function get_check_slugs_param();
+
 	/**
-	 * Returns an array of Check slugs to ignore based on the request.
+	 * Returns an array of Check slugs to exclude based on the request.
 	 *
 	 * @since n.e.x.t
 	 *
 	 * @return array An array of Check slugs.
 	 */
-	abstract protected function get_check_ignore_slugs_param();
+	abstract protected function get_check_exclude_slugs_param();
 
 	/**
 	 * Returns the include experimental parameter based on the request.
@@ -186,17 +187,17 @@ abstract class Abstract_Check_Runner implements Check_Runner {
 	 *
 	 * @throws Exception Thrown if the checks do not match those in the original request.
 	 */
-	final public function set_check_ignore_slugs( array $check_slugs ) {
+	final public function set_check_exclude_slugs( array $check_slugs ) {
 		if ( $this->initialized_early ) {
 			// Compare the check slugs to see if there was an error.
-			if ( $check_slugs !== $this->get_check_ignore_slugs_param() ) {
+			if ( $check_slugs !== $this->get_check_exclude_slugs_param() ) {
 				throw new Exception(
 					__( 'Invalid checks: The checks to ignore do not match the original request.', 'plugin-check' )
 				);
 			}
 		}
 
-		$this->check_ignore_slugs = $check_slugs;
+		$this->check_exclude_slugs = $check_slugs;
 	}
 
 	/**
@@ -406,7 +407,7 @@ abstract class Abstract_Check_Runner implements Check_Runner {
 			$check_flags = $check_flags | Check_Repository::INCLUDE_EXPERIMENTAL;
 		}
 
-		$excluded_checks = $this->get_check_ignore_slugs();
+		$excluded_checks = $this->get_check_exclude_slugs();
 
 		$collection = $this->check_repository->get_checks( $check_flags )
 			->include( $check_slugs ) // Ensures only the checks with the given slugs are included.
@@ -458,18 +459,18 @@ abstract class Abstract_Check_Runner implements Check_Runner {
 	}
 
 	/**
-	 * Returns the check slugs to ignore.
+	 * Returns the check slugs to exclude.
 	 *
 	 * @since n.e.x.t
 	 *
-	 * @return array An array of check slugs to ignore.
+	 * @return array An array of check slugs to exclude.
 	 */
-	private function get_check_ignore_slugs() {
-		if ( null !== $this->check_ignore_slugs ) {
-			return $this->check_ignore_slugs;
+	private function get_check_exclude_slugs() {
+		if ( null !== $this->check_exclude_slugs ) {
+			return $this->check_exclude_slugs;
 		}
 
-		return $this->get_check_ignore_slugs_param();
+		return $this->get_check_exclude_slugs_param();
 	}
 
 	/**

--- a/includes/Checker/CLI_Runner.php
+++ b/includes/Checker/CLI_Runner.php
@@ -90,6 +90,26 @@ class CLI_Runner extends Abstract_Check_Runner {
 	}
 
 	/**
+	 * Returns an array of Check slugs to ignore based on the request.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @return array An array of Check slugs to run.
+	 */
+	protected function get_check_ignore_slugs_param() {
+		$checks = array();
+
+		foreach ( $_SERVER['argv'] as $value ) {
+			if ( false !== strpos( $value, '--exclude-checks=' ) ) {
+				$checks = wp_parse_list( str_replace( '--exclude-checks=', '', $value ) );
+				break;
+			}
+		}
+
+		return $checks;
+	}
+
+	/**
 	 * Returns the include experimental parameter based on the request.
 	 *
 	 * @since n.e.x.t

--- a/includes/Checker/CLI_Runner.php
+++ b/includes/Checker/CLI_Runner.php
@@ -90,13 +90,13 @@ class CLI_Runner extends Abstract_Check_Runner {
 	}
 
 	/**
-	 * Returns an array of Check slugs to ignore based on the request.
+	 * Returns an array of Check slugs to exclude based on the request.
 	 *
 	 * @since n.e.x.t
 	 *
 	 * @return array An array of Check slugs to run.
 	 */
-	protected function get_check_ignore_slugs_param() {
+	protected function get_check_exclude_slugs_param() {
 		$checks = array();
 
 		foreach ( $_SERVER['argv'] as $value ) {

--- a/includes/Checker/Check_Categories.php
+++ b/includes/Checker/Check_Categories.php
@@ -57,13 +57,12 @@ class Check_Categories {
 	 *
 	 * @since n.e.x.t
 	 *
-	 * @param array $checks     An array of Check instances.
-	 * @param array $categories An array of categories to filter by.
-	 * @return array Filtered $checks list.
+	 * @param Check_Collection $collection Check collection.
+	 * @param array            $categories An array of categories to filter by.
+	 * @return Check_Collection Filtered check collection.
 	 */
-	public static function filter_checks_by_categories( array $checks, array $categories ) {
-		return array_filter(
-			$checks,
+	public static function filter_checks_by_categories( Check_Collection $collection, array $categories ): Check_Collection {
+		return $collection->filter(
 			static function ( $check ) use ( $categories ) {
 				// Return true if at least one of the check categories is among the filter categories.
 				return (bool) array_intersect( $check->get_categories(), $categories );

--- a/includes/Checker/Check_Collection.php
+++ b/includes/Checker/Check_Collection.php
@@ -42,8 +42,10 @@ interface Check_Collection extends ArrayAccess, Countable, IteratorAggregate {
 	 *
 	 * @since n.e.x.t
 	 *
-	 * @param callable $filter_fn Filter function that accepts a single check object and should return a boolean for
-	 *                            whether to include the check in the new collection.
+	 * @phpstan-param callable(Check,string): bool $filter_fn
+	 *
+	 * @param callable $filter_fn Filter function that accepts a Check object and a Check slug and
+	 *                            should return a boolean for whether to include the check in the new collection.
 	 * @return Check_Collection New check collection, effectively a subset of this one.
 	 */
 	public function filter( callable $filter_fn ): Check_Collection;
@@ -59,6 +61,18 @@ interface Check_Collection extends ArrayAccess, Countable, IteratorAggregate {
 	 * @return Check_Collection New check collection, effectively a subset of this one.
 	 */
 	public function include( array $check_slugs ): Check_Collection;
+
+	/**
+	 * Returns a new check collection excluding the provided checks.
+	 *
+	 * If the given list is empty, the same collection will be returned without any change.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param array $check_slugs List of slugs to exclude. If empty, the same collection is returned.
+	 * @return Check_Collection New check collection, effectively a subset of this one.
+	 */
+	public function exclude( array $check_slugs ): Check_Collection;
 
 	/**
 	 * Throws an exception if any of the given check slugs are not present, or returns the same collection otherwise.

--- a/includes/Checker/Default_Check_Collection.php
+++ b/includes/Checker/Default_Check_Collection.php
@@ -73,15 +73,18 @@ class Default_Check_Collection implements Check_Collection {
 	 *
 	 * @since n.e.x.t
 	 *
-	 * @param callable $filter_fn Filter function that accepts a single check object and should return a boolean for
-	 *                            whether to include the check in the new collection.
+	 * @phpstan-param callable(Check,string): bool $filter_fn
+	 *
+	 * @param callable $filter_fn Filter function that accepts a Check object and a Check slug and
+	 *                            should return a boolean for whether to include the check in the new collection.
 	 * @return Check_Collection New check collection, effectively a subset of this one.
 	 */
 	public function filter( callable $filter_fn ): Check_Collection {
 		return new self(
 			array_filter(
 				$this->checks,
-				$filter_fn
+				$filter_fn,
+				ARRAY_FILTER_USE_BOTH
 			)
 		);
 	}
@@ -114,6 +117,29 @@ class Default_Check_Collection implements Check_Collection {
 		}
 
 		return new self( $checks );
+	}
+
+	/**
+	 * Returns a new check collection excluding the provided checks.
+	 *
+	 * If the given list is empty, the same collection will be returned without any change.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param array $check_slugs List of slugs to exclude. If empty, the same collection is returned.
+	 * @return Check_Collection New check collection, effectively a subset of this one.
+	 */
+	public function exclude( array $check_slugs ): Check_Collection {
+		// Return unmodified collection if no check slugs to ignore are given.
+		if ( ! $check_slugs ) {
+			return $this;
+		}
+
+		return $this->filter(
+			static function ( Check $check, $slug ) use( $check_slugs ) {
+				return ! in_array( $slug, $check_slugs, true );
+			}
+		);
 	}
 
 	/**

--- a/includes/Checker/Default_Check_Collection.php
+++ b/includes/Checker/Default_Check_Collection.php
@@ -130,7 +130,7 @@ class Default_Check_Collection implements Check_Collection {
 	 * @return Check_Collection New check collection, effectively a subset of this one.
 	 */
 	public function exclude( array $check_slugs ): Check_Collection {
-		// Return unmodified collection if no check slugs to ignore are given.
+		// Return unmodified collection if no check slugs to exclude are given.
 		if ( ! $check_slugs ) {
 			return $this;
 		}

--- a/includes/Checker/Default_Check_Repository.php
+++ b/includes/Checker/Default_Check_Repository.php
@@ -103,7 +103,7 @@ class Default_Check_Repository implements Check_Repository {
 
 		// Remove experimental checks before returning.
 		return ( new Default_Check_Collection( $checks ) )->filter(
-			static function ( $check ) {
+			static function ( Check $check ) {
 				return $check->get_stability() !== Check::STABILITY_EXPERIMENTAL;
 			}
 		);

--- a/tests/phpunit/Checker/Check_Categories_Tests.php
+++ b/tests/phpunit/Checker/Check_Categories_Tests.php
@@ -49,7 +49,7 @@ class Check_Categories_Tests extends WP_UnitTestCase {
 		$check_categories = new Check_Categories();
 		$filtered_checks  = $check_categories->filter_checks_by_categories( $checks, $categories );
 
-		$this->assertEquals( $expected_filtered_checks, $filtered_checks );
+		$this->assertEquals( $expected_filtered_checks, $filtered_checks->to_map() );
 	}
 
 	public function data_checks_by_categories() {

--- a/tests/phpunit/Checker/Check_Categories_Tests.php
+++ b/tests/phpunit/Checker/Check_Categories_Tests.php
@@ -44,8 +44,7 @@ class Check_Categories_Tests extends WP_UnitTestCase {
 			$this->repository->register_check( $check[0], $check[1] );
 		}
 
-		$checks = $this->repository->get_checks()
-			->to_map();
+		$checks = $this->repository->get_checks();
 
 		$check_categories = new Check_Categories();
 		$filtered_checks  = $check_categories->filter_checks_by_categories( $checks, $categories );

--- a/tests/phpunit/Checker/Default_Check_Collection_Tests.php
+++ b/tests/phpunit/Checker/Default_Check_Collection_Tests.php
@@ -107,7 +107,7 @@ class Default_Check_Collection_Tests extends WP_UnitTestCase {
 
 	public function test_exclude_with_invalid() {
 		$this->assertSame(
-			array( $this->checks['runtime_check'] ),
+			array( $this->checks['static_check'], $this->checks['runtime_check'] ),
 			$this->collection->exclude( array( 'invalid_check' ) )->to_array()
 		);
 	}

--- a/tests/phpunit/Checker/Default_Check_Collection_Tests.php
+++ b/tests/phpunit/Checker/Default_Check_Collection_Tests.php
@@ -111,5 +111,4 @@ class Default_Check_Collection_Tests extends WP_UnitTestCase {
 			$this->collection->exclude( array( 'invalid_check' ) )->to_array()
 		);
 	}
-
 }

--- a/tests/phpunit/Checker/Default_Check_Collection_Tests.php
+++ b/tests/phpunit/Checker/Default_Check_Collection_Tests.php
@@ -90,4 +90,26 @@ class Default_Check_Collection_Tests extends WP_UnitTestCase {
 
 		$this->collection->require( array( 'static_check', 'invalid_check' ) );
 	}
+
+	public function test_exclude() {
+		$this->assertSame(
+			array( $this->checks['runtime_check'] ),
+			$this->collection->exclude( array( 'static_check' ) )->to_array()
+		);
+	}
+
+	public function test_exclude_with_empty() {
+		$this->assertSame(
+			array_values( $this->checks ),
+			$this->collection->exclude( array() )->to_array()
+		);
+	}
+
+	public function test_exclude_with_invalid() {
+		$this->assertSame(
+			array( $this->checks['runtime_check'] ),
+			$this->collection->exclude( array( 'invalid_check' ) )->to_array()
+		);
+	}
+
 }


### PR DESCRIPTION
Fixes #308

Successfully tested using something like this:

```
wp plugin check web-stories # Returns some errors
wp plugin check web-stories --exclude-checks=late_escaping,plugin_readme,plugin_review_phpcs # No errors
```