### PR TITLE
Fix edit file URL for single file plugin

### DIFF
--- a/includes/Traits/File_Editor_URL.php
+++ b/includes/Traits/File_Editor_URL.php
@@ -101,7 +101,7 @@ trait File_Editor_URL {
 		if ( ! $edit_url && current_user_can( 'edit_plugins' ) ) {
 			$query_args = array(
 				'plugin' => rawurlencode( $result->plugin()->basename() ),
-				'file'   => rawurlencode( str_contains( $result->plugin()->basename(), '/' ) ? $plugin_slug . '/' . $filename : $filename ),
+				'file'   => rawurlencode( $result->plugin()->is_single_file_plugin() ? $filename : $plugin_slug . '/' . $filename ),
 			);
 			if ( $line ) {
 				$query_args['line'] = $line;

--- a/includes/Traits/File_Editor_URL.php
+++ b/includes/Traits/File_Editor_URL.php
@@ -101,7 +101,7 @@ trait File_Editor_URL {
 		if ( ! $edit_url && current_user_can( 'edit_plugins' ) ) {
 			$query_args = array(
 				'plugin' => rawurlencode( $result->plugin()->basename() ),
-				'file'   => rawurlencode( $plugin_slug . '/' . $filename ),
+				'file'   => rawurlencode( str_contains( $result->plugin()->basename(), '/' ) ? $plugin_slug . '/' . $filename : $filename ),
 			);
 			if ( $line ) {
 				$query_args['line'] = $line;


### PR DESCRIPTION
Fixes https://github.com/WordPress/plugin-check/issues/412

- Value of `file` is generated conditionally