### PR TITLE
Check upgrade notice in plugin readme

### DIFF
--- a/includes/Checker/Checks/Plugin_Readme_Check.php
+++ b/includes/Checker/Checks/Plugin_Readme_Check.php
@@ -320,7 +320,7 @@ class Plugin_Readme_Check extends Abstract_File_Check {
 	/**
 	 * Checks the readme file upgrade notice.
 	 *
-	 * @since n.e.x.t
+	 * @since 1.0.0
 	 *
 	 * @param Check_Result $result      The Check Result to amend.
 	 * @param string       $readme_file Readme file.
@@ -339,11 +339,11 @@ class Plugin_Readme_Check extends Abstract_File_Check {
 		foreach ( $notices as $version => $notice ) {
 			if ( strlen( $notice ) > $maximum_characters ) {
 				if ( empty( $version ) ) {
-					/* translators: Maximum characters. */
-					$message = sprintf( __( 'The upgrade notice exceeds the limit of %d characters.', 'plugin-check' ), $maximum_characters );
+					/* translators: %s: maximum limit. */
+					$message = sprintf( _n( 'The upgrade notice exceeds the limit of %d character.', 'The upgrade notice exceeds the limit of %d characters.', $maximum_characters, 'plugin-check' ), $maximum_characters );
 				} else {
-					/* translators: 1: Version, 2: Maximum characters. */
-					$message = sprintf( __( 'The upgrade notice for \'%1$s\' exceeds the limit of %2$d characters.', 'plugin-check' ), $version, $maximum_characters );
+					/* translators: 1: version, 2: maximum limit. */
+					$message = sprintf( _n( 'The upgrade notice for "%1$s" exceeds the limit of %2$d character.', 'The upgrade notice for "%1$s" exceeds the limit of %2$d characters.', $maximum_characters, 'plugin-check' ), $version, $maximum_characters );
 				}
 
 				$this->add_result_warning_for_file( $result, $message, 'upgrade_notice_limit', $readme_file );

--- a/includes/Checker/Checks/Plugin_Readme_Check.php
+++ b/includes/Checker/Checks/Plugin_Readme_Check.php
@@ -339,7 +339,7 @@ class Plugin_Readme_Check extends Abstract_File_Check {
 		foreach ( $notices as $version => $notice ) {
 			if ( strlen( $notice ) > $maximum_characters ) {
 				if ( empty( $version ) ) {
-					/* translators: %s: maximum limit. */
+					/* translators: %d: maximum limit. */
 					$message = sprintf( _n( 'The upgrade notice exceeds the limit of %d character.', 'The upgrade notice exceeds the limit of %d characters.', $maximum_characters, 'plugin-check' ), $maximum_characters );
 				} else {
 					/* translators: 1: version, 2: maximum limit. */

--- a/includes/Checker/Checks/Plugin_Readme_Check.php
+++ b/includes/Checker/Checks/Plugin_Readme_Check.php
@@ -320,7 +320,7 @@ class Plugin_Readme_Check extends Abstract_File_Check {
 	/**
 	 * Checks the readme file upgrade notice.
 	 *
-	 * @since 1.0.0
+	 * @since 1.0.2
 	 *
 	 * @param Check_Result $result      The Check Result to amend.
 	 * @param string       $readme_file Readme file.

--- a/includes/Checker/Checks/Plugin_Readme_Check.php
+++ b/includes/Checker/Checks/Plugin_Readme_Check.php
@@ -86,6 +86,9 @@ class Plugin_Readme_Check extends Abstract_File_Check {
 		// Check the readme file for a valid version.
 		$this->check_stable_tag( $result, $readme_file, $parser );
 
+		// Check the readme file for upgrade notice.
+		$this->check_upgrade_notice( $result, $readme_file, $parser );
+
 		// Check the readme file for warnings.
 		$this->check_for_warnings( $result, $readme_file, $parser );
 	}
@@ -309,6 +312,32 @@ class Plugin_Readme_Check extends Abstract_File_Check {
 				$result,
 				__( 'The Stable Tag in your readme file does not match the version in your main plugin file.', 'plugin-check' ),
 				'stable_tag_mismatch',
+				$readme_file
+			);
+		}
+	}
+
+	/**
+	 * Checks the readme file upgrade notice.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param Check_Result $result      The Check Result to amend.
+	 * @param string       $readme_file Readme file.
+	 * @param Parser       $parser      The Parser object.
+	 */
+	private function check_upgrade_notice( Check_Result $result, string $readme_file, Parser $parser ) {
+		if ( 0 === count( $parser->upgrade_notice ) ) {
+			return;
+		}
+
+		$notice = reset( $parser->upgrade_notice );
+
+		if ( strlen( $notice ) > 300 ) {
+			$this->add_result_warning_for_file(
+				$result,
+				__( 'The upgrade notice exceeds the limit of 300 characters.', 'plugin-check' ),
+				'upgrade_notice_limit',
 				$readme_file
 			);
 		}

--- a/includes/Checker/Checks/Plugin_Readme_Check.php
+++ b/includes/Checker/Checks/Plugin_Readme_Check.php
@@ -327,19 +327,27 @@ class Plugin_Readme_Check extends Abstract_File_Check {
 	 * @param Parser       $parser      The Parser object.
 	 */
 	private function check_upgrade_notice( Check_Result $result, string $readme_file, Parser $parser ) {
-		if ( 0 === count( $parser->upgrade_notice ) ) {
+		$notices = $parser->upgrade_notice;
+
+		$maximum_characters = 300;
+
+		// Bail if no upgrade notices.
+		if ( 0 === count( $notices ) ) {
 			return;
 		}
 
-		$notice = reset( $parser->upgrade_notice );
+		foreach ( $notices as $version => $notice ) {
+			if ( strlen( $notice ) > $maximum_characters ) {
+				if ( empty( $version ) ) {
+					/* translators: Maximum characters. */
+					$message = sprintf( __( 'The upgrade notice exceeds the limit of %d characters.', 'plugin-check' ), $maximum_characters );
+				} else {
+					/* translators: 1: Version, 2: Maximum characters. */
+					$message = sprintf( __( 'The upgrade notice for \'%1$s\' exceeds the limit of %2$d characters.', 'plugin-check' ), $version, $maximum_characters );
+				}
 
-		if ( strlen( $notice ) > 300 ) {
-			$this->add_result_warning_for_file(
-				$result,
-				__( 'The upgrade notice exceeds the limit of 300 characters.', 'plugin-check' ),
-				'upgrade_notice_limit',
-				$readme_file
-			);
+				$this->add_result_warning_for_file( $result, $message, 'upgrade_notice_limit', $readme_file );
+			}
 		}
 	}
 

--- a/tests/phpunit/testdata/plugins/test-plugin-plugin-readme-errors-upgrade-notice/load.php
+++ b/tests/phpunit/testdata/plugins/test-plugin-plugin-readme-errors-upgrade-notice/load.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * Plugin Name: Test Plugin Readme Errors Upgrade Notice
+ * Plugin URI: https://github.com/WordPress/plugin-check
+ * Description: Test plugin for the Readme check.
+ * Requires at least: 6.0
+ * Requires PHP: 5.6
+ * Version: 1.0.0
+ * Author: WordPress Performance Team
+ * Author URI: https://make.wordpress.org/performance/
+ * License: GPLv2 or later
+ * License URI: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+ * Text Domain: test-plugin-check-errors-upgrade-notice
+ *
+ * @package test-plugin-check-errors-upgrade-notice
+ */

--- a/tests/phpunit/testdata/plugins/test-plugin-plugin-readme-errors-upgrade-notice/readme.txt
+++ b/tests/phpunit/testdata/plugins/test-plugin-plugin-readme-errors-upgrade-notice/readme.txt
@@ -13,4 +13,12 @@ Plugin description.
 
 == Upgrade Notice ==
 
-Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+Long notice message here. Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+
+= 1.0.1 =
+
+Minor update. There should be no warning here.
+
+= 1.0.0 =
+
+Another long message. Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.

--- a/tests/phpunit/testdata/plugins/test-plugin-plugin-readme-errors-upgrade-notice/readme.txt
+++ b/tests/phpunit/testdata/plugins/test-plugin-plugin-readme-errors-upgrade-notice/readme.txt
@@ -1,0 +1,16 @@
+=== Test Plugin with readme ===
+
+Contributors:      plugin-check
+Requires at least: 6.0
+Tested up to:      6.1
+Requires PHP:      5.6
+Stable tag:        1.0.0
+License:           GPLv2 or later
+License URI:       https://www.gnu.org/licenses/gpl-2.0.html
+Tags:              testing, security
+
+Plugin description.
+
+== Upgrade Notice ==
+
+Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.

--- a/tests/phpunit/tests/Checker/Checks/Plugin_Readme_Check_Tests.php
+++ b/tests/phpunit/tests/Checker/Checks/Plugin_Readme_Check_Tests.php
@@ -461,4 +461,24 @@ class Plugin_Readme_Check_Tests extends WP_UnitTestCase {
 			}
 		);
 	}
+
+	public function test_run_with_errors_upgrade_notice() {
+		$readme_check  = new Plugin_Readme_Check();
+		$check_context = new Check_Context( UNIT_TESTS_PLUGIN_DIR . 'test-plugin-plugin-readme-errors-upgrade-notice/load.php' );
+		$check_result  = new Check_Result( $check_context );
+
+		$readme_check->run( $check_result );
+
+		$warnings = $check_result->get_warnings();
+
+		$this->assertNotEmpty( $warnings );
+		$this->assertArrayHasKey( 'readme.txt', $warnings );
+		$this->assertEquals( 1, $check_result->get_warning_count() );
+
+		// Check for upgrade notice.
+		$this->assertArrayHasKey( 0, $warnings['readme.txt'] );
+		$this->assertArrayHasKey( 0, $warnings['readme.txt'][0] );
+		$this->assertArrayHasKey( 'code', $warnings['readme.txt'][0][0][0] );
+		$this->assertEquals( 'upgrade_notice_limit', $warnings['readme.txt'][0][0][0]['code'] );
+	}
 }

--- a/tests/phpunit/tests/Checker/Checks/Plugin_Readme_Check_Tests.php
+++ b/tests/phpunit/tests/Checker/Checks/Plugin_Readme_Check_Tests.php
@@ -473,12 +473,14 @@ class Plugin_Readme_Check_Tests extends WP_UnitTestCase {
 
 		$this->assertNotEmpty( $warnings );
 		$this->assertArrayHasKey( 'readme.txt', $warnings );
-		$this->assertEquals( 1, $check_result->get_warning_count() );
+		$this->assertEquals( 2, $check_result->get_warning_count() );
 
-		// Check for upgrade notice.
+		// Check for upgrade notices.
 		$this->assertArrayHasKey( 0, $warnings['readme.txt'] );
 		$this->assertArrayHasKey( 0, $warnings['readme.txt'][0] );
 		$this->assertArrayHasKey( 'code', $warnings['readme.txt'][0][0][0] );
 		$this->assertEquals( 'upgrade_notice_limit', $warnings['readme.txt'][0][0][0]['code'] );
+		$this->assertArrayHasKey( 'code', $warnings['readme.txt'][0][0][1] );
+		$this->assertEquals( 'upgrade_notice_limit', $warnings['readme.txt'][0][0][1]['code'] );
 	}
 }


### PR DESCRIPTION
If readme file has upgrade notice is longer than 300 characters then `WARNING` will be shown.