### PR TITLE
Fix `Undefined array key "argv"` in version 0.2.2

### DIFF
--- a/inc/class-phpcs-runner.php
+++ b/inc/class-phpcs-runner.php
@@ -123,7 +123,7 @@ class PHPCS_Runner {
 	 */
 	public function run() {
 		// Backup the original command line arguments.
-		$orig_cmd_args = $_SERVER['argv'];
+		$orig_cmd_args = $_SERVER['argv'] ?? [];
 
 		// Create the default arguments for PHPCS.
 		$defaults = [


### PR DESCRIPTION
add guard to line 126, fixes #338 