### PR TITLE
Fix failing Behat test

### DIFF
--- a/tests/behat/features/plugin-check.feature
+++ b/tests/behat/features/plugin-check.feature
@@ -100,11 +100,11 @@ Feature: Test that the WP-CLI command works.
     When I run the WP-CLI command `plugin check akismet`
     Then STDOUT should contain:
       """
-      FILE: views/config.php
+      FILE: views/notice.php
       """
 
     When I run the WP-CLI command `plugin check akismet --exclude-directories=views`
     Then STDOUT should not contain:
       """
-      FILE: views/config.php
+      FILE: views/notice.php
       """

--- a/tests/behat/features/plugin-check.feature
+++ b/tests/behat/features/plugin-check.feature
@@ -94,17 +94,42 @@ Feature: Test that the WP-CLI command works.
       WordPress.Security.EscapeOutput.OutputNotEscaped
       """
 
-  Scenario: Check Akismet
+  Scenario: Exclude directories in plugin check
     Given a WP install with the Plugin Check plugin
+    And an empty wp-content/plugins/foo-plugin directory
+    And an empty wp-content/plugins/foo-plugin/subdirectory directory
+    And a wp-content/plugins/foo-plugin/foo-plugin.php file:
+      """
+      <?php
+      /**
+       * Plugin Name: Foo Plugin
+       * Plugin URI:  https://example.com
+       * Description:
+       * Version:     0.1.0
+       * Author:
+       * Author URI:
+       * License:     GPL-2.0+
+       * License URI: http://www.gnu.org/licenses/gpl-2.0.txt
+       * Text Domain: foo-plugin
+       * Domain Path: /languages
+       */
 
-    When I run the WP-CLI command `plugin check akismet`
+      """
+    And a wp-content/plugins/foo-plugin/subdirectory/bar.php file:
+      """
+      <?php
+      $value = 1;
+      echo $value;
+      """
+
+    When I run the WP-CLI command `plugin check foo-plugin`
     Then STDOUT should contain:
       """
-      FILE: views/notice.php
+      FILE: subdirectory/bar.php
       """
 
-    When I run the WP-CLI command `plugin check akismet --exclude-directories=views`
+    When I run the WP-CLI command `plugin check foo-plugin --exclude-directories=subdirectory`
     Then STDOUT should not contain:
       """
-      FILE: views/notice.php
+      FILE: subdirectory/bar.php
       """


### PR DESCRIPTION
Ref: https://github.com/WordPress/plugin-check/actions/runs/7728228566/job/21068526460

Behat test is failing because Akismet has done some update which we have used in the CLI test.