### PR TITLE
Add missing `@since` annotation

### DIFF
--- a/includes/Checker/Checks/Enqueued_Scripts_Size_Check.php
+++ b/includes/Checker/Checks/Enqueued_Scripts_Size_Check.php
@@ -251,6 +251,8 @@ class Enqueued_Scripts_Size_Check extends Abstract_Runtime_Check implements With
 	/**
 	 * Returns an array of viewable post types.
 	 *
+	 * @since n.e.x.t
+	 *
 	 * @return array Array of viewable post type slugs.
 	 */
 	private function get_viewable_post_types() {

--- a/includes/Checker/Checks/Enqueued_Styles_Scope_Check.php
+++ b/includes/Checker/Checks/Enqueued_Styles_Scope_Check.php
@@ -261,6 +261,8 @@ class Enqueued_Styles_Scope_Check extends Abstract_Runtime_Check implements With
 	/**
 	 * Returns an array of viewable post types.
 	 *
+	 * @since n.e.x.t
+	 *
 	 * @return array Array of viewable post type slugs.
 	 */
 	private function get_viewable_post_types() {

--- a/includes/Checker/Preparations/Force_Single_Plugin_Preparation.php
+++ b/includes/Checker/Preparations/Force_Single_Plugin_Preparation.php
@@ -76,6 +76,8 @@ class Force_Single_Plugin_Preparation implements Preparation {
 	/**
 	 * Filter active plugins.
 	 *
+	 * @since n.e.x.t
+	 *
 	 * @param array $active_plugins List of active plugins.
 	 * @return array List of active plugins.
 	 */

--- a/includes/Plugin_Main.php
+++ b/includes/Plugin_Main.php
@@ -21,7 +21,6 @@ class Plugin_Main {
 	 * Context instance for the plugin.
 	 *
 	 * @since n.e.x.t
-	 *
 	 * @var Plugin_Context
 	 */
 	protected $context;

--- a/includes/Utilities/Plugin_Request_Utility.php
+++ b/includes/Utilities/Plugin_Request_Utility.php
@@ -38,6 +38,8 @@ class Plugin_Request_Utility {
 	/**
 	 * Returns the plugin basename based on the input provided.
 	 *
+	 * @since n.e.x.t
+	 *
 	 * @param string $plugin_slug The plugin slug or basename.
 	 * @return string The plugin basename.
 	 *


### PR DESCRIPTION
While working on #319, I noticed that some functions were missing the `@since` annotation. This PR will add those missing annotations to the functions.