### PR TITLE
Make parser warnings more clear

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -12,12 +12,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/afragen/wordpress-plugin-readme-parser.git",
-                "reference": "c21c250a510972ac46658a315133ac8b91d60ba0"
+                "reference": "e402e0c48e5421167b6a44edd8194a182ec33aeb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/afragen/wordpress-plugin-readme-parser/zipball/c21c250a510972ac46658a315133ac8b91d60ba0",
-                "reference": "c21c250a510972ac46658a315133ac8b91d60ba0",
+                "url": "https://api.github.com/repos/afragen/wordpress-plugin-readme-parser/zipball/e402e0c48e5421167b6a44edd8194a182ec33aeb",
+                "reference": "e402e0c48e5421167b6a44edd8194a182ec33aeb",
                 "shasum": ""
             },
             "require": {
@@ -51,7 +51,7 @@
                 "issues": "https://github.com/afragen/wordpress-plugin-readme-parser/issues",
                 "source": "https://github.com/afragen/wordpress-plugin-readme-parser/tree/master"
             },
-            "time": "2023-06-24T18:22:04+00:00"
+            "time": "2024-01-22T16:19:32+00:00"
         },
         {
             "name": "automattic/vipwpcs",
@@ -612,16 +612,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.8.0",
+            "version": "3.8.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
-                "reference": "5805f7a4e4958dbb5e944ef1e6edae0a303765e7"
+                "reference": "14f5fff1e64118595db5408e946f3a22c75807f7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/5805f7a4e4958dbb5e944ef1e6edae0a303765e7",
-                "reference": "5805f7a4e4958dbb5e944ef1e6edae0a303765e7",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/14f5fff1e64118595db5408e946f3a22c75807f7",
+                "reference": "14f5fff1e64118595db5408e946f3a22c75807f7",
                 "shasum": ""
             },
             "require": {
@@ -631,11 +631,11 @@
                 "php": ">=5.4.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.0"
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.3.4"
             },
             "bin": [
-                "bin/phpcs",
-                "bin/phpcbf"
+                "bin/phpcbf",
+                "bin/phpcs"
             ],
             "type": "library",
             "extra": {
@@ -688,7 +688,7 @@
                     "type": "open_collective"
                 }
             ],
-            "time": "2023-12-08T12:32:31+00:00"
+            "time": "2024-01-11T20:47:48+00:00"
         },
         {
             "name": "wp-coding-standards/wpcs",
@@ -3946,16 +3946,16 @@
         },
         {
             "name": "wp-cli/extension-command",
-            "version": "v2.1.16",
+            "version": "v2.1.17",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-cli/extension-command.git",
-                "reference": "71183254b1e403bc0f9b4a97fab48e284cfe1367"
+                "reference": "955bd947d95ef91da501179c7e561d229ab3cc19"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-cli/extension-command/zipball/71183254b1e403bc0f9b4a97fab48e284cfe1367",
-                "reference": "71183254b1e403bc0f9b4a97fab48e284cfe1367",
+                "url": "https://api.github.com/repos/wp-cli/extension-command/zipball/955bd947d95ef91da501179c7e561d229ab3cc19",
+                "reference": "955bd947d95ef91da501179c7e561d229ab3cc19",
                 "shasum": ""
             },
             "require": {
@@ -4038,9 +4038,9 @@
             "homepage": "https://github.com/wp-cli/extension-command",
             "support": {
                 "issues": "https://github.com/wp-cli/extension-command/issues",
-                "source": "https://github.com/wp-cli/extension-command/tree/v2.1.16"
+                "source": "https://github.com/wp-cli/extension-command/tree/v2.1.17"
             },
-            "time": "2023-11-10T12:24:35+00:00"
+            "time": "2024-01-11T11:03:21+00:00"
         },
         {
             "name": "wp-cli/mustangostang-spyc",

--- a/composer.lock
+++ b/composer.lock
@@ -12,12 +12,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/afragen/wordpress-plugin-readme-parser.git",
-                "reference": "e402e0c48e5421167b6a44edd8194a182ec33aeb"
+                "reference": "2f4fbe89bb7ffaf905eb28b385b7d1def4a83f54"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/afragen/wordpress-plugin-readme-parser/zipball/e402e0c48e5421167b6a44edd8194a182ec33aeb",
-                "reference": "e402e0c48e5421167b6a44edd8194a182ec33aeb",
+                "url": "https://api.github.com/repos/afragen/wordpress-plugin-readme-parser/zipball/2f4fbe89bb7ffaf905eb28b385b7d1def4a83f54",
+                "reference": "2f4fbe89bb7ffaf905eb28b385b7d1def4a83f54",
                 "shasum": ""
             },
             "require": {
@@ -51,7 +51,7 @@
                 "issues": "https://github.com/afragen/wordpress-plugin-readme-parser/issues",
                 "source": "https://github.com/afragen/wordpress-plugin-readme-parser/tree/master"
             },
-            "time": "2024-01-22T16:19:32+00:00"
+            "time": "2024-01-25T16:41:35+00:00"
         },
         {
             "name": "automattic/vipwpcs",

--- a/includes/Checker/Checks/Plugin_Readme_Check.php
+++ b/includes/Checker/Checks/Plugin_Readme_Check.php
@@ -212,29 +212,29 @@ class Plugin_Readme_Check extends Abstract_File_Check {
 		$messages = array(
 			'contributor_ignored'          => sprintf(
 				/* translators: %s: plugin header tag */
-				__( 'One or more contributors listed were ignored. The %s field should only contain WordPress.org usernames. Remember that usernames are case-sensitive.', 'plugin-check' ),
-				"'Contributors'"
+				__( 'One or more contributors listed were ignored. The "%s" field should only contain WordPress.org usernames. Remember that usernames are case-sensitive.', 'plugin-check' ),
+				'Contributors'
 			),
 			'requires_php_header_ignored'  => sprintf(
 				/* translators: 1: plugin header tag; 2: Example version 5.2.4. 3: Example version 7.0. */
-				__( 'The %1$s field was ignored. This field should only contain a PHP version such as %2$s or %3$s.', 'plugin-check' ),
-				"'Requires PHP'",
-				"'5.2.4'",
-				"'7.0'"
+				__( 'The "%1$s" field was ignored. This field should only contain a PHP version such as "%2$s" or "%3$s".', 'plugin-check' ),
+				'Requires PHP',
+				'5.2.4',
+				'7.0'
 			),
 			'tested_header_ignored'        => sprintf(
 				/* translators: 1: plugin header tag; 2: Example version 5.0. 3: Example version 5.1. */
-				__( 'The %1$s field was ignored. This field should only contain a valid WordPress version such as %2$s or %3$s.', 'plugin-check' ),
-				"'Tested up to'",
-				"'" . number_format( $latest_wordpress_version, 1 ) . "'",
-				"'" . number_format( $latest_wordpress_version + 0.1, 1 ) . "'"
+				__( 'The "%1$s" field was ignored. This field should only contain a valid WordPress version such as "%2$s" or "%3$s".', 'plugin-check' ),
+				'Tested up to',
+				number_format( $latest_wordpress_version, 1 ),
+				number_format( $latest_wordpress_version + 0.1, 1 )
 			),
 			'requires_header_ignored'      => sprintf(
 				/* translators: 1: plugin header tag; 2: Example version 5.0. 3: Example version 4.9. */
-				__( 'The %1$s field was ignored. This field should only contain a valid WordPress version such as %2$s or %3$s.', 'plugin-check' ),
-				"'Requires at least'",
-				"'" . number_format( $latest_wordpress_version, 1 ) . "'",
-				"'" . number_format( $latest_wordpress_version - 0.1, 1 ) . "'"
+				__( 'The "%1$s" field was ignored. This field should only contain a valid WordPress version such as "%2$s" or "%3$s".', 'plugin-check' ),
+				'Requires at least',
+				number_format( $latest_wordpress_version, 1 ),
+				number_format( $latest_wordpress_version - 0.1, 1 )
 			),
 			'too_many_tags'                => sprintf(
 				/* translators: %d: maximum tags limit */
@@ -244,17 +244,17 @@ class Plugin_Readme_Check extends Abstract_File_Check {
 			'ignored_tags'                 => sprintf(
 				/* translators: %s: list of tags not supported */
 				__( 'One or more tags were ignored. The following tags are not permitted: %s', 'plugin-check' ),
-				"'" . implode( "', '", $parser->ignore_tags ) . "'"
+				'"' . implode( '", "', $parser->ignore_tags ) . '"'
 			),
 			'no_short_description_present' => sprintf(
 				/* translators: %s: section title */
-				__( 'The %s section is missing. An excerpt was generated from your main plugin description.', 'plugin-check' ),
-				"'Short Description'"
+				__( 'The "%s" section is missing. An excerpt was generated from your main plugin description.', 'plugin-check' ),
+				'Short Description'
 			),
 			'trimmed_short_description'    => sprintf(
 				/* translators: 1: section title; 2: maximum limit */
-				_n( 'The %1$s section is too long and was truncated. A maximum of %2$d character is supported.', 'The %1$s section is too long and was truncated. A maximum of %2$d characters is supported.', 150, 'plugin-check' ),
-				"'Short Description'",
+				_n( 'The "%1$s" section is too long and was truncated. A maximum of %2$d character is supported.', 'The "%1$s" section is too long and was truncated. A maximum of %2$d characters is supported.', 150, 'plugin-check' ),
+				'Short Description',
 				150
 			),
 		);
@@ -291,7 +291,7 @@ class Plugin_Readme_Check extends Abstract_File_Check {
 		if ( false === $version ) {
 			$response = wp_remote_get( 'https://api.wordpress.org/core/version-check/1.7/' );
 
-			if ( ! is_wp_error( $response ) ) {
+			if ( ! is_wp_error( $response ) && 200 === wp_remote_retrieve_response_code( $response ) ) {
 				$body = json_decode( wp_remote_retrieve_body( $response ), true );
 
 				if ( isset( $body['offers'] ) && ! empty( $body['offers'] ) ) {

--- a/includes/Checker/Checks/Plugin_Readme_Check.php
+++ b/includes/Checker/Checks/Plugin_Readme_Check.php
@@ -207,31 +207,52 @@ class Plugin_Readme_Check extends Abstract_File_Check {
 		);
 
 		$messages = array(
-			'contributor_ignored'         => sprintf(
+			'contributor_ignored'          => sprintf(
 				/* translators: %s: plugin header tag */
 				__( 'One or more contributors listed were ignored. The %s field should only contain WordPress.org usernames. Remember that usernames are case-sensitive.', 'plugin-check' ),
 				"'Contributors'"
 			),
-			'requires_php_header_ignored' => sprintf(
+			'requires_php_header_ignored'  => sprintf(
 				/* translators: 1: plugin header tag; 2: Example version 5.2.4. 3: Example version 7.0. */
 				__( 'The %1$s field was ignored. This field should only contain a PHP version such as %2$s or %3$s.', 'plugin-check' ),
 				"'Requires PHP'",
 				"'5.2.4'",
 				"'7.0'"
 			),
-			'tested_header_ignored'       => sprintf(
+			'tested_header_ignored'        => sprintf(
 				/* translators: 1: plugin header tag; 2: Example version 5.0. 3: Example version 5.1. */
 				__( 'The %1$s field was ignored. This field should only contain a valid WordPress version such as %2$s or %3$s.', 'plugin-check' ),
 				"'Tested up to'",
 				"'" . number_format( $latest_wordpress_version, 1 ) . "'",
 				"'" . number_format( $latest_wordpress_version + 0.1, 1 ) . "'"
 			),
-			'requires_header_ignored'     => sprintf(
+			'requires_header_ignored'      => sprintf(
 				/* translators: 1: plugin header tag; 2: Example version 5.0. 3: Example version 4.9. */
 				__( 'The %1$s field was ignored. This field should only contain a valid WordPress version such as %2$s or %3$s.', 'plugin-check' ),
 				"'Requires at least'",
 				"'" . number_format( $latest_wordpress_version, 1 ) . "'",
 				"'" . number_format( $latest_wordpress_version - 0.1, 1 ) . "'"
+			),
+			'too_many_tags'                => sprintf(
+				/* translators: %d: maximum tags limit */
+				__( 'One or more tags were ignored. Please limit your plugin to %d tags.', 'plugin-check' ),
+				5
+			),
+			'ignored_tags'                 => sprintf(
+				/* translators: %s: list of tags not supported */
+				__( 'One or more tags were ignored. The following tags are not permitted: %s', 'plugin-check' ),
+				"'" . implode( "', '", $parser->ignore_tags ) . "'"
+			),
+			'no_short_description_present' => sprintf(
+				/* translators: %s: section title */
+				__( 'The %s section is missing. An excerpt was generated from your main plugin description.', 'plugin-check' ),
+				"'Short Description'"
+			),
+			'trimmed_short_description'    => sprintf(
+				/* translators: 1: section title; 2 maximum limit */
+				__( 'The %1$s section is too long and was truncated. A maximum of %2$d characters is supported.', 'plugin-check' ),
+				"'Short Description'",
+				150
 			),
 		);
 
@@ -259,7 +280,7 @@ class Plugin_Readme_Check extends Abstract_File_Check {
 	 *
 	 * @since n.e.x.t
 	 *
-	 * @param string Stable WordPress version.
+	 * @return string Stable WordPress version.
 	 */
 	private function get_wordpress_stable_version() {
 		$version = get_bloginfo( 'version' );

--- a/includes/Checker/Checks/Plugin_Readme_Check.php
+++ b/includes/Checker/Checks/Plugin_Readme_Check.php
@@ -223,15 +223,15 @@ class Plugin_Readme_Check extends Abstract_File_Check {
 				/* translators: 1: plugin header tag; 2: Example version 5.0. 3: Example version 5.1. */
 				__( 'The %1$s field was ignored. This field should only contain a valid WordPress version such as %2$s or %3$s.', 'plugin-check' ),
 				"'Tested up to'",
-				"'" . number_format( $latest_wordpress_version, 1 ) . "'",
-				"'" . number_format( $latest_wordpress_version + 0.1, 1 ) . "'"
+				"'" . number_format( floatval( $latest_wordpress_version ), 1 ) . "'",
+				"'" . number_format( floatval( $latest_wordpress_version ) + 0.1, 1 ) . "'"
 			),
 			'requires_header_ignored'      => sprintf(
 				/* translators: 1: plugin header tag; 2: Example version 5.0. 3: Example version 4.9. */
 				__( 'The %1$s field was ignored. This field should only contain a valid WordPress version such as %2$s or %3$s.', 'plugin-check' ),
 				"'Requires at least'",
-				"'" . number_format( $latest_wordpress_version, 1 ) . "'",
-				"'" . number_format( $latest_wordpress_version - 0.1, 1 ) . "'"
+				"'" . number_format( floatval( $latest_wordpress_version ), 1 ) . "'",
+				"'" . number_format( floatval( $latest_wordpress_version ) - 0.1, 1 ) . "'"
 			),
 			'too_many_tags'                => sprintf(
 				/* translators: %d: maximum tags limit */

--- a/includes/Checker/Checks/Plugin_Readme_Check.php
+++ b/includes/Checker/Checks/Plugin_Readme_Check.php
@@ -199,13 +199,11 @@ class Plugin_Readme_Check extends Abstract_File_Check {
 		$warnings = $parser->warnings ? $parser->warnings : array();
 
 		// This should be ERROR rather than WARNING. So ignoring here to handle separately.
-		if ( isset( $warnings['invalid_plugin_name_header'] ) ) {
-			unset( $warnings['invalid_plugin_name_header'] );
-		}
+		unset( $warnings['invalid_plugin_name_header'] );
 
 		$warning_keys = array_keys( $warnings );
 
-		$latest_wordpress_version = $this->get_wordpress_stable_version();
+		$latest_wordpress_version = (float) $this->get_wordpress_stable_version();
 
 		$ignored_warnings = array(
 			'contributor_ignored',
@@ -228,15 +226,15 @@ class Plugin_Readme_Check extends Abstract_File_Check {
 				/* translators: 1: plugin header tag; 2: Example version 5.0. 3: Example version 5.1. */
 				__( 'The %1$s field was ignored. This field should only contain a valid WordPress version such as %2$s or %3$s.', 'plugin-check' ),
 				"'Tested up to'",
-				"'" . number_format( floatval( $latest_wordpress_version ), 1 ) . "'",
-				"'" . number_format( floatval( $latest_wordpress_version ) + 0.1, 1 ) . "'"
+				"'" . number_format( $latest_wordpress_version, 1 ) . "'",
+				"'" . number_format( $latest_wordpress_version + 0.1, 1 ) . "'"
 			),
 			'requires_header_ignored'      => sprintf(
 				/* translators: 1: plugin header tag; 2: Example version 5.0. 3: Example version 4.9. */
 				__( 'The %1$s field was ignored. This field should only contain a valid WordPress version such as %2$s or %3$s.', 'plugin-check' ),
 				"'Requires at least'",
-				"'" . number_format( floatval( $latest_wordpress_version ), 1 ) . "'",
-				"'" . number_format( floatval( $latest_wordpress_version ) - 0.1, 1 ) . "'"
+				"'" . number_format( $latest_wordpress_version, 1 ) . "'",
+				"'" . number_format( $latest_wordpress_version - 0.1, 1 ) . "'"
 			),
 			'too_many_tags'                => sprintf(
 				/* translators: %d: maximum tags limit */
@@ -254,8 +252,8 @@ class Plugin_Readme_Check extends Abstract_File_Check {
 				"'Short Description'"
 			),
 			'trimmed_short_description'    => sprintf(
-				/* translators: 1: section title; 2 maximum limit */
-				__( 'The %1$s section is too long and was truncated. A maximum of %2$d characters is supported.', 'plugin-check' ),
+				/* translators: 1: section title; 2: maximum limit */
+				_n( 'The %1$s section is too long and was truncated. A maximum of %2$d character is supported.', 'The %1$s section is too long and was truncated. A maximum of %2$d characters is supported.', 150, 'plugin-check' ),
 				"'Short Description'",
 				150
 			),

--- a/includes/Checker/Checks/Plugin_Readme_Check.php
+++ b/includes/Checker/Checks/Plugin_Readme_Check.php
@@ -200,15 +200,39 @@ class Plugin_Readme_Check extends Abstract_File_Check {
 
 		$warning_keys = array_keys( $warnings );
 
+		$latest_wordpress_version = $this->get_wordpress_stable_version();
+
 		$ignored_warnings = array(
 			'contributor_ignored',
 		);
 
 		$messages = array(
-			'contributor_ignored'         => __( "'Contributors' header is invalid. It should be comma separated list of wordpress.org usernames", 'plugin-check' ),
-			'requires_php_header_ignored' => __( "'Requires PHP' header is invalid. It should be in either x.y or x.y.z format.", 'plugin-check' ),
-			'tested_header_ignored'       => __( "'Tested up to' header is invalid. It should be in either x.y or x.y.z format.", 'plugin-check' ),
-			'requires_header_ignored'     => __( "'Requires at least' header is invalid. It should be in either x.y or x.y.z format.", 'plugin-check' ),
+			'contributor_ignored'         => sprintf(
+				/* translators: %s: plugin header tag */
+				__( 'One or more contributors listed were ignored. The %s field should only contain WordPress.org usernames. Remember that usernames are case-sensitive.', 'plugin-check' ),
+				"'Contributors'"
+			),
+			'requires_php_header_ignored' => sprintf(
+				/* translators: 1: plugin header tag; 2: Example version 5.2.4. 3: Example version 7.0. */
+				__( 'The %1$s field was ignored. This field should only contain a PHP version such as %2$s or %3$s.', 'plugin-check' ),
+				"'Requires PHP'",
+				"'5.2.4'",
+				"'7.0'"
+			),
+			'tested_header_ignored'       => sprintf(
+				/* translators: 1: plugin header tag; 2: Example version 5.0. 3: Example version 5.1. */
+				__( 'The %1$s field was ignored. This field should only contain a valid WordPress version such as %2$s or %3$s.', 'plugin-check' ),
+				"'Tested up to'",
+				"'" . number_format( $latest_wordpress_version, 1 ) . "'",
+				"'" . number_format( $latest_wordpress_version + 0.1, 1 ) . "'"
+			),
+			'requires_header_ignored'     => sprintf(
+				/* translators: 1: plugin header tag; 2: Example version 5.0. 3: Example version 4.9. */
+				__( 'The %1$s field was ignored. This field should only contain a valid WordPress version such as %2$s or %3$s.', 'plugin-check' ),
+				"'Requires at least'",
+				"'" . number_format( $latest_wordpress_version, 1 ) . "'",
+				"'" . number_format( $latest_wordpress_version - 0.1, 1 ) . "'"
+			),
 		);
 
 		/**
@@ -228,5 +252,25 @@ class Plugin_Readme_Check extends Abstract_File_Check {
 				$this->add_result_warning_for_file( $result, $messages[ $warning ], 'readme_parser_warnings', $readme_file );
 			}
 		}
+	}
+
+	/**
+	 * Returns current major WordPress version.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param string Stable WordPress version.
+	 */
+	private function get_wordpress_stable_version() {
+		$version = get_bloginfo( 'version' );
+
+		// Strip off any -alpha, -RC, -beta suffixes.
+		list( $version, ) = explode( '-', $version );
+
+		if ( preg_match( '#^\d.\d#', $version, $matches ) ) {
+			$version = $matches[0];
+		}
+
+		return $version;
 	}
 }

--- a/includes/Checker/Checks/Plugin_Readme_Check.php
+++ b/includes/Checker/Checks/Plugin_Readme_Check.php
@@ -204,6 +204,13 @@ class Plugin_Readme_Check extends Abstract_File_Check {
 			'contributor_ignored',
 		);
 
+		$messages = array(
+			'contributor_ignored'         => __( "'Contributors' header is invalid. It should be comma separated list of wordpress.org usernames", 'plugin-check' ),
+			'requires_php_header_ignored' => __( "'Requires PHP' header is invalid. It should be in either x.y or x.y.z format.", 'plugin-check' ),
+			'tested_header_ignored'       => __( "'Tested up to' header is invalid. It should be in either x.y or x.y.z format.", 'plugin-check' ),
+			'requires_header_ignored'     => __( "'Requires at least' header is invalid. It should be in either x.y or x.y.z format.", 'plugin-check' ),
+		);
+
 		/**
 		 * Filter the list of ignored readme parser warnings.
 		 *
@@ -217,16 +224,9 @@ class Plugin_Readme_Check extends Abstract_File_Check {
 		$warning_keys = array_diff( $warning_keys, $ignored_warnings );
 
 		if ( ! empty( $warning_keys ) ) {
-			$this->add_result_warning_for_file(
-				$result,
-				sprintf(
-					/* translators: list of warnings */
-					esc_html__( 'The following readme parser warnings were detected: %s', 'plugin-check' ),
-					esc_html( implode( ', ', $warning_keys ) )
-				),
-				'readme_parser_warnings',
-				$readme_file
-			);
+			foreach ( $warning_keys as $warning ) {
+				$this->add_result_warning_for_file( $result, $messages[ $warning ], 'readme_parser_warnings', $readme_file );
+			}
 		}
 	}
 }

--- a/includes/Checker/Checks/Plugin_Readme_Check.php
+++ b/includes/Checker/Checks/Plugin_Readme_Check.php
@@ -198,6 +198,11 @@ class Plugin_Readme_Check extends Abstract_File_Check {
 	private function check_for_warnings( Check_Result $result, string $readme_file, Parser $parser ) {
 		$warnings = $parser->warnings ? $parser->warnings : array();
 
+		// This should be ERROR rather than WARNING. So ignoring here to handle separately.
+		if ( isset( $warnings['invalid_plugin_name_header'] ) ) {
+			unset( $warnings['invalid_plugin_name_header'] );
+		}
+
 		$warning_keys = array_keys( $warnings );
 
 		$latest_wordpress_version = $this->get_wordpress_stable_version();

--- a/includes/Checker/Checks/Plugin_Readme_Check.php
+++ b/includes/Checker/Checks/Plugin_Readme_Check.php
@@ -304,6 +304,18 @@ class Plugin_Readme_Check extends Abstract_File_Check {
 			}
 		}
 
+		// If $version is still false at this point, use current installed WordPress version.
+		if ( false === $version ) {
+			$version = get_bloginfo( 'version' );
+
+			// Strip off any -alpha, -RC, -beta suffixes.
+			list( $version, ) = explode( '-', $version );
+
+			if ( preg_match( '#^\d.\d#', $version, $matches ) ) {
+				$version = $matches[0];
+			}
+		}
+
 		return $version;
 	}
 }

--- a/tests/phpunit/testdata/plugins/test-plugin-plugin-readme-multiple-parser-warnings/load.php
+++ b/tests/phpunit/testdata/plugins/test-plugin-plugin-readme-multiple-parser-warnings/load.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * Plugin Name: Test Plugin Readme Errors (Multiple Parser Warnings)
+ * Plugin URI: https://github.com/WordPress/plugin-check
+ * Description: Test plugin for the Readme check.
+ * Requires at least: 6.0
+ * Requires PHP: 5.6
+ * Version: 1.0.0
+ * Author: WordPress Performance Team
+ * Author URI: https://make.wordpress.org/performance/
+ * License: GPLv2 or later
+ * License URI: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+ * Text Domain: test-plugin-check-errors-multiple-parser-warnings
+ *
+ * @package test-plugin-check-errors-multiple-parser-warnings
+ */

--- a/tests/phpunit/testdata/plugins/test-plugin-plugin-readme-multiple-parser-warnings/readme.txt
+++ b/tests/phpunit/testdata/plugins/test-plugin-plugin-readme-multiple-parser-warnings/readme.txt
@@ -1,0 +1,12 @@
+=== Test Plugin Readme Errors Multiple Parser Warnings ===
+
+Contributors:      plugin-check, first name
+Requires at least: Previous
+Tested up to:      Latest
+Requires PHP:      PHP 5.6
+Stable tag:        1.0.0
+License:           GPLv2 or later
+License URI:       https://www.gnu.org/licenses/gpl-2.0.html
+Tags:              testing, security, plugin, readme, validation, enhancement, performance
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer vulputate nunc velit, vitae sollicitudin tortor viverra sed. Morbi sed nibh ex. Nulla vel augue velit. Maecenas vel lobortis orci. In eget metus dui. Vivamus eleifend volutpat diam. Duis viverra leo non eros auctor, nec placerat elit placerat. Nulla blandit odio risus. In eu dui non erat congue sagittis. Donec luctus tincidunt dolor, nec tempus erat pretium eu. Nunc a dictum odio. Vivamus vel faucibus lorem, eu finibus sem. Sed et vehicula ante, vel sodales augue. Donec tincidunt bibendum libero, ac tristique tellus rutrum nec. Curabitur viverra tincidunt eros non laoreet. Sed vitae consequat diam.

--- a/tests/phpunit/testdata/plugins/test-plugin-plugin-readme-parser-warnings/readme.txt
+++ b/tests/phpunit/testdata/plugins/test-plugin-plugin-readme-parser-warnings/readme.txt
@@ -3,8 +3,8 @@
 
 Contributors:      plugin-check
 Requires at least: 6.0
-Tested up to:      6.1
-Requires PHP:      PHP 5.6
+Tested up to:      Latest
+Requires PHP:      5.6
 Stable tag:        1.0.0
 License:           GPLv2 or later
 License URI:       https://www.gnu.org/licenses/gpl-2.0.html

--- a/tests/phpunit/testdata/plugins/test-plugin-plugin-readme-parser-warnings/readme.txt
+++ b/tests/phpunit/testdata/plugins/test-plugin-plugin-readme-parser-warnings/readme.txt
@@ -3,7 +3,7 @@
 
 Contributors:      plugin-check
 Requires at least: 6.0
-Tested up to:      6.1
+Tested up to:      Latest
 Requires PHP:      PHP 5.6
 Stable tag:        1.0.0
 License:           GPLv2 or later

--- a/tests/phpunit/testdata/plugins/test-plugin-plugin-readme-parser-warnings/readme.txt
+++ b/tests/phpunit/testdata/plugins/test-plugin-plugin-readme-parser-warnings/readme.txt
@@ -3,7 +3,7 @@
 
 Contributors:      plugin-check
 Requires at least: 6.0
-Tested up to:      Latest
+Tested up to:      6.1
 Requires PHP:      PHP 5.6
 Stable tag:        1.0.0
 License:           GPLv2 or later

--- a/tests/phpunit/tests/Checker/Checks/Plugin_Readme_Check_Tests.php
+++ b/tests/phpunit/tests/Checker/Checks/Plugin_Readme_Check_Tests.php
@@ -327,6 +327,11 @@ class Plugin_Readme_Check_Tests extends WP_UnitTestCase {
 
 		$this->assertNotEmpty( $warnings );
 		$this->assertArrayHasKey( 'readme.txt', $warnings );
+
+		/*
+		 * Parser warning `contributor_ignored` is ignored by default. When empty array is returned for
+		 * 'wp_plugin_check_ignored_readme_warnings' then that ignored warning is also added in the list of warnings.
+		 */
 		$this->assertEquals( 7, $check_result->get_warning_count() );
 		$this->assertEmpty( $errors );
 		$this->assertEquals( 0, $check_result->get_error_count() );

--- a/tests/phpunit/tests/Checker/Checks/Plugin_Readme_Check_Tests.php
+++ b/tests/phpunit/tests/Checker/Checks/Plugin_Readme_Check_Tests.php
@@ -233,13 +233,15 @@ class Plugin_Readme_Check_Tests extends WP_UnitTestCase {
 
 		$this->assertNotEmpty( $warnings );
 		$this->assertArrayHasKey( 'readme.txt', $warnings );
-		$this->assertEquals( 1, $check_result->get_warning_count() );
+		$this->assertEquals( 2, $check_result->get_warning_count() );
 
-		// Check for parser warning.
+		// Check for parser warnings.
 		$this->assertArrayHasKey( 0, $warnings['readme.txt'] );
 		$this->assertArrayHasKey( 0, $warnings['readme.txt'][0] );
 		$this->assertArrayHasKey( 'code', $warnings['readme.txt'][0][0][0] );
 		$this->assertEquals( 'readme_parser_warnings', $warnings['readme.txt'][0][0][0]['code'] );
+		$this->assertArrayHasKey( 'code', $warnings['readme.txt'][0][0][1] );
+		$this->assertEquals( 'readme_parser_warnings', $warnings['readme.txt'][0][0][1]['code'] );
 	}
 
 	public function test_filter_readme_warnings_ignored() {
@@ -275,6 +277,7 @@ class Plugin_Readme_Check_Tests extends WP_UnitTestCase {
 		$custom_ignores = array(
 			'requires_php_header_ignored',
 			'contributor_ignored',
+			'tested_header_ignored',
 		);
 
 		// Create a mock filter that will return our custom ignores.

--- a/tests/phpunit/tests/Checker/Checks/Plugin_Readme_Check_Tests.php
+++ b/tests/phpunit/tests/Checker/Checks/Plugin_Readme_Check_Tests.php
@@ -233,15 +233,60 @@ class Plugin_Readme_Check_Tests extends WP_UnitTestCase {
 
 		$this->assertNotEmpty( $warnings );
 		$this->assertArrayHasKey( 'readme.txt', $warnings );
-		$this->assertEquals( 2, $check_result->get_warning_count() );
+		$this->assertEquals( 1, $check_result->get_warning_count() );
 
-		// Check for parser warnings.
+		// Check for parser warning.
 		$this->assertArrayHasKey( 0, $warnings['readme.txt'] );
 		$this->assertArrayHasKey( 0, $warnings['readme.txt'][0] );
 		$this->assertArrayHasKey( 'code', $warnings['readme.txt'][0][0][0] );
 		$this->assertEquals( 'readme_parser_warnings', $warnings['readme.txt'][0][0][0]['code'] );
-		$this->assertArrayHasKey( 'code', $warnings['readme.txt'][0][0][1] );
-		$this->assertEquals( 'readme_parser_warnings', $warnings['readme.txt'][0][0][1]['code'] );
+	}
+
+	public function test_run_with_errors_multiple_parser_warnings() {
+		$readme_check  = new Plugin_Readme_Check();
+		$check_context = new Check_Context( UNIT_TESTS_PLUGIN_DIR . 'test-plugin-plugin-readme-multiple-parser-warnings/load.php' );
+		$check_result  = new Check_Result( $check_context );
+
+		$readme_check->run( $check_result );
+
+		$errors   = $check_result->get_errors();
+		$warnings = $check_result->get_warnings();
+
+		$this->assertNotEmpty( $warnings );
+		$this->assertArrayHasKey( 'readme.txt', $warnings );
+		$this->assertEquals( 6, $check_result->get_warning_count() );
+		$this->assertEmpty( $errors );
+		$this->assertEquals( 0, $check_result->get_error_count() );
+
+		// Check for parser warnings.
+		$this->assertArrayHasKey( 0, $warnings['readme.txt'] );
+		$this->assertArrayHasKey( 0, $warnings['readme.txt'][0] );
+
+		for ( $i = 0; $i < 6; ++$i ) {
+			$this->assertArrayHasKey( 'code', $warnings['readme.txt'][0][0][ $i ] );
+			$this->assertEquals( 'readme_parser_warnings', $warnings['readme.txt'][0][0][ $i ]['code'] );
+		}
+	}
+
+	public function test_run_with_errors_multiple_parser_warnings_and_empty_ignored_array() {
+		add_filter( 'wp_plugin_check_ignored_readme_warnings', '__return_empty_array' );
+
+		$readme_check  = new Plugin_Readme_Check();
+		$check_context = new Check_Context( UNIT_TESTS_PLUGIN_DIR . 'test-plugin-plugin-readme-multiple-parser-warnings/load.php' );
+		$check_result  = new Check_Result( $check_context );
+
+		$readme_check->run( $check_result );
+
+		$errors   = $check_result->get_errors();
+		$warnings = $check_result->get_warnings();
+
+		$this->assertNotEmpty( $warnings );
+		$this->assertArrayHasKey( 'readme.txt', $warnings );
+		$this->assertEquals( 7, $check_result->get_warning_count() );
+		$this->assertEmpty( $errors );
+		$this->assertEquals( 0, $check_result->get_error_count() );
+
+		remove_filter( 'wp_plugin_check_ignored_readme_warnings', '__return_empty_array' );
 	}
 
 	public function test_filter_readme_warnings_ignored() {
@@ -277,7 +322,6 @@ class Plugin_Readme_Check_Tests extends WP_UnitTestCase {
 		$custom_ignores = array(
 			'requires_php_header_ignored',
 			'contributor_ignored',
-			'tested_header_ignored',
 		);
 
 		// Create a mock filter that will return our custom ignores.

--- a/tests/phpunit/tests/Checker/Checks/Plugin_Readme_Check_Tests.php
+++ b/tests/phpunit/tests/Checker/Checks/Plugin_Readme_Check_Tests.php
@@ -268,22 +268,10 @@ class Plugin_Readme_Check_Tests extends WP_UnitTestCase {
 		}
 	}
 
-	public function test_run_with_errors_parser_warnings_and_http_disabled() {
-		// Get current stable WordPress version.
-		$version = get_bloginfo( 'version' );
+	public function test_run_with_errors_parser_warnings_with_custom_set_transient_version() {
+		$version = '5.0';
 
-		list( $version, ) = explode( '-', $version );
-
-		if ( preg_match( '#^\d.\d#', $version, $matches ) ) {
-			$version = $matches[0];
-		}
-
-		add_filter(
-			'pre_http_request',
-			static function () {
-				return new WP_Error( 'http_request_blocked', __( 'This request is not allowed', 'plugin-check' ) );
-			}
-		);
+		set_transient( 'wp_plugin_check_latest_wp_version', $version );
 
 		$readme_check  = new Plugin_Readme_Check();
 		$check_context = new Check_Context( UNIT_TESTS_PLUGIN_DIR . 'test-plugin-plugin-readme-parser-warnings/load.php' );
@@ -305,12 +293,7 @@ class Plugin_Readme_Check_Tests extends WP_UnitTestCase {
 		$this->assertEquals( 'readme_parser_warnings', $warnings['readme.txt'][0][0][0]['code'] );
 		$this->assertStringContainsString( 'The "Tested up to" field was ignored. This field should only contain a valid WordPress version such as "' . $version . '"', $warnings['readme.txt'][0][0][0]['message'] );
 
-		remove_filter(
-			'pre_http_request',
-			static function () {
-				return new WP_Error( 'http_request_blocked', __( 'This request is not allowed', 'plugin-check' ) );
-			}
-		);
+		delete_transient( 'wp_plugin_check_latest_wp_version' );
 	}
 
 	public function test_run_with_errors_multiple_parser_warnings_and_empty_ignored_array() {


### PR DESCRIPTION
Fixes https://github.com/WordPress/plugin-check/issues/394