### PR TITLE
Enhance list-checks command

### DIFF
--- a/includes/CLI/Plugin_Check_Command.php
+++ b/includes/CLI/Plugin_Check_Command.php
@@ -322,7 +322,8 @@ final class Plugin_Check_Command {
 			$all_checks = array_filter(
 				$all_checks,
 				static function ( $item ) use ( $options ) {
-					return array_intersect( explode( ',', $options['categories'] ), $item['category'] );
+					$categories = array_map( 'trim', explode( ',', $options['categories'] ) );
+					return array_intersect( $categories, $item['category'] );
 				}
 			);
 		}

--- a/tests/behat/features/plugin-list-checks.feature
+++ b/tests/behat/features/plugin-list-checks.feature
@@ -34,3 +34,12 @@ Feature: Test that the WP-CLI plugin list checks command works.
       slug,category,stability
       i18n_usage,general,stable
       """
+
+    When I run the WP-CLI command `plugin list-checks --format=csv --categories="general, security"`
+    Then STDOUT should be:
+      """
+      slug,category,stability
+      i18n_usage,general,stable
+      late_escaping,security,stable
+      direct_db_queries,security,stable
+      """

--- a/tests/behat/features/plugin-list-checks.feature
+++ b/tests/behat/features/plugin-list-checks.feature
@@ -14,3 +14,23 @@ Feature: Test that the WP-CLI plugin list checks command works.
       """
       plugin_header_text_domain,plugin_repo
       """
+
+    When I run the WP-CLI command `plugin list-checks --stability=stable`
+    Then STDOUT should not be empty
+    And STDOUT should not contain:
+      """
+      experimental
+      """
+
+    When I run the WP-CLI command `plugin list-checks --format=json --stability=experimental`
+    Then STDOUT should be:
+      """
+      []
+      """
+
+    When I run the WP-CLI command `plugin list-checks --format=csv --categories=general`
+    Then STDOUT should be:
+      """
+      slug,category,stability
+      i18n_usage,general,stable
+      """

--- a/tests/behat/features/plugin-list-checks.feature
+++ b/tests/behat/features/plugin-list-checks.feature
@@ -8,6 +8,10 @@ Feature: Test that the WP-CLI plugin list checks command works.
       """
       [{"slug":"i18n_usage","category":"general","stability":"stable"}]
       """
+    And STDOUT should not contain:
+      """
+      experimental
+      """
 
     When I run the WP-CLI command `plugin list-checks --format=csv --fields=slug,category`
     Then STDOUT should contain:
@@ -15,31 +19,21 @@ Feature: Test that the WP-CLI plugin list checks command works.
       plugin_header_text_domain,plugin_repo
       """
 
-    When I run the WP-CLI command `plugin list-checks --stability=stable`
+    When I run the WP-CLI command `plugin list-checks --include-experimental`
     Then STDOUT should not be empty
-    And STDOUT should not contain:
-      """
-      experimental
-      """
-
-    When I run the WP-CLI command `plugin list-checks --format=json --stability=experimental`
-    Then STDOUT should be:
-      """
-      []
-      """
 
     When I run the WP-CLI command `plugin list-checks --format=csv --categories=general`
-    Then STDOUT should be:
+    Then STDOUT should contain:
       """
-      slug,category,stability
       i18n_usage,general,stable
       """
 
     When I run the WP-CLI command `plugin list-checks --format=csv --categories="general, security"`
-    Then STDOUT should be:
+    Then STDOUT should contain:
       """
-      slug,category,stability
       i18n_usage,general,stable
+      """
+    And STDOUT should contain:
+      """
       late_escaping,security,stable
-      direct_db_queries,security,stable
       """


### PR DESCRIPTION

Refactor list-checks command with improvements.

* Fix: `get_checks()` of `Default_Check_Repository` by default does not return experimental checks. This PR fix that issue for returing all checks with parameter `Default_Check_Repository::TYPE_ALL | Default_Check_Repository::INCLUDE_EXPERIMENTAL`.
* Addition: `--categories` argument is added to filter checks by categories.
* Addition: `--stability` argument is added to filter checks by stability. Takes either `stable` or `experimental`.


Output:

`wp plugin list-checks --stability=stable` - Currently all checks will be displayed as we dont have experimental checks yet.

<img width="676" alt="stability" src="https://github.com/WordPress/plugin-check/assets/2098823/c94d1119-e028-4df9-a298-673cd06f0fd7">


`wp plugin list-checks --categories=performance`

<img width="699" alt="single-category" src="https://github.com/WordPress/plugin-check/assets/2098823/798204b1-9d49-460c-a974-29177330f519">


`wp plugin list-checks --categories=performance,general`

<img width="752" alt="multiple-category" src="https://github.com/WordPress/plugin-check/assets/2098823/b4bfc0e8-be7a-4c4d-ab1c-2c03d662d1c2">
