### PR TITLE
Add examples for plugin list-checks command

### DIFF
--- a/includes/CLI/Plugin_Check_Command.php
+++ b/includes/CLI/Plugin_Check_Command.php
@@ -259,6 +259,11 @@ final class Plugin_Check_Command {
 	 * [--include-experimental]
 	 * : Include experimental checks.
 	 *
+	 * ## EXAMPLES
+	 *
+	 *   wp plugin list-checks
+	 *   wp plugin list-checks --format=json
+	 *
 	 * @subcommand list-checks
 	 *
 	 * @since n.e.x.t


### PR DESCRIPTION
Example was missing for `wp plugin list-checks` command.

cc: @swissspidy @felixarntz @mukeshpanchal27