### PR TITLE
Add check for missing Stable Tag in readme

### DIFF
--- a/includes/Checker/Checks/Plugin_Readme_Check.php
+++ b/includes/Checker/Checks/Plugin_Readme_Check.php
@@ -172,6 +172,7 @@ class Plugin_Readme_Check extends Abstract_File_Check {
 				'no_stable_tag',
 				$readme_file
 			);
+
 			return;
 		}
 
@@ -188,7 +189,7 @@ class Plugin_Readme_Check extends Abstract_File_Check {
 		$plugin_data = get_plugin_data( WP_PLUGIN_DIR . '/' . $result->plugin()->basename() );
 
 		if (
-			$stable_tag && ! empty( $plugin_data['Version'] ) &&
+			! empty( $plugin_data['Version'] ) &&
 			$stable_tag !== $plugin_data['Version']
 		) {
 			$this->add_result_error_for_file(

--- a/includes/Checker/Checks/Plugin_Readme_Check.php
+++ b/includes/Checker/Checks/Plugin_Readme_Check.php
@@ -166,8 +166,8 @@ class Plugin_Readme_Check extends Abstract_File_Check {
 				$result,
 				sprintf(
 					/* translators: %s: plugin header tag */
-					__( 'The %s field is missing.', 'plugin-check' ),
-					"'Stable Tag'"
+					__( 'The "%s" field is missing.', 'plugin-check' ),
+					'Stable Tag'
 				),
 				'no_stable_tag',
 				$readme_file

--- a/includes/Checker/Checks/Plugin_Readme_Check.php
+++ b/includes/Checker/Checks/Plugin_Readme_Check.php
@@ -161,6 +161,20 @@ class Plugin_Readme_Check extends Abstract_File_Check {
 	private function check_stable_tag( Check_Result $result, string $readme_file, Parser $parser ) {
 		$stable_tag = $parser->stable_tag;
 
+		if ( empty( $stable_tag ) ) {
+			$this->add_result_error_for_file(
+				$result,
+				sprintf(
+					/* translators: %s: plugin header tag */
+					__( 'The %s field is missing.', 'plugin-check' ),
+					"'Stable Tag'"
+				),
+				'no_stable_tag',
+				$readme_file
+			);
+			return;
+		}
+
 		if ( 'trunk' === $stable_tag ) {
 			$this->add_result_error_for_file(
 				$result,

--- a/tests/phpunit/testdata/plugins/test-plugin-plugin-readme-errors-no-stable-tag/load.php
+++ b/tests/phpunit/testdata/plugins/test-plugin-plugin-readme-errors-no-stable-tag/load.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * Plugin Name: Test Plugin Readme Errors (no stable tag)
+ * Plugin URI: https://github.com/WordPress/plugin-check
+ * Description: Test plugin for the Readme check.
+ * Requires at least: 6.0
+ * Requires PHP: 5.6
+ * Version: n.e.x.t
+ * Author: WordPress Performance Team
+ * Author URI: https://make.wordpress.org/performance/
+ * License: GPLv2 or later
+ * License URI: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+ * Text Domain: test-plugin-check-errors
+ *
+ * @package test-plugin-check-errors
+ */

--- a/tests/phpunit/testdata/plugins/test-plugin-plugin-readme-errors-no-stable-tag/readme.txt
+++ b/tests/phpunit/testdata/plugins/test-plugin-plugin-readme-errors-no-stable-tag/readme.txt
@@ -1,0 +1,11 @@
+=== Test Plugin with readme ===
+
+Contributors:      plugin-check
+Requires at least: 6.0
+Tested up to:      6.1
+Requires PHP:      5.6
+License:           GPLv2 or later
+License URI:       https://www.gnu.org/licenses/gpl-2.0.html
+Tags:              testing, security
+
+Plugin description.

--- a/tests/phpunit/tests/Checker/Checks/Plugin_Readme_Check_Tests.php
+++ b/tests/phpunit/tests/Checker/Checks/Plugin_Readme_Check_Tests.php
@@ -75,6 +75,30 @@ class Plugin_Readme_Check_Tests extends WP_UnitTestCase {
 		$this->assertEquals( 'stable_tag_mismatch', $errors['readme.txt'][0][0][1]['code'] );
 	}
 
+	public function test_run_with_errors_no_stable_tag() {
+		$readme_check  = new Plugin_Readme_Check();
+		$check_context = new Check_Context( UNIT_TESTS_PLUGIN_DIR . 'test-plugin-plugin-readme-errors-no-stable-tag/load.php' );
+		$check_result  = new Check_Result( $check_context );
+
+		$readme_check->run( $check_result );
+
+		$errors   = $check_result->get_errors();
+		$warnings = $check_result->get_warnings();
+
+		$this->assertNotEmpty( $errors );
+		$this->assertArrayHasKey( 'readme.txt', $errors );
+		$this->assertEquals( 1, $check_result->get_error_count() );
+
+		$this->assertEmpty( $warnings );
+		$this->assertEquals( 0, $check_result->get_warning_count() );
+
+		// Check for no stable tag error.
+		$this->assertArrayHasKey( 0, $errors['readme.txt'] );
+		$this->assertArrayHasKey( 0, $errors['readme.txt'][0] );
+		$this->assertArrayHasKey( 'code', $errors['readme.txt'][0][0][0] );
+		$this->assertEquals( 'no_stable_tag', $errors['readme.txt'][0][0][0]['code'] );
+	}
+
 	public function test_run_with_errors_license() {
 		$readme_check  = new Plugin_Readme_Check();
 		$check_context = new Check_Context( UNIT_TESTS_PLUGIN_DIR . 'test-plugin-plugin-readme-errors-license/load.php' );


### PR DESCRIPTION
* Update `function check_stable_tag()` to test if `Stable Tag` is missing
* Raise ERROR for missing stable tag
* Update tests to reflect new changes

Since the value of `Stable Tag` is very important in our directory, I have kept this check as ERROR. We can keep it as WARNING if otherwise. This check is currently not there in legacy version.

cc: @swissspidy @felixarntz @mukeshpanchal27