### PR TITLE
Run checks in the context of the minimum WP version supported by a plugin

### DIFF
--- a/includes/Checker/Checks/Abstract_PHP_CodeSniffer_Check.php
+++ b/includes/Checker/Checks/Abstract_PHP_CodeSniffer_Check.php
@@ -80,25 +80,7 @@ abstract class Abstract_PHP_CodeSniffer_Check implements Static_Check {
 		$orig_cmd_args = $_SERVER['argv'];
 
 		// Create the default arguments for PHPCS.
-		$defaults = array(
-			'',
-			$result->plugin()->location(),
-			'--report=Json',
-			'--report-width=9999',
-		);
-
-		$directories_to_ignore = Plugin_Request_Utility::get_directories_to_ignore();
-		if ( ! empty( $directories_to_ignore ) ) {
-			$defaults[] = '--ignore=*/' . implode( '/*,*/', $directories_to_ignore ) . '/*';
-		}
-
-		// Set the Minimum WP version supported for the plugin.
-		if ( $result->plugin()->minimum_supported_wp() ) {
-			// Due to the syntax of runtime-set, these must be passed as individual args.
-			$defaults[] = '--runtime-set';
-			$defaults[] = 'minimum_wp_version';
-			$defaults[] = $result->plugin()->minimum_supported_wp();
-		}
+		$defaults = $this->get_argv_defaults( $result );
 
 		// Set the check arguments for PHPCS.
 		$_SERVER['argv'] = $this->parse_argv( $this->get_args(), $defaults );
@@ -162,6 +144,38 @@ abstract class Abstract_PHP_CodeSniffer_Check implements Static_Check {
 		// Format check arguments for PHPCS.
 		foreach ( $check_args as $key => $value ) {
 			$defaults[] = "--{$key}=$value";
+		}
+
+		return $defaults;
+	}
+
+	/**
+	 * Gets the default command arguments.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param Check_Result $result The check result to amend, including the plugin context to check.
+	 * @return array An indexed array of PHPCS CLI arguments.
+	 */
+	private function get_argv_defaults( Check_Result $result ): array {
+		$defaults = array(
+			'',
+			$result->plugin()->location(),
+			'--report=Json',
+			'--report-width=9999',
+		);
+
+		$directories_to_ignore = Plugin_Request_Utility::get_directories_to_ignore();
+		if ( ! empty( $directories_to_ignore ) ) {
+			$defaults[] = '--ignore=*/' . implode( '/*,*/', $directories_to_ignore ) . '/*';
+		}
+
+		// Set the Minimum WP version supported for the plugin.
+		if ( $result->plugin()->minimum_supported_wp() ) {
+			// Due to the syntax of runtime-set, these must be passed as individual args.
+			$defaults[] = '--runtime-set';
+			$defaults[] = 'minimum_wp_version';
+			$defaults[] = $result->plugin()->minimum_supported_wp();
 		}
 
 		return $defaults;

--- a/includes/Checker/Checks/Abstract_PHP_CodeSniffer_Check.php
+++ b/includes/Checker/Checks/Abstract_PHP_CodeSniffer_Check.php
@@ -92,6 +92,14 @@ abstract class Abstract_PHP_CodeSniffer_Check implements Static_Check {
 			$defaults[] = '--ignore=*/' . implode( '/*,*/', $directories_to_ignore ) . '/*';
 		}
 
+		// Set the Minimum WP version supported for the plugin.
+		if ( $result->plugin()->minimum_supported_wp() ) {
+			// Due to the syntax of runtime-set, these must be passed as individual args.
+			$defaults[] = '--runtime-set';
+			$defaults[] = 'minimum_wp_version';
+			$defaults[] = $result->plugin()->minimum_supported_wp();
+		}
+
 		// Set the check arguments for PHPCS.
 		$_SERVER['argv'] = $this->parse_argv( $this->get_args(), $defaults );
 

--- a/includes/Plugin_Context.php
+++ b/includes/Plugin_Context.php
@@ -108,7 +108,7 @@ class Plugin_Context {
 	 *
 	 * @since n.e.x.t
 	 *
-	 * @return bool|string The minimum version supported, otherwise false.
+	 * @return string The minimum version supported, or empty string if unknown.
 	 */
 	public function minimum_supported_wp() {
 		$headers = get_plugin_data( $this->main_file );
@@ -130,6 +130,6 @@ class Plugin_Context {
 			}
 		}
 
-		return false;
+		return '';
 	}
 }

--- a/includes/Plugin_Context.php
+++ b/includes/Plugin_Context.php
@@ -27,6 +27,14 @@ class Plugin_Context {
 	protected $main_file;
 
 	/**
+	 * The minimum supported WordPress version of the plugin.
+	 *
+	 * @since n.e.x.t
+	 * @var string
+	 */
+	protected $minimum_supported_wp;
+
+	/**
 	 * Constructor.
 	 *
 	 * @since n.e.x.t
@@ -111,13 +119,17 @@ class Plugin_Context {
 	 * @return string The minimum version supported, or empty string if unknown.
 	 */
 	public function minimum_supported_wp() {
-		$headers = get_plugin_data( $this->main_file );
-		if ( ! empty( $headers['RequiresWP'] ) ) {
-			return $headers['RequiresWP'];
+		if ( ! is_null( $this->minimum_supported_wp ) ) {
+			return $this->minimum_supported_wp;
 		}
 
-		// Look for the readme.
-		if ( ! $this->is_single_file_plugin() ) {
+		$this->minimum_supported_wp = '';
+
+		$headers = get_plugin_data( $this->main_file );
+		if ( ! empty( $headers['RequiresWP'] ) ) {
+			$this->minimum_supported_wp = $headers['RequiresWP'];
+		} elseif ( ! $this->is_single_file_plugin() ) {
+			// Look for the readme.
 			$readme_files = glob( $this->path() . '*' );
 			$readme_files = $this->filter_files_for_readme( $readme_files, $this->path() );
 			$readme_file  = reset( $readme_files );
@@ -125,11 +137,11 @@ class Plugin_Context {
 				$parser = new Parser( $readme_file );
 
 				if ( ! empty( $parser->requires ) ) {
-					return $parser->requires;
+					$this->minimum_supported_wp = $parser->requires;
 				}
 			}
 		}
 
-		return '';
+		return $this->minimum_supported_wp;
 	}
 }

--- a/includes/Plugin_Context.php
+++ b/includes/Plugin_Context.php
@@ -111,7 +111,7 @@ class Plugin_Context {
 	 * @return bool|string The minimum version supported, otherwise false.
 	 */
 	public function minimum_supported_wp() {
-		$headers = get_plugin_data( $this->location() );
+		$headers = get_plugin_data( $this->main_file );
 		if ( ! empty( $headers['RequiresWP'] ) ) {
 			return $headers['RequiresWP'];
 		}

--- a/includes/Traits/Find_Readme.php
+++ b/includes/Traits/Find_Readme.php
@@ -25,7 +25,7 @@ trait Find_Readme {
 	 */
 	protected function filter_files_for_readme( array $files, $plugin_relative_path ) {
 		// Find the readme file.
-		$readme_list = self::filter_files_by_regex( $files, '/readme\.(txt|md)$/i' );
+		$readme_list = preg_grep( '/readme\.(txt|md)$/i', $files );
 
 		// Filter the readme files located at root.
 		$potential_readme_files = array_filter(


### PR DESCRIPTION
Some PHPCS rules are WordPress version dependent, only being triggered for older (or newer) versions of WordPress.

One such rule is this, which is triggered unless the minimum wp is set to 6.2:
```
LINE  84: ERROR Unsupported placeholder used in $wpdb->prepare(). Found: "%i".
                (WordPress.DB.PreparedSQLPlaceholders.UnsupportedPlaceholder)
>>  84:  ········$count·=·$wpdb->get_var($wpdb->prepare("SELECT·COUNT(*)·FROM·%i",·$table_name));
```

WPCS allows setting the minimum required WP version, which this PR implements
https://github.com/WordPress/WordPress-Coding-Standards/wiki/Customizable-sniff-properties#setting-minimum-supported-wp-version-from-the-command-line-wordpresscs-0140

I've not added a unit test for this, as I wasn't immediately able to figure out how to do so, but this PR works in my initial testing.