### PR TITLE
Prevent rewrite flushes for runtime checks

### DIFF
--- a/includes/Checker/Runtime_Environment_Setup.php
+++ b/includes/Checker/Runtime_Environment_Setup.php
@@ -27,11 +27,27 @@ final class Runtime_Environment_Setup {
 		// Get the existing active plugins.
 		$active_plugins = get_option( 'active_plugins' );
 
+		// Get the existing permalink structure.
+		$permalink_structure = get_option( 'permalink_structure' );
+
 		// Set the new prefix.
 		$old_prefix = $wpdb->set_prefix( $table_prefix . 'pc_' );
 
 		// Create and populate the test database tables if they do not exist.
 		if ( $wpdb->posts !== $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $wpdb->posts ) ) ) {
+			/*
+			 * Set the same permalink structure *before* install finishes,
+			 * so that wp_install_maybe_enable_pretty_permalinks() does not flush rewrite rules.
+			 *
+			 * See https://github.com/WordPress/plugin-check/issues/330
+			 */
+			add_action(
+				'populate_options',
+				static function() use( $permalink_structure ) {
+					add_option( 'permalink_structure', $permalink_structure );
+				}
+			);
+
 			wp_install(
 				'Plugin Check',
 				'plugincheck',

--- a/includes/Checker/Runtime_Environment_Setup.php
+++ b/includes/Checker/Runtime_Environment_Setup.php
@@ -43,7 +43,7 @@ final class Runtime_Environment_Setup {
 			 */
 			add_action(
 				'populate_options',
-				static function() use( $permalink_structure ) {
+				static function () use( $permalink_structure ) {
 					add_option( 'permalink_structure', $permalink_structure );
 				}
 			);

--- a/includes/Checker/Runtime_Environment_Setup.php
+++ b/includes/Checker/Runtime_Environment_Setup.php
@@ -43,7 +43,7 @@ final class Runtime_Environment_Setup {
 			 */
 			add_action(
 				'populate_options',
-				static function () use( $permalink_structure ) {
+				static function () use ( $permalink_structure ) {
 					add_option( 'permalink_structure', $permalink_structure );
 				}
 			);


### PR DESCRIPTION
Fixes #330

To test:

1. Activate a plugin
2. Set up pretty permalinks
3. Run performance checks for the activated plugin
4. See that `.htaccess` file won't be empty.

Cannot be tested with unit tests as there is no Apache with mod_rewrite in a testing environment, so it's not possible to verify `.htaccess` modifications in any way.