### PR TITLE
Detect localhost/127.0.0.1 code in multiple files

### DIFF
--- a/includes/Checker/Checks/Abstract_File_Check.php
+++ b/includes/Checker/Checks/Abstract_File_Check.php
@@ -144,7 +144,7 @@ abstract class Abstract_File_Check implements Static_Check {
 	/**
 	 * Returns matched files performing a regular expression match on the file contents of the given list of files.
 	 *
-	 * @since 1.0.2
+	 * @since 1.1.0
 	 *
 	 * @param string $pattern The pattern to search for.
 	 * @param array  $files   List of absolute file paths.
@@ -169,7 +169,7 @@ abstract class Abstract_File_Check implements Static_Check {
 	/**
 	 * Returns matched files performing a regular expression match on the file contents of the given list of files with line and column information.
 	 *
-	 * @since 1.0.2
+	 * @since 1.1.0
 	 *
 	 * @param string $pattern The pattern to search for.
 	 * @param array  $files   List of absolute file paths.

--- a/includes/Checker/Checks/Abstract_File_Check.php
+++ b/includes/Checker/Checks/Abstract_File_Check.php
@@ -144,7 +144,7 @@ abstract class Abstract_File_Check implements Static_Check {
 	/**
 	 * Returns matched files performing a regular expression match on the file contents of the given list of files.
 	 *
-	 * @since n.e.x.t
+	 * @since 1.0.2
 	 *
 	 * @param string $pattern The pattern to search for.
 	 * @param array  $files   List of absolute file paths.
@@ -160,6 +160,44 @@ abstract class Abstract_File_Check implements Static_Check {
 
 			if ( false !== $matched_file_name ) {
 				$matched_files[] = array( $matched_file_name, $matches[0] );
+			}
+		}
+
+		return count( $matched_files ) > 0 ? $matched_files : false;
+	}
+
+	/**
+	 * Returns matched files performing a regular expression match on the file contents of the given list of files with line and column information.
+	 *
+	 * @since 1.0.2
+	 *
+	 * @param string $pattern The pattern to search for.
+	 * @param array  $files   List of absolute file paths.
+	 * @return array|bool Array of file paths and matched string/pattern if matches were found, false otherwise.
+	 */
+	final protected static function files_preg_match_all( $pattern, array $files ) {
+		$matched_files = array();
+
+		foreach ( $files as $file ) {
+			$matches = array();
+
+			$contents = self::file_get_contents( $file );
+
+			preg_match_all( $pattern, $contents, $matches, PREG_OFFSET_CAPTURE );
+
+			if ( is_array( $matches ) && ! empty( $matches ) ) {
+				foreach ( $matches[0] as $match ) {
+					list( $before ) = str_split( $contents, $match[1] );
+
+					$exploded  = explode( PHP_EOL, $before );
+					$last_item = end( $exploded );
+
+					$matched_files[] = array(
+						'file'   => $file,
+						'line'   => count( $exploded ),
+						'column' => strlen( $last_item ) + 1,
+					);
+				}
 			}
 		}
 

--- a/includes/Checker/Checks/Abstract_File_Check.php
+++ b/includes/Checker/Checks/Abstract_File_Check.php
@@ -142,6 +142,31 @@ abstract class Abstract_File_Check implements Static_Check {
 	}
 
 	/**
+	 * Returns matched files performing a regular expression match on the file contents of the given list of files.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param string $pattern The pattern to search for.
+	 * @param array  $files   List of absolute file paths.
+	 * @return array|bool Array of file paths and matched string/pattern if matches were found, false otherwise.
+	 */
+	final protected static function files_preg_match( $pattern, array $files ) {
+		$matched_files = array();
+
+		foreach ( $files as $file ) {
+			$matches = array();
+
+			$matched_file_name = self::file_preg_match( $pattern, array( $file ), $matches );
+
+			if ( false !== $matched_file_name ) {
+				$matched_files[] = array( $matched_file_name, $matches[0] );
+			}
+		}
+
+		return count( $matched_files ) > 0 ? $matched_files : false;
+	}
+
+	/**
 	 * Performs a check indicating if the needle is contained in the file contents of the given list of files.
 	 *
 	 * This is a wrapper around the native `str_contains()` function that will find the needle within the list of

--- a/includes/Checker/Checks/Localhost_Check.php
+++ b/includes/Checker/Checks/Localhost_Check.php
@@ -45,7 +45,7 @@ class Localhost_Check extends Abstract_File_Check {
 	 */
 	protected function check_files( Check_Result $result, array $files ) {
 		$php_files = self::filter_files_by_extension( $files, 'php' );
-		$files     = self::files_preg_match( '#https?://(localhost|127.0.0.1)#', $php_files );
+		$files     = self::files_preg_match_all( '#https?://(localhost|127.0.0.1)#', $php_files );
 
 		if ( ! empty( $files ) ) {
 			foreach ( $files as $file ) {
@@ -53,7 +53,9 @@ class Localhost_Check extends Abstract_File_Check {
 					$result,
 					__( 'Do not use Localhost/127.0.0.1 in your code.', 'plugin-check' ),
 					'localhost_code_detected',
-					$file[0]
+					$file['file'],
+					$file['line'],
+					$file['column']
 				);
 			}
 		}

--- a/includes/Checker/Checks/Localhost_Check.php
+++ b/includes/Checker/Checks/Localhost_Check.php
@@ -45,7 +45,7 @@ class Localhost_Check extends Abstract_File_Check {
 	 */
 	protected function check_files( Check_Result $result, array $files ) {
 		$php_files = self::filter_files_by_extension( $files, 'php' );
-		$files     = self::files_preg_match_all( '#https?://(localhost|127.0.0.1)#', $php_files );
+		$files     = self::files_preg_match_all( '#https?:\/\/(localhost|127.0.0.1|(.*\.local(host)?))\/#', $php_files );
 
 		if ( ! empty( $files ) ) {
 			foreach ( $files as $file ) {

--- a/includes/Checker/Checks/Localhost_Check.php
+++ b/includes/Checker/Checks/Localhost_Check.php
@@ -45,14 +45,17 @@ class Localhost_Check extends Abstract_File_Check {
 	 */
 	protected function check_files( Check_Result $result, array $files ) {
 		$php_files = self::filter_files_by_extension( $files, 'php' );
-		$file      = self::file_preg_match( '#https?://(localhost|127.0.0.1)#', $php_files );
-		if ( $file ) {
-			$this->add_result_error_for_file(
-				$result,
-				__( 'Do not use Localhost/127.0.0.1 in your code.', 'plugin-check' ),
-				'localhost_code_detected',
-				$file
-			);
+		$files     = self::files_preg_match( '#https?://(localhost|127.0.0.1)#', $php_files );
+
+		if ( ! empty( $files ) ) {
+			foreach ( $files as $file ) {
+				$this->add_result_error_for_file(
+					$result,
+					__( 'Do not use Localhost/127.0.0.1 in your code.', 'plugin-check' ),
+					'localhost_code_detected',
+					$file[0]
+				);
+			}
 		}
 	}
 }

--- a/tests/phpunit/testdata/plugins/test-plugin-localhost-with-errors/another.php
+++ b/tests/phpunit/testdata/plugins/test-plugin-localhost-with-errors/another.php
@@ -1,2 +1,4 @@
 <?php
-$var = 'This file contains https://127.0.0.1/example url.';
+$var        = 'This file contains https://127.0.0.1/example url.';
+$sample_url = 'Sample URL is http://docker.local/example here.';
+$custom_url = 'Custom URL https://docker.localhost/example here.';

--- a/tests/phpunit/testdata/plugins/test-plugin-localhost-with-errors/another.php
+++ b/tests/phpunit/testdata/plugins/test-plugin-localhost-with-errors/another.php
@@ -1,0 +1,2 @@
+<?php
+$var = 'This file contains https://127.0.0.1/example url.';

--- a/tests/phpunit/tests/Checker/Checks/Localhost_Check_Tests.php
+++ b/tests/phpunit/tests/Checker/Checks/Localhost_Check_Tests.php
@@ -23,16 +23,22 @@ class Localhost_Check_Tests extends WP_UnitTestCase {
 		$this->assertNotEmpty( $errors );
 		$this->assertArrayHasKey( 'load.php', $errors );
 		$this->assertArrayHasKey( 'another.php', $errors );
-		$this->assertEquals( 2, $check_result->get_error_count() );
+		$this->assertSame( 4, $check_result->get_error_count() );
 
 		$this->assertArrayHasKey( 19, $errors['load.php'] );
 		$this->assertArrayHasKey( 24, $errors['load.php'][19] );
-		$this->assertArrayHasKey( 'code', $errors['load.php'][19][24][0] );
-		$this->assertEquals( 'localhost_code_detected', $errors['load.php'][19][24][0]['code'] );
+		$this->assertCount( 1, wp_list_filter( $errors['load.php'][19][24], array( 'code' => 'localhost_code_detected' ) ) );
 
 		$this->assertArrayHasKey( 2, $errors['another.php'] );
-		$this->assertArrayHasKey( 28, $errors['another.php'][2] );
-		$this->assertArrayHasKey( 'code', $errors['another.php'][2][28][0] );
-		$this->assertEquals( 'localhost_code_detected', $errors['another.php'][2][28][0]['code'] );
+		$this->assertArrayHasKey( 35, $errors['another.php'][2] );
+		$this->assertCount( 1, wp_list_filter( $errors['another.php'][2][35], array( 'code' => 'localhost_code_detected' ) ) );
+
+		$this->assertArrayHasKey( 3, $errors['another.php'] );
+		$this->assertArrayHasKey( 30, $errors['another.php'][3] );
+		$this->assertCount( 1, wp_list_filter( $errors['another.php'][3][30], array( 'code' => 'localhost_code_detected' ) ) );
+
+		$this->assertArrayHasKey( 4, $errors['another.php'] );
+		$this->assertArrayHasKey( 27, $errors['another.php'][4] );
+		$this->assertCount( 1, wp_list_filter( $errors['another.php'][4][27], array( 'code' => 'localhost_code_detected' ) ) );
 	}
 }

--- a/tests/phpunit/tests/Checker/Checks/Localhost_Check_Tests.php
+++ b/tests/phpunit/tests/Checker/Checks/Localhost_Check_Tests.php
@@ -25,14 +25,14 @@ class Localhost_Check_Tests extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'another.php', $errors );
 		$this->assertEquals( 2, $check_result->get_error_count() );
 
-		$this->assertArrayHasKey( 0, $errors['load.php'] );
-		$this->assertArrayHasKey( 0, $errors['load.php'][0] );
-		$this->assertArrayHasKey( 'code', $errors['load.php'][0][0][0] );
-		$this->assertEquals( 'localhost_code_detected', $errors['load.php'][0][0][0]['code'] );
+		$this->assertArrayHasKey( 19, $errors['load.php'] );
+		$this->assertArrayHasKey( 24, $errors['load.php'][19] );
+		$this->assertArrayHasKey( 'code', $errors['load.php'][19][24][0] );
+		$this->assertEquals( 'localhost_code_detected', $errors['load.php'][19][24][0]['code'] );
 
-		$this->assertArrayHasKey( 0, $errors['another.php'] );
-		$this->assertArrayHasKey( 0, $errors['another.php'][0] );
-		$this->assertArrayHasKey( 'code', $errors['another.php'][0][0][0] );
-		$this->assertEquals( 'localhost_code_detected', $errors['another.php'][0][0][0]['code'] );
+		$this->assertArrayHasKey( 2, $errors['another.php'] );
+		$this->assertArrayHasKey( 28, $errors['another.php'][2] );
+		$this->assertArrayHasKey( 'code', $errors['another.php'][2][28][0] );
+		$this->assertEquals( 'localhost_code_detected', $errors['another.php'][2][28][0]['code'] );
 	}
 }

--- a/tests/phpunit/tests/Checker/Checks/Localhost_Check_Tests.php
+++ b/tests/phpunit/tests/Checker/Checks/Localhost_Check_Tests.php
@@ -22,11 +22,17 @@ class Localhost_Check_Tests extends WP_UnitTestCase {
 
 		$this->assertNotEmpty( $errors );
 		$this->assertArrayHasKey( 'load.php', $errors );
-		$this->assertEquals( 1, $check_result->get_error_count() );
+		$this->assertArrayHasKey( 'another.php', $errors );
+		$this->assertEquals( 2, $check_result->get_error_count() );
 
 		$this->assertArrayHasKey( 0, $errors['load.php'] );
 		$this->assertArrayHasKey( 0, $errors['load.php'][0] );
 		$this->assertArrayHasKey( 'code', $errors['load.php'][0][0][0] );
 		$this->assertEquals( 'localhost_code_detected', $errors['load.php'][0][0][0]['code'] );
+
+		$this->assertArrayHasKey( 0, $errors['another.php'] );
+		$this->assertArrayHasKey( 0, $errors['another.php'][0] );
+		$this->assertArrayHasKey( 'code', $errors['another.php'][0][0][0] );
+		$this->assertEquals( 'localhost_code_detected', $errors['another.php'][0][0][0]['code'] );
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/WordPress/plugin-check/issues/362

* Adds method `files_preg_match` in `Abstract_File_Check` to return multiple results matched with given regex.
* Update `Localhost_Check` to handle array of results
* Update `Localhost_Check_Tests` accordingly