### PR TITLE
Avoid plugin header text domain check for single file plugin

### DIFF
--- a/includes/Checker/Checks/Plugin_Header_Text_Domain_Check.php
+++ b/includes/Checker/Checks/Plugin_Header_Text_Domain_Check.php
@@ -48,6 +48,10 @@ class Plugin_Header_Text_Domain_Check implements Static_Check {
 	 *                   the check).
 	 */
 	public function run( Check_Result $result ) {
+		// Check if single file plugin, then bail early.
+		if ( $result->plugin()->is_single_file_plugin() ) {
+			return;
+		}
 
 		if ( ! function_exists( 'get_plugin_data' ) ) {
 			require_once ABSPATH . 'wp-admin/includes/plugin.php';


### PR DESCRIPTION
This `Plugin_Header_Text_Domain_Check` is not applicable to single file plugin because logic of finding plugin slug here will always return `plugins` as plugin slug value. Since we generally don't accept single file plugin in the directory and also message here is of `WARNING` type, bailing this check would be desirable I believe.