### PR TITLE
Add admin page link in plugin actions

### DIFF
--- a/includes/Admin/Admin_Page.php
+++ b/includes/Admin/Admin_Page.php
@@ -220,10 +220,14 @@ final class Admin_Page {
 
 		$plugin_check_base_name = plugin_basename( WP_PLUGIN_CHECK_MAIN_FILE );
 
+		if ( in_array( $context, array( 'mustuse', 'dropins' ), true ) ) {
+			return $actions;
+		}
+
 		if ( $plugin_check_base_name === $plugin_file ) {
 			$actions = array_merge(
 				array(
-					'plugin-check' => sprintf(
+					sprintf(
 						'<a href="%1$s">%2$s</a>',
 						esc_url( admin_url( 'tools.php?page=plugin-check' ) ),
 						esc_html__( 'Plugin Check', 'plugin-check' )
@@ -231,9 +235,7 @@ final class Admin_Page {
 				),
 				$actions
 			);
-		}
 
-		if ( in_array( $context, array( 'mustuse', 'dropins' ), true ) || $plugin_check_base_name === $plugin_file ) {
 			return $actions;
 		}
 

--- a/includes/Admin/Admin_Page.php
+++ b/includes/Admin/Admin_Page.php
@@ -219,6 +219,20 @@ final class Admin_Page {
 	public function filter_plugin_action_links( $actions, $plugin_file, $plugin_data, $context ) {
 
 		$plugin_check_base_name = plugin_basename( WP_PLUGIN_CHECK_MAIN_FILE );
+
+		if ( $plugin_check_base_name === $plugin_file ) {
+			$actions = array_merge(
+				array(
+					'plugin-check' => sprintf(
+						'<a href="%1$s">%2$s</a>',
+						esc_url( admin_url( 'tools.php?page=plugin-check' ) ),
+						esc_html__( 'Plugin Check', 'plugin-check' )
+					),
+				),
+				$actions
+			);
+		}
+
 		if ( in_array( $context, array( 'mustuse', 'dropins' ), true ) || $plugin_check_base_name === $plugin_file ) {
 			return $actions;
 		}

--- a/tests/phpunit/tests/Admin/Admin_Page_Tests.php
+++ b/tests/phpunit/tests/Admin/Admin_Page_Tests.php
@@ -155,12 +155,13 @@ class Admin_Page_Tests extends WP_UnitTestCase {
 		);
 	}
 
-	public function test_filter_plugin_action_links_should_not_add_check_link_for_plugin_checker() {
+	public function test_filter_plugin_action_links_plugin_should_have_self_admin_page_link_only() {
 
 		$base_file = plugin_basename( WP_PLUGIN_CHECK_MAIN_FILE );
 
 		$action_links = $this->admin_page->filter_plugin_action_links( array(), $base_file, array(), 'all' );
-		$this->assertEmpty( $action_links );
+		$this->assertNotEmpty( $action_links );
+		$this->assertEquals( 1, count( $action_links ) );
 
 		/** Administrator check */
 		$admin_user = self::factory()->user->create( array( 'role' => 'administrator' ) );
@@ -171,7 +172,16 @@ class Admin_Page_Tests extends WP_UnitTestCase {
 		wp_set_current_user( $admin_user );
 		$action_links = $this->admin_page->filter_plugin_action_links( array(), $base_file, array(), 'all' );
 
-		$this->assertEmpty( $action_links );
+		$this->assertEquals( 1, count( $action_links ) );
+
+		$this->assertEquals(
+			sprintf(
+				'<a href="%1$s">%2$s</a>',
+				esc_url( admin_url( 'tools.php?page=plugin-check' ) ),
+				esc_html__( 'Plugin Check', 'plugin-check' )
+			),
+			$action_links[0]
+		);
 	}
 
 	/**


### PR DESCRIPTION
This PR adds admin page link in plugin action links. This will be helpful accessing the page in the admin panel.

![Screen Shot 2023-12-26 at 10 53 19 AM](https://github.com/WordPress/plugin-check/assets/2098823/d86a178b-34b9-44b0-b434-9bce363c6577)
