### PR TITLE
Increase spacing between success message and form

### DIFF
--- a/templates/admin-page.php
+++ b/templates/admin-page.php
@@ -11,7 +11,7 @@
 
 	<h1><?php esc_html_e( 'Plugin Check', 'plugin-check' ); ?></h1>
 
-	<div class="plugin-check-content">
+	<div class="plugin-check-content" style="margin-bottom: 1.33em;">
 
 		<?php if ( ! empty( $available_plugins ) ) { ?>
 


### PR DESCRIPTION
Fixes https://github.com/WordPress/plugin-check/issues/202

This PR just increase the spacing between success message and the form.
