### PR TITLE
Add Categories and Checks CLI commands

### DIFF
--- a/includes/CLI/Plugin_Check_Command.php
+++ b/includes/CLI/Plugin_Check_Command.php
@@ -125,7 +125,6 @@ final class Plugin_Check_Command {
 				'ignore-warnings'      => false,
 				'ignore-errors'        => false,
 				'include-experimental' => false,
-
 			)
 		);
 
@@ -236,7 +235,7 @@ final class Plugin_Check_Command {
 	}
 
 	/**
-	 * Runs plugin list-checks.
+	 * Lists the available checks for plugins.
 	 *
 	 * ## OPTIONS
 	 *
@@ -260,16 +259,14 @@ final class Plugin_Check_Command {
 	 * @param array $args       List of the positional arguments.
 	 * @param array $assoc_args List of the associative arguments.
 	 *
-	 * @throws WP_CLI\ExitException Show error if not valid runner.
+	 * @throws WP_CLI\ExitException Show error if invalid format argument.
 	 */
 	public function list_checks( $args, $assoc_args ) {
 		$check_repo = new Default_Check_Repository();
 
 		$all_checks = array();
 
-		$checks_items = $check_repo->get_checks()->to_map();
-
-		foreach ( $checks_items as $key => $check ) {
+		foreach ( $check_repo->get_checks() as $key => $check ) {
 			$item = array();
 
 			$item['slug']      = $key;
@@ -297,7 +294,7 @@ final class Plugin_Check_Command {
 	}
 
 	/**
-	 * Runs plugin list-check-categories.
+	 * Lists the available check categories for plugins.
 	 *
 	 * ## OPTIONS
 	 *
@@ -325,6 +322,8 @@ final class Plugin_Check_Command {
 	 *
 	 * @param array $args       List of the positional arguments.
 	 * @param array $assoc_args List of the associative arguments.
+	 *
+	 * @throws WP_CLI\ExitException Show error if invalid format argument.
 	 */
 	public function list_check_categories( $args, $assoc_args ) {
 		// Get options based on the CLI arguments.
@@ -354,12 +353,10 @@ final class Plugin_Check_Command {
 	 * @return array List of the check categories.
 	 */
 	private function get_check_categories() {
-		$categories = array();
-
 		$check_categories = new Check_Categories();
 		$categories_slugs = $check_categories->get_categories();
 
-		$categories = array_map(
+		return array_map(
 			function ( $slug ) {
 				return array(
 					'slug' => $slug,
@@ -368,8 +365,6 @@ final class Plugin_Check_Command {
 			},
 			$categories_slugs
 		);
-
-		return $categories;
 	}
 
 	/**
@@ -381,7 +376,7 @@ final class Plugin_Check_Command {
 	 * @param array $defaults   List of the default arguments.
 	 * @return array List of the associative arguments.
 	 *
-	 * @throws WP_CLI\ExitException Show error if plugin not found.
+	 * @throws WP_CLI\ExitException Show error if invalid format argument.
 	 */
 	private function get_options( $assoc_args, $defaults ) {
 		$options = wp_parse_args( $assoc_args, $defaults );

--- a/includes/Checker/Abstract_Check_Runner.php
+++ b/includes/Checker/Abstract_Check_Runner.php
@@ -151,8 +151,8 @@ abstract class Abstract_Check_Runner implements Check_Runner {
 	 * @since n.e.x.t
 	 */
 	final public function __construct() {
-		$this->initialized_early = ! did_action( 'muplugins_loaded' );
-		$this->register_checks();
+		$this->initialized_early   = ! did_action( 'muplugins_loaded' );
+		$this->check_repository    = new Default_Check_Repository();
 		$this->runtime_environment = new Runtime_Environment_Setup();
 	}
 
@@ -527,48 +527,6 @@ abstract class Abstract_Check_Runner implements Check_Runner {
 	 */
 	private function get_check_context() {
 		return new Check_Context( WP_PLUGIN_DIR . '/' . $this->get_plugin_basename() );
-	}
-
-	/**
-	 * Registers Checks to the Check_Repository.
-	 *
-	 * @since n.e.x.t
-	 */
-	private function register_checks() {
-		$this->check_repository = new Default_Check_Repository();
-
-		/**
-		 * Filters the available plugin check classes.
-		 *
-		 * @since n.e.x.t
-		 *
-		 * @param array $checks An array map of check slugs to Check instances.
-		 */
-		$checks = apply_filters(
-			'wp_plugin_check_checks',
-			array(
-				'i18n_usage'                 => new Checks\I18n_Usage_Check(),
-				'enqueued_scripts_size'      => new Checks\Enqueued_Scripts_Size_Check(),
-				'code_obfuscation'           => new Checks\Code_Obfuscation_Check(),
-				'file_type'                  => new Checks\File_Type_Check(),
-				'plugin_header_text_domain'  => new Checks\Plugin_Header_Text_Domain_Check(),
-				'late_escaping'              => new Checks\Late_Escaping_Check(),
-				'plugin_updater'             => new Checks\Plugin_Updater_Check(),
-				'plugin_review_phpcs'        => new Checks\Plugin_Review_PHPCS_Check(),
-				'direct_db_queries'          => new Checks\Direct_DB_Queries_Check(),
-				'performant_wp_query_params' => new Checks\Performant_WP_Query_Params_Check(),
-				'enqueued_scripts_in_footer' => new Checks\Enqueued_Scripts_In_Footer_Check(),
-				'plugin_readme'              => new Checks\Plugin_Readme_Check(),
-				'enqueued_styles_scope'      => new Checks\Enqueued_Styles_Scope_Check(),
-				'localhost'                  => new Checks\Localhost_Check(),
-				'no_unfiltered_uploads'      => new Checks\No_Unfiltered_Uploads_Check(),
-				'trademarks'                 => new Checks\Trademarks_Check(),
-			)
-		);
-
-		foreach ( $checks as $slug => $check ) {
-			$this->check_repository->register_check( $slug, $check );
-		}
 	}
 
 	/**

--- a/includes/Checker/Default_Check_Repository.php
+++ b/includes/Checker/Default_Check_Repository.php
@@ -7,105 +7,59 @@
 
 namespace WordPress\Plugin_Check\Checker;
 
-use Exception;
-
 /**
  * Default Check Repository class.
  *
  * @since n.e.x.t
  */
-class Default_Check_Repository implements Check_Repository {
+class Default_Check_Repository extends Empty_Check_Repository implements Check_Repository {
 
 	/**
-	 * Array map holding all runtime checks.
+	 * Initializes checks.
 	 *
 	 * @since n.e.x.t
-	 * @var array
 	 */
-	protected $runtime_checks = array();
-
-	/**
-	 * Array map holding all static checks.
-	 *
-	 * @since n.e.x.t
-	 * @var array
-	 */
-	protected $static_checks = array();
-
-	/**
-	 * Registers a check to the repository.
-	 *
-	 * @since n.e.x.t
-	 *
-	 * @param string $slug  The checks slug.
-	 * @param Check  $check The Check instance.
-	 *
-	 * @throws Exception Thrown if Check does not use correct interface, or slug already exists.
-	 */
-	public function register_check( $slug, Check $check ) {
-		if ( ! $check instanceof Runtime_Check && ! $check instanceof Static_Check ) {
-			throw new Exception(
-				sprintf(
-					/* translators: %s: The Check slug. */
-					__( 'Check with slug "%s" must be an instance of Runtime_Check or Static_Check.', 'plugin-check' ),
-					$slug
-				)
-			);
-		}
-
-		if ( isset( $this->runtime_checks[ $slug ] ) || isset( $this->static_checks[ $slug ] ) ) {
-			throw new Exception(
-				sprintf(
-					/* translators: %s: The Check slug. */
-					__( 'Check slug "%s" is already in use.', 'plugin-check' ),
-					$slug
-				)
-			);
-		}
-
-		if ( ! $check->get_categories() ) {
-			throw new Exception(
-				sprintf(
-					/* translators: %s: The Check slug. */
-					__( 'Check with slug "%s" has no categories associated with it.', 'plugin-check' ),
-					$slug
-				)
-			);
-		}
-
-		$check_array                   = $check instanceof Runtime_Check ? 'runtime_checks' : 'static_checks';
-		$this->{$check_array}[ $slug ] = $check;
+	public function __construct() {
+		$this->register_default_checks();
 	}
 
 	/**
-	 * Returns an array of checks.
+	 * Registers Checks.
 	 *
 	 * @since n.e.x.t
-	 *
-	 * @param int $flags The check type flag.
-	 * @return Check_Collection Check collection providing an indexed array of check instances.
 	 */
-	public function get_checks( $flags = self::TYPE_ALL ) {
-		$checks = array();
-
-		if ( $flags & self::TYPE_STATIC ) {
-			$checks += $this->static_checks;
-		}
-
-		if ( $flags & self::TYPE_RUNTIME ) {
-			$checks += $this->runtime_checks;
-		}
-
-		// Return all checks, including experimental if requested.
-		if ( $flags & self::INCLUDE_EXPERIMENTAL ) {
-			return new Default_Check_Collection( $checks );
-		}
-
-		// Remove experimental checks before returning.
-		return ( new Default_Check_Collection( $checks ) )->filter(
-			static function ( Check $check ) {
-				return $check->get_stability() !== Check::STABILITY_EXPERIMENTAL;
-			}
+	private function register_default_checks() {
+		/**
+		 * Filters the available plugin check classes.
+		 *
+		 * @since n.e.x.t
+		 *
+		 * @param array $checks An array map of check slugs to Check instances.
+		 */
+		$checks = apply_filters(
+			'wp_plugin_check_checks',
+			array(
+				'i18n_usage'                 => new Checks\I18n_Usage_Check(),
+				'enqueued_scripts_size'      => new Checks\Enqueued_Scripts_Size_Check(),
+				'code_obfuscation'           => new Checks\Code_Obfuscation_Check(),
+				'file_type'                  => new Checks\File_Type_Check(),
+				'plugin_header_text_domain'  => new Checks\Plugin_Header_Text_Domain_Check(),
+				'late_escaping'              => new Checks\Late_Escaping_Check(),
+				'plugin_updater'             => new Checks\Plugin_Updater_Check(),
+				'plugin_review_phpcs'        => new Checks\Plugin_Review_PHPCS_Check(),
+				'direct_db_queries'          => new Checks\Direct_DB_Queries_Check(),
+				'performant_wp_query_params' => new Checks\Performant_WP_Query_Params_Check(),
+				'enqueued_scripts_in_footer' => new Checks\Enqueued_Scripts_In_Footer_Check(),
+				'plugin_readme'              => new Checks\Plugin_Readme_Check(),
+				'enqueued_styles_scope'      => new Checks\Enqueued_Styles_Scope_Check(),
+				'localhost'                  => new Checks\Localhost_Check(),
+				'no_unfiltered_uploads'      => new Checks\No_Unfiltered_Uploads_Check(),
+				'trademarks'                 => new Checks\Trademarks_Check(),
+			)
 		);
+
+		foreach ( $checks as $slug => $check ) {
+			$this->register_check( $slug, $check );
+		}
 	}
 }

--- a/includes/Checker/Default_Check_Repository.php
+++ b/includes/Checker/Default_Check_Repository.php
@@ -12,7 +12,7 @@ namespace WordPress\Plugin_Check\Checker;
  *
  * @since n.e.x.t
  */
-class Default_Check_Repository extends Empty_Check_Repository implements Check_Repository {
+class Default_Check_Repository extends Empty_Check_Repository {
 
 	/**
 	 * Initializes checks.

--- a/includes/Checker/Empty_Check_Repository.php
+++ b/includes/Checker/Empty_Check_Repository.php
@@ -1,0 +1,119 @@
+<?php
+/**
+ * Class WordPress\Plugin_Check\Checker\Empty_Check_Repository
+ *
+ * @package plugin-check
+ */
+
+namespace WordPress\Plugin_Check\Checker;
+
+use Exception;
+
+/**
+ * Empty Check Repository class.
+ *
+ * @since n.e.x.t
+ */
+class Empty_Check_Repository implements Check_Repository {
+
+	/**
+	 * Array map holding all runtime checks.
+	 *
+	 * @since n.e.x.t
+	 * @var array
+	 */
+	protected $runtime_checks = array();
+
+	/**
+	 * Array map holding all static checks.
+	 *
+	 * @since n.e.x.t
+	 * @var array
+	 */
+	protected $static_checks = array();
+
+	/**
+	 * Constructor.
+	 *
+	 * @since n.e.x.t
+	 */
+	public function __construct() {
+	}
+
+	/**
+	 * Registers a check to the repository.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param string $slug  The checks slug.
+	 * @param Check  $check The Check instance.
+	 *
+	 * @throws Exception Thrown if Check does not use correct interface, or slug already exists.
+	 */
+	public function register_check( $slug, Check $check ) {
+		if ( ! $check instanceof Runtime_Check && ! $check instanceof Static_Check ) {
+			throw new Exception(
+				sprintf(
+					/* translators: %s: The Check slug. */
+					__( 'Check with slug "%s" must be an instance of Runtime_Check or Static_Check.', 'plugin-check' ),
+					$slug
+				)
+			);
+		}
+
+		if ( isset( $this->runtime_checks[ $slug ] ) || isset( $this->static_checks[ $slug ] ) ) {
+			throw new Exception(
+				sprintf(
+					/* translators: %s: The Check slug. */
+					__( 'Check slug "%s" is already in use.', 'plugin-check' ),
+					$slug
+				)
+			);
+		}
+
+		if ( ! $check->get_categories() ) {
+			throw new Exception(
+				sprintf(
+					/* translators: %s: The Check slug. */
+					__( 'Check with slug "%s" has no categories associated with it.', 'plugin-check' ),
+					$slug
+				)
+			);
+		}
+
+		$check_array                   = $check instanceof Runtime_Check ? 'runtime_checks' : 'static_checks';
+		$this->{$check_array}[ $slug ] = $check;
+	}
+
+	/**
+	 * Returns an array of checks.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param int $flags The check type flag.
+	 * @return Check_Collection Check collection providing an indexed array of check instances.
+	 */
+	public function get_checks( $flags = self::TYPE_ALL ) {
+		$checks = array();
+
+		if ( $flags & self::TYPE_STATIC ) {
+			$checks += $this->static_checks;
+		}
+
+		if ( $flags & self::TYPE_RUNTIME ) {
+			$checks += $this->runtime_checks;
+		}
+
+		// Return all checks, including experimental if requested.
+		if ( $flags & self::INCLUDE_EXPERIMENTAL ) {
+			return new Default_Check_Collection( $checks );
+		}
+
+		// Remove experimental checks before returning.
+		return ( new Default_Check_Collection( $checks ) )->filter(
+			static function ( Check $check ) {
+				return $check->get_stability() !== Check::STABILITY_EXPERIMENTAL;
+			}
+		);
+	}
+}

--- a/includes/Checker/Empty_Check_Repository.php
+++ b/includes/Checker/Empty_Check_Repository.php
@@ -33,14 +33,6 @@ class Empty_Check_Repository implements Check_Repository {
 	protected $static_checks = array();
 
 	/**
-	 * Constructor.
-	 *
-	 * @since n.e.x.t
-	 */
-	public function __construct() {
-	}
-
-	/**
 	 * Registers a check to the repository.
 	 *
 	 * @since n.e.x.t

--- a/tests/behat/features/plugin-list-check-categories.feature
+++ b/tests/behat/features/plugin-list-check-categories.feature
@@ -1,0 +1,10 @@
+Feature: Test that the WP-CLI plugin list check categories command works.
+
+  Scenario: List check categories in JSON format
+    Given a WP install with the Plugin Check plugin
+
+    When I try the WP-CLI command `plugin list-check-categories --format=json`
+    Then STDOUT should be JSON containing:
+      """
+      [{"name":"General","slug":"general"}]
+      """

--- a/tests/behat/features/plugin-list-check-categories.feature
+++ b/tests/behat/features/plugin-list-check-categories.feature
@@ -1,10 +1,16 @@
 Feature: Test that the WP-CLI plugin list check categories command works.
 
-  Scenario: List check categories in JSON format
+  Scenario: List check categories
     Given a WP install with the Plugin Check plugin
 
-    When I try the WP-CLI command `plugin list-check-categories --format=json`
+    When I run the WP-CLI command `plugin list-check-categories --format=json`
     Then STDOUT should be JSON containing:
       """
       [{"name":"General","slug":"general"}]
+      """
+
+    When I run the WP-CLI command `plugin list-check-categories --format=csv --fields=slug,name`
+    Then STDOUT should contain:
+      """
+      plugin_repo,"Plugin repo"
       """

--- a/tests/behat/features/plugin-list-checks.feature
+++ b/tests/behat/features/plugin-list-checks.feature
@@ -1,10 +1,16 @@
 Feature: Test that the WP-CLI plugin list checks command works.
 
-  Scenario: List checks in JSON format
+  Scenario: List checks
     Given a WP install with the Plugin Check plugin
 
-    When I try the WP-CLI command `plugin list-checks --format=json`
+    When I run the WP-CLI command `plugin list-checks --format=json`
     Then STDOUT should be JSON containing:
       """
       [{"slug":"i18n_usage","category":"general","stability":"stable"}]
+      """
+
+    When I run the WP-CLI command `plugin list-checks --format=csv --fields=slug,category`
+    Then STDOUT should contain:
+      """
+      plugin_header_text_domain,plugin_repo
       """

--- a/tests/behat/features/plugin-list-checks.feature
+++ b/tests/behat/features/plugin-list-checks.feature
@@ -1,0 +1,10 @@
+Feature: Test that the WP-CLI plugin list checks command works.
+
+  Scenario: List checks in JSON format
+    Given a WP install with the Plugin Check plugin
+
+    When I try the WP-CLI command `plugin list-checks --format=json`
+    Then STDOUT should be JSON containing:
+      """
+      [{"slug":"i18n_usage","category":"general","stability":"stable"}]
+      """

--- a/tests/phpunit/tests/Checker/Check_Categories_Tests.php
+++ b/tests/phpunit/tests/Checker/Check_Categories_Tests.php
@@ -53,7 +53,7 @@ class Check_Categories_Tests extends WP_UnitTestCase {
 		$check_categories = new Check_Categories();
 		$filtered_checks  = $check_categories->filter_checks_by_categories( $checks, $categories );
 
-		$this->assertEquals( $expected_filtered_checks, $filtered_checks->to_map() );
+		$this->assertEquals( array_keys( $expected_filtered_checks ), array_values( array_intersect( array_keys( $filtered_checks->to_map() ), array_keys( $expected_filtered_checks ) ) ) );
 	}
 
 	public function data_checks_by_categories() {

--- a/tests/phpunit/tests/Checker/Check_Categories_Tests.php
+++ b/tests/phpunit/tests/Checker/Check_Categories_Tests.php
@@ -6,7 +6,7 @@
  */
 
 use WordPress\Plugin_Check\Checker\Check_Categories;
-use WordPress\Plugin_Check\Checker\Default_Check_Repository;
+use WordPress\Plugin_Check\Checker\Empty_Check_Repository;
 use WordPress\Plugin_Check\Test_Data\Category_Check_Five;
 use WordPress\Plugin_Check\Test_Data\Category_Check_Four;
 use WordPress\Plugin_Check\Test_Data\Category_Check_One;
@@ -17,13 +17,13 @@ use WordPress\Plugin_Check\Test_Data\Category_Check_Two;
 
 class Check_Categories_Tests extends WP_UnitTestCase {
 	/**
-	 * @var Default_Check_Repository
+	 * @var Empty_Check_Repository
 	 */
 	protected $repository;
 
 	public function set_up() {
 		parent::set_up();
-		$this->repository = new Default_Check_Repository();
+		$this->repository = new Empty_Check_Repository();
 	}
 
 	public function test_get_categories() {
@@ -53,7 +53,7 @@ class Check_Categories_Tests extends WP_UnitTestCase {
 		$check_categories = new Check_Categories();
 		$filtered_checks  = $check_categories->filter_checks_by_categories( $checks, $categories );
 
-		$this->assertEquals( array_keys( $expected_filtered_checks ), array_values( array_intersect( array_keys( $filtered_checks->to_map() ), array_keys( $expected_filtered_checks ) ) ) );
+		$this->assertEquals( $expected_filtered_checks, $filtered_checks->to_map() );
 	}
 
 	public function data_checks_by_categories() {

--- a/tests/phpunit/tests/Checker/Default_Check_Collection_Tests.php
+++ b/tests/phpunit/tests/Checker/Default_Check_Collection_Tests.php
@@ -5,7 +5,7 @@
  * @package plugin-check
  */
 
-use WordPress\Plugin_Check\Checker\Default_Check_Repository;
+use WordPress\Plugin_Check\Checker\Empty_Check_Repository;
 use WordPress\Plugin_Check\Checker\Runtime_Check as Runtime_Check_Interface;
 use WordPress\Plugin_Check\Test_Data\Runtime_Check;
 use WordPress\Plugin_Check\Test_Data\Static_Check;
@@ -23,7 +23,7 @@ class Default_Check_Collection_Tests extends WP_UnitTestCase {
 			'runtime_check' => new Runtime_Check(),
 		);
 
-		$repository = new Default_Check_Repository();
+		$repository = new Empty_Check_Repository();
 		foreach ( $this->checks as $slug => $check ) {
 			$repository->register_check( $slug, $check );
 		}

--- a/tests/phpunit/tests/Checker/Empty_Check_Repository_Tests.php
+++ b/tests/phpunit/tests/Checker/Empty_Check_Repository_Tests.php
@@ -1,12 +1,12 @@
 <?php
 /**
- * Tests for the Default_Check_Repository class.
+ * Tests for the Empty_Check_Repository class.
  *
  * @package plugin-check
  */
 
 use WordPress\Plugin_Check\Checker\Check_Repository;
-use WordPress\Plugin_Check\Checker\Default_Check_Repository;
+use WordPress\Plugin_Check\Checker\Empty_Check_Repository;
 use WordPress\Plugin_Check\Test_Data\Check_Without_Category;
 use WordPress\Plugin_Check\Test_Data\Experimental_Runtime_Check;
 use WordPress\Plugin_Check\Test_Data\Experimental_Static_Check;
@@ -14,14 +14,14 @@ use WordPress\Plugin_Check\Test_Data\Invalid_Check;
 use WordPress\Plugin_Check\Test_Data\Runtime_Check;
 use WordPress\Plugin_Check\Test_Data\Static_Check;
 
-class Default_Check_Repository_Tests extends WP_UnitTestCase {
+class Empty_Check_Repository_Tests extends WP_UnitTestCase {
 
 	private $repository;
 
 	public function set_up() {
 		parent::set_up();
 
-		$this->repository = new Default_Check_Repository();
+		$this->repository = new Empty_Check_Repository();
 	}
 
 	public function test_register_static_check() {


### PR DESCRIPTION
Fixes #303

Command:
`wp plugin list-check-categories`

Output:
![Screen Shot 2023-12-14 at 4 01 54 PM](https://github.com/WordPress/plugin-check/assets/2098823/19a277de-55b3-446a-8ae1-9bc045ee5244)

Command:
`wp plugin list-checks`

Output:
![Screen Shot 2023-12-14 at 4 01 39 PM](https://github.com/WordPress/plugin-check/assets/2098823/51fa93c6-7260-49c6-9e9e-44aa8db438c7)
