### PR TITLE
Fix plugin name from readme in `Trademarks` check

### DIFF
--- a/includes/Checker/Checks/Trademarks_Check.php
+++ b/includes/Checker/Checks/Trademarks_Check.php
@@ -256,7 +256,7 @@ class Trademarks_Check extends Abstract_File_Check {
 			return;
 		}
 
-		$name = $matches[1];
+		$name = trim( $matches[1] );
 
 		try {
 			$this->validate_name_has_no_trademarks( $name );

--- a/tests/phpunit/tests/Checker/Checks/Trademarks_Check_Tests.php
+++ b/tests/phpunit/tests/Checker/Checks/Trademarks_Check_Tests.php
@@ -55,7 +55,7 @@ class Trademarks_Check_Tests extends WP_UnitTestCase {
 				Trademarks_Check::TYPE_README,
 				'test-trademarks-plugin-readme-errors/load.php',
 				'readme.txt',
-				'The plugin name includes a restricted term. Your chosen plugin name - " Test Plugin with readme " - contains the restricted term "plugin" which cannot be used at all in your plugin name.',
+				'The plugin name includes a restricted term. Your chosen plugin name - "Test Plugin with readme" - contains the restricted term "plugin" which cannot be used at all in your plugin name.',
 			),
 			'Plugin header - Test Trademarks Plugin Header Name Errors' => array(
 				Trademarks_Check::TYPE_NAME,


### PR DESCRIPTION
When checking plugin name from readme, we are using this `/===(.*)===/i` regex. So its matches will also include whitespace around the actual plugin name. This PR will omit that whitespace characters.

* Updated `Trademarks_Check`
* Updated `Trademarks_Check_Tests` to reflect this change

Before

![before-this-pr](https://github.com/WordPress/plugin-check/assets/2098823/d16c5ea8-0ae0-407d-b026-4b6c9323317b)

After

![after-this-pr](https://github.com/WordPress/plugin-check/assets/2098823/4f3e20be-38d5-4f6f-954d-1ca6c8f1d86f)

cc: @swissspidy @felixarntz @mukeshpanchal27
