### PR TITLE
Validate fields names

### DIFF
--- a/includes/CLI/Plugin_Check_Command.php
+++ b/includes/CLI/Plugin_Check_Command.php
@@ -41,6 +41,20 @@ final class Plugin_Check_Command {
 	);
 
 	/**
+	 * Field names.
+	 *
+	 * @since n.e.x.t
+	 * @var string[]
+	 */
+	protected $allowed_fields = array(
+		'line',
+		'column',
+		'type',
+		'code',
+		'message',
+	);
+
+	/**
 	 * Constructor.
 	 *
 	 * @since n.e.x.t
@@ -128,6 +142,9 @@ final class Plugin_Check_Command {
 
 		// Get options based on the CLI arguments.
 		$options = $this->get_options( $assoc_args );
+
+		// Validate field names.
+		$this->validate_fields( wp_parse_list( $options['fields'] ) );
 
 		// Create the plugin and checks array from CLI arguments.
 		$plugin = isset( $args[0] ) ? $args[0] : '';
@@ -410,5 +427,22 @@ final class Plugin_Check_Command {
 		}
 
 		return false;
+	}
+
+	/**
+	 * Validate field names.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param array $fields An array of field names.
+	 */
+	private function validate_fields( array $fields ) {
+		$invalid_fields = array_diff( $fields, $this->allowed_fields );
+
+		if ( count( $invalid_fields ) > 0 ) {
+			// translators: %s: Field names.
+			$message = ( 1 === count( $invalid_fields ) ) ? __( 'Invalid field: %s', 'plugin-check' ) : __( 'Invalid fields: %s', 'plugin-check' );
+			WP_CLI::error( sprintf( $message, join( ', ', $invalid_fields ) ) );
+		}
 	}
 }

--- a/tests/behat/features/plugin-check.feature
+++ b/tests/behat/features/plugin-check.feature
@@ -29,3 +29,8 @@ Feature: Test that the WP-CLI command works.
       """
       All output should be run through an escaping function
       """
+    When I try the WP-CLI command `plugin check hello.php --fields=line,column,code,nonexistent_name`
+    Then STDERR should be:
+      """
+      Error: Invalid field: nonexistent_name
+      """


### PR DESCRIPTION
Fixes https://github.com/WordPress/plugin-check/issues/360

This PR validates the field names passed to `--fields`. Show error if invalid names are given.