### PR TITLE
Add check in readme for invalid plugin name header

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -12,12 +12,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/afragen/wordpress-plugin-readme-parser.git",
-                "reference": "c21c250a510972ac46658a315133ac8b91d60ba0"
+                "reference": "e402e0c48e5421167b6a44edd8194a182ec33aeb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/afragen/wordpress-plugin-readme-parser/zipball/c21c250a510972ac46658a315133ac8b91d60ba0",
-                "reference": "c21c250a510972ac46658a315133ac8b91d60ba0",
+                "url": "https://api.github.com/repos/afragen/wordpress-plugin-readme-parser/zipball/e402e0c48e5421167b6a44edd8194a182ec33aeb",
+                "reference": "e402e0c48e5421167b6a44edd8194a182ec33aeb",
                 "shasum": ""
             },
             "require": {
@@ -51,7 +51,7 @@
                 "issues": "https://github.com/afragen/wordpress-plugin-readme-parser/issues",
                 "source": "https://github.com/afragen/wordpress-plugin-readme-parser/tree/master"
             },
-            "time": "2023-06-24T18:22:04+00:00"
+            "time": "2024-01-22T16:19:32+00:00"
         },
         {
             "name": "automattic/vipwpcs",
@@ -612,16 +612,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.8.0",
+            "version": "3.8.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
-                "reference": "5805f7a4e4958dbb5e944ef1e6edae0a303765e7"
+                "reference": "14f5fff1e64118595db5408e946f3a22c75807f7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/5805f7a4e4958dbb5e944ef1e6edae0a303765e7",
-                "reference": "5805f7a4e4958dbb5e944ef1e6edae0a303765e7",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/14f5fff1e64118595db5408e946f3a22c75807f7",
+                "reference": "14f5fff1e64118595db5408e946f3a22c75807f7",
                 "shasum": ""
             },
             "require": {
@@ -631,11 +631,11 @@
                 "php": ">=5.4.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.0"
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.3.4"
             },
             "bin": [
-                "bin/phpcs",
-                "bin/phpcbf"
+                "bin/phpcbf",
+                "bin/phpcs"
             ],
             "type": "library",
             "extra": {
@@ -688,7 +688,7 @@
                     "type": "open_collective"
                 }
             ],
-            "time": "2023-12-08T12:32:31+00:00"
+            "time": "2024-01-11T20:47:48+00:00"
         },
         {
             "name": "wp-coding-standards/wpcs",
@@ -3946,16 +3946,16 @@
         },
         {
             "name": "wp-cli/extension-command",
-            "version": "v2.1.16",
+            "version": "v2.1.17",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-cli/extension-command.git",
-                "reference": "71183254b1e403bc0f9b4a97fab48e284cfe1367"
+                "reference": "955bd947d95ef91da501179c7e561d229ab3cc19"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-cli/extension-command/zipball/71183254b1e403bc0f9b4a97fab48e284cfe1367",
-                "reference": "71183254b1e403bc0f9b4a97fab48e284cfe1367",
+                "url": "https://api.github.com/repos/wp-cli/extension-command/zipball/955bd947d95ef91da501179c7e561d229ab3cc19",
+                "reference": "955bd947d95ef91da501179c7e561d229ab3cc19",
                 "shasum": ""
             },
             "require": {
@@ -4038,9 +4038,9 @@
             "homepage": "https://github.com/wp-cli/extension-command",
             "support": {
                 "issues": "https://github.com/wp-cli/extension-command/issues",
-                "source": "https://github.com/wp-cli/extension-command/tree/v2.1.16"
+                "source": "https://github.com/wp-cli/extension-command/tree/v2.1.17"
             },
-            "time": "2023-11-10T12:24:35+00:00"
+            "time": "2024-01-11T11:03:21+00:00"
         },
         {
             "name": "wp-cli/mustangostang-spyc",

--- a/composer.lock
+++ b/composer.lock
@@ -12,12 +12,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/afragen/wordpress-plugin-readme-parser.git",
-                "reference": "e402e0c48e5421167b6a44edd8194a182ec33aeb"
+                "reference": "2f4fbe89bb7ffaf905eb28b385b7d1def4a83f54"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/afragen/wordpress-plugin-readme-parser/zipball/e402e0c48e5421167b6a44edd8194a182ec33aeb",
-                "reference": "e402e0c48e5421167b6a44edd8194a182ec33aeb",
+                "url": "https://api.github.com/repos/afragen/wordpress-plugin-readme-parser/zipball/2f4fbe89bb7ffaf905eb28b385b7d1def4a83f54",
+                "reference": "2f4fbe89bb7ffaf905eb28b385b7d1def4a83f54",
                 "shasum": ""
             },
             "require": {
@@ -51,7 +51,7 @@
                 "issues": "https://github.com/afragen/wordpress-plugin-readme-parser/issues",
                 "source": "https://github.com/afragen/wordpress-plugin-readme-parser/tree/master"
             },
-            "time": "2024-01-22T16:19:32+00:00"
+            "time": "2024-01-25T16:41:35+00:00"
         },
         {
             "name": "automattic/vipwpcs",

--- a/includes/Checker/Checks/Plugin_Readme_Check.php
+++ b/includes/Checker/Checks/Plugin_Readme_Check.php
@@ -100,15 +100,23 @@ class Plugin_Readme_Check extends Abstract_File_Check {
 	 * @param Parser       $parser      The Parser object.
 	 */
 	private function check_name( Check_Result $result, string $readme_file, Parser $parser ) {
-		if ( empty( $parser->name ) || isset( $parser->warnings['invalid_plugin_name_header'] ) ) {
+		if ( isset( $parser->warnings['invalid_plugin_name_header'] ) ) {
 			$message = sprintf(
 				/* translators: 1: 'Plugin Name' section title, 2: 'Plugin Name' */
-				__( 'We cannot find a plugin name in your readme. Plugin names look like: %1$s. Please change %2$s to reflect the actual name of your plugin.', 'plugin-check' ),
+				__( 'Plugin names look like: %1$s. Please change %2$s to reflect the actual name of your plugin.', 'plugin-check' ),
 				"'=== Plugin Name ==='",
 				"'Plugin Name'"
 			);
 
 			$this->add_result_error_for_file( $result, $message, 'invalid_plugin_name', $readme_file );
+		} elseif ( empty( $parser->name ) ) {
+			$message = sprintf(
+				/* translators: %s: Example plugin name header */
+				__( 'We cannot find a plugin name in your readme. Please update your readme with a valid plugin name header. Eg: %s', 'plugin-check' ),
+				"'=== Example Name ==='"
+			);
+
+			$this->add_result_error_for_file( $result, $message, 'empty_plugin_name', $readme_file );
 		}
 	}
 

--- a/includes/Checker/Checks/Plugin_Readme_Check.php
+++ b/includes/Checker/Checks/Plugin_Readme_Check.php
@@ -74,6 +74,9 @@ class Plugin_Readme_Check extends Abstract_File_Check {
 
 		$parser = new Parser( $readme_file );
 
+		// Check the readme file for plugin name.
+		$this->check_name( $result, $readme_file, $parser );
+
 		// Check the readme file for default text.
 		$this->check_default_text( $result, $readme_file, $parser );
 
@@ -85,6 +88,28 @@ class Plugin_Readme_Check extends Abstract_File_Check {
 
 		// Check the readme file for warnings.
 		$this->check_for_warnings( $result, $readme_file, $parser );
+	}
+
+	/**
+	 * Checks the readme file for plugin name.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param Check_Result $result      The Check Result to amend.
+	 * @param string       $readme_file Readme file.
+	 * @param Parser       $parser      The Parser object.
+	 */
+	private function check_name( Check_Result $result, string $readme_file, Parser $parser ) {
+		if ( empty( $parser->name ) || isset( $parser->warnings['invalid_plugin_name_header'] ) ) {
+			$message = sprintf(
+				/* translators: 1: 'Plugin Name' section title, 2: 'Plugin Name' */
+				__( 'We cannot find a plugin name in your readme. Plugin names look like: %1$s. Please change %2$s to reflect the actual name of your plugin.', 'plugin-check' ),
+				"'=== Plugin Name ==='",
+				"'Plugin Name'"
+			);
+
+			$this->add_result_error_for_file( $result, $message, 'invalid_plugin_name', $readme_file );
+		}
 	}
 
 	/**

--- a/includes/Checker/Checks/Plugin_Readme_Check.php
+++ b/includes/Checker/Checks/Plugin_Readme_Check.php
@@ -103,17 +103,17 @@ class Plugin_Readme_Check extends Abstract_File_Check {
 		if ( isset( $parser->warnings['invalid_plugin_name_header'] ) ) {
 			$message = sprintf(
 				/* translators: 1: 'Plugin Name' section title, 2: 'Plugin Name' */
-				__( 'Plugin names look like: %1$s. Please change %2$s to reflect the actual name of your plugin.', 'plugin-check' ),
-				"'=== Plugin Name ==='",
-				"'Plugin Name'"
+				__( 'Plugin names look like: "%1$s". Please change "%2$s" to reflect the actual name of your plugin.', 'plugin-check' ),
+				'=== Plugin Name ===',
+				'Plugin Name'
 			);
 
 			$this->add_result_error_for_file( $result, $message, 'invalid_plugin_name', $readme_file );
 		} elseif ( empty( $parser->name ) ) {
 			$message = sprintf(
 				/* translators: %s: Example plugin name header */
-				__( 'We cannot find a plugin name in your readme. Please update your readme with a valid plugin name header. Eg: %s', 'plugin-check' ),
-				"'=== Example Name ==='"
+				__( 'We cannot find a plugin name in your readme. Please update your readme with a valid plugin name header. Eg: "%s"', 'plugin-check' ),
+				'=== Example Name ==='
 			);
 
 			$this->add_result_error_for_file( $result, $message, 'empty_plugin_name', $readme_file );

--- a/includes/Checker/Checks/Plugin_Readme_Check.php
+++ b/includes/Checker/Checks/Plugin_Readme_Check.php
@@ -231,6 +231,9 @@ class Plugin_Readme_Check extends Abstract_File_Check {
 	private function check_for_warnings( Check_Result $result, string $readme_file, Parser $parser ) {
 		$warnings = $parser->warnings ? $parser->warnings : array();
 
+		// This should be ERROR rather than WARNING. So ignoring here to handle separately.
+		unset( $warnings['invalid_plugin_name_header'] );
+
 		$warning_keys = array_keys( $warnings );
 
 		$ignored_warnings = array(

--- a/includes/Checker/Checks/Plugin_Readme_Check.php
+++ b/includes/Checker/Checks/Plugin_Readme_Check.php
@@ -103,7 +103,7 @@ class Plugin_Readme_Check extends Abstract_File_Check {
 		if ( isset( $parser->warnings['invalid_plugin_name_header'] ) ) {
 			$message = sprintf(
 				/* translators: 1: 'Plugin Name' section title, 2: 'Plugin Name' */
-				__( 'Plugin names look like: "%1$s". Please change "%2$s" to reflect the actual name of your plugin.', 'plugin-check' ),
+				__( 'Plugin name look like: "%1$s". Please change "%2$s" to reflect the actual name of your plugin.', 'plugin-check' ),
 				'=== Plugin Name ===',
 				'Plugin Name'
 			);

--- a/tests/phpunit/testdata/plugins/test-plugin-plugin-readme-errors-empty-name/load.php
+++ b/tests/phpunit/testdata/plugins/test-plugin-plugin-readme-errors-empty-name/load.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * Plugin Name: Test Plugin Readme Errors (empty name)
+ * Plugin URI: https://github.com/WordPress/plugin-check
+ * Description: Test plugin for the Readme check.
+ * Requires at least: 6.0
+ * Requires PHP: 5.6
+ * Version: n.e.x.t
+ * Author: WordPress Performance Team
+ * Author URI: https://make.wordpress.org/performance/
+ * License: GPLv2 or later
+ * License URI: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+ * Text Domain: test-plugin-check-errors
+ *
+ * @package test-plugin-check-errors
+ */

--- a/tests/phpunit/testdata/plugins/test-plugin-plugin-readme-errors-invalid-name/load.php
+++ b/tests/phpunit/testdata/plugins/test-plugin-plugin-readme-errors-invalid-name/load.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * Plugin Name: Test Plugin Readme Errors (invalid name)
+ * Plugin URI: https://github.com/WordPress/plugin-check
+ * Description: Test plugin for the Readme check.
+ * Requires at least: 6.0
+ * Requires PHP: 5.6
+ * Version: n.e.x.t
+ * Author: WordPress Performance Team
+ * Author URI: https://make.wordpress.org/performance/
+ * License: GPLv2 or later
+ * License URI: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+ * Text Domain: test-plugin-check-errors
+ *
+ * @package test-plugin-check-errors
+ */

--- a/tests/phpunit/testdata/plugins/test-plugin-plugin-readme-errors-invalid-name/readme.txt
+++ b/tests/phpunit/testdata/plugins/test-plugin-plugin-readme-errors-invalid-name/readme.txt
@@ -1,0 +1,12 @@
+=== Plugin Name ===
+
+Contributors:      plugin-check
+Requires at least: 6.0
+Tested up to:      6.1
+Requires PHP:      5.6
+Stable tag:        n.e.x.t
+License:           GPLv2 or later
+License URI:       https://www.gnu.org/licenses/gpl-2.0.html
+Tags:              testing, security
+
+A simple readme file for testing.

--- a/tests/phpunit/tests/Checker/Checks/Plugin_Readme_Check_Tests.php
+++ b/tests/phpunit/tests/Checker/Checks/Plugin_Readme_Check_Tests.php
@@ -31,6 +31,30 @@ class Plugin_Readme_Check_Tests extends WP_UnitTestCase {
 		$this->assertEquals( 'no_plugin_readme', $warnings['readme.txt'][0][0][0]['code'] );
 	}
 
+	public function test_run_with_errors_invalid_name() {
+		$readme_check  = new Plugin_Readme_Check();
+		$check_context = new Check_Context( UNIT_TESTS_PLUGIN_DIR . 'test-plugin-plugin-readme-errors-invalid-name/load.php' );
+		$check_result  = new Check_Result( $check_context );
+
+		$readme_check->run( $check_result );
+
+		$errors   = $check_result->get_errors();
+		$warnings = $check_result->get_warnings();
+
+		$this->assertNotEmpty( $errors );
+		$this->assertArrayHasKey( 'readme.txt', $errors );
+		$this->assertEquals( 1, $check_result->get_error_count() );
+
+		$this->assertEmpty( $warnings );
+		$this->assertEquals( 0, $check_result->get_warning_count() );
+
+		// Check for invalid name error.
+		$this->assertArrayHasKey( 0, $errors['readme.txt'] );
+		$this->assertArrayHasKey( 0, $errors['readme.txt'][0] );
+		$this->assertArrayHasKey( 'code', $errors['readme.txt'][0][0][0] );
+		$this->assertEquals( 'invalid_plugin_name', $errors['readme.txt'][0][0][0]['code'] );
+	}
+
 	public function test_run_with_errors_default_text() {
 		$readme_check  = new Plugin_Readme_Check();
 		$check_context = new Check_Context( UNIT_TESTS_PLUGIN_DIR . 'test-plugin-plugin-readme-errors-default-text/load.php' );

--- a/tests/phpunit/tests/Checker/Checks/Plugin_Readme_Check_Tests.php
+++ b/tests/phpunit/tests/Checker/Checks/Plugin_Readme_Check_Tests.php
@@ -55,6 +55,30 @@ class Plugin_Readme_Check_Tests extends WP_UnitTestCase {
 		$this->assertEquals( 'invalid_plugin_name', $errors['readme.txt'][0][0][0]['code'] );
 	}
 
+	public function test_run_with_errors_empty_name() {
+		$readme_check  = new Plugin_Readme_Check();
+		$check_context = new Check_Context( UNIT_TESTS_PLUGIN_DIR . 'test-plugin-plugin-readme-errors-empty-name/load.php' );
+		$check_result  = new Check_Result( $check_context );
+
+		$readme_check->run( $check_result );
+
+		$errors   = $check_result->get_errors();
+		$warnings = $check_result->get_warnings();
+
+		$this->assertNotEmpty( $errors );
+		$this->assertArrayHasKey( 'readme.txt', $errors );
+		// Two errors are 'empty_plugin_name' and 'no_license'.
+		$this->assertEquals( 2, $check_result->get_error_count() );
+		$this->assertEmpty( $warnings );
+		$this->assertEquals( 0, $check_result->get_warning_count() );
+
+		// Check for empty name error.
+		$this->assertArrayHasKey( 0, $errors['readme.txt'] );
+		$this->assertArrayHasKey( 0, $errors['readme.txt'][0] );
+		$this->assertArrayHasKey( 'code', $errors['readme.txt'][0][0][0] );
+		$this->assertEquals( 'empty_plugin_name', $errors['readme.txt'][0][0][0]['code'] );
+	}
+
 	public function test_run_with_errors_default_text() {
 		$readme_check  = new Plugin_Readme_Check();
 		$check_context = new Check_Context( UNIT_TESTS_PLUGIN_DIR . 'test-plugin-plugin-readme-errors-default-text/load.php' );


### PR DESCRIPTION
Fixes https://github.com/WordPress/plugin-check/issues/397

* Add check for invalid plugin name header in readme.
* ERROR is raised if plugin name in the readme is invalid.