### PR TITLE
Show error message for empty license in readme

### DIFF
--- a/includes/Checker/Checks/Plugin_Readme_Check.php
+++ b/includes/Checker/Checks/Plugin_Readme_Check.php
@@ -127,8 +127,19 @@ class Plugin_Readme_Check extends Abstract_File_Check {
 	private function check_license( Check_Result $result, string $readme_file, Parser $parser ) {
 		$license = $parser->license;
 
+		if ( empty( $license ) ) {
+			$this->add_result_error_for_file(
+				$result,
+				__( 'Your plugin has no license declared. Please update your readme with a GPLv2 (or later) compatible license.', 'plugin-check' ),
+				'no_license',
+				$readme_file
+			);
+
+			return;
+		}
+
 		// Test for a valid SPDX license identifier.
-		if ( ! empty( $license ) && ! preg_match( '/^([a-z0-9\-\+\.]+)(\sor\s([a-z0-9\-\+\.]+))*$/i', $license ) ) {
+		if ( ! preg_match( '/^([a-z0-9\-\+\.]+)(\sor\s([a-z0-9\-\+\.]+))*$/i', $license ) ) {
 			$this->add_result_warning_for_file(
 				$result,
 				__( 'Your plugin has an invalid license declared. Please update your readme with a valid SPDX license identifier.', 'plugin-check' ),

--- a/tests/phpunit/testdata/plugins/test-plugin-plugin-readme-errors-no-license/load.php
+++ b/tests/phpunit/testdata/plugins/test-plugin-plugin-readme-errors-no-license/load.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * Plugin Name: Test Plugin Readme Errors (no license)
+ * Plugin URI: https://github.com/WordPress/plugin-check
+ * Description: Test plugin for the Readme check.
+ * Requires at least: 6.0
+ * Requires PHP: 5.6
+ * Version: 1.0.0
+ * Author: WordPress Performance Team
+ * Author URI: https://make.wordpress.org/performance/
+ * License: GPLv2 or later
+ * License URI: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+ * Text Domain: test-plugin-check-errors-no-license
+ *
+ * @package test-plugin-check-errors-no-license
+ */

--- a/tests/phpunit/testdata/plugins/test-plugin-plugin-readme-errors-no-license/readme.txt
+++ b/tests/phpunit/testdata/plugins/test-plugin-plugin-readme-errors-no-license/readme.txt
@@ -1,0 +1,10 @@
+=== Test Plugin with readme ===
+
+Contributors:      plugin-check
+Requires at least: 6.0
+Tested up to:      6.1
+Requires PHP:      5.6
+Stable tag:        1.0.0
+Tags:              testing, security
+
+Plugin description.

--- a/tests/phpunit/tests/Checker/Checks/Plugin_Readme_Check_Tests.php
+++ b/tests/phpunit/tests/Checker/Checks/Plugin_Readme_Check_Tests.php
@@ -95,6 +95,26 @@ class Plugin_Readme_Check_Tests extends WP_UnitTestCase {
 		$this->assertEquals( 'invalid_license', $warnings['readme.txt'][0][0][0]['code'] );
 	}
 
+	public function test_run_with_errors_no_license() {
+		$readme_check  = new Plugin_Readme_Check();
+		$check_context = new Check_Context( UNIT_TESTS_PLUGIN_DIR . 'test-plugin-plugin-readme-errors-no-license/load.php' );
+		$check_result  = new Check_Result( $check_context );
+
+		$readme_check->run( $check_result );
+
+		$errors = $check_result->get_errors();
+
+		$this->assertNotEmpty( $errors );
+		$this->assertArrayHasKey( 'readme.txt', $errors );
+		$this->assertEquals( 1, $check_result->get_error_count() );
+
+		// Check for no license.
+		$this->assertArrayHasKey( 0, $errors['readme.txt'] );
+		$this->assertArrayHasKey( 0, $errors['readme.txt'][0] );
+		$this->assertArrayHasKey( 'code', $errors['readme.txt'][0][0][0] );
+		$this->assertEquals( 'no_license', $errors['readme.txt'][0][0][0]['code'] );
+	}
+
 	public function test_run_without_errors() {
 		$readme_check  = new Plugin_Readme_Check();
 		$check_context = new Check_Context( UNIT_TESTS_PLUGIN_DIR . 'test-plugin-plugin-readme-without-errors/load.php' );

--- a/tests/phpunit/tests/Checker/Checks/Plugin_Readme_Check_Tests.php
+++ b/tests/phpunit/tests/Checker/Checks/Plugin_Readme_Check_Tests.php
@@ -102,11 +102,15 @@ class Plugin_Readme_Check_Tests extends WP_UnitTestCase {
 
 		$readme_check->run( $check_result );
 
-		$errors = $check_result->get_errors();
+		$errors   = $check_result->get_errors();
+		$warnings = $check_result->get_warnings();
 
 		$this->assertNotEmpty( $errors );
 		$this->assertArrayHasKey( 'readme.txt', $errors );
 		$this->assertEquals( 1, $check_result->get_error_count() );
+
+		$this->assertEmpty( $warnings );
+		$this->assertEquals( 0, $check_result->get_warning_count() );
 
 		// Check for no license.
 		$this->assertArrayHasKey( 0, $errors['readme.txt'] );


### PR DESCRIPTION
This check exists in `legacy` plugin. So I have ported here in the trunk.

* Add checking for empty license in readme
* Update Unit tests to reflect new changes