### PR TITLE
Improve readme plugin name header check

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -12,12 +12,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/afragen/wordpress-plugin-readme-parser.git",
-                "reference": "2f4fbe89bb7ffaf905eb28b385b7d1def4a83f54"
+                "reference": "0dc64ee6d4cb6d32e3855d016763d9bd08652e0f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/afragen/wordpress-plugin-readme-parser/zipball/2f4fbe89bb7ffaf905eb28b385b7d1def4a83f54",
-                "reference": "2f4fbe89bb7ffaf905eb28b385b7d1def4a83f54",
+                "url": "https://api.github.com/repos/afragen/wordpress-plugin-readme-parser/zipball/0dc64ee6d4cb6d32e3855d016763d9bd08652e0f",
+                "reference": "0dc64ee6d4cb6d32e3855d016763d9bd08652e0f",
                 "shasum": ""
             },
             "require": {
@@ -51,7 +51,7 @@
                 "issues": "https://github.com/afragen/wordpress-plugin-readme-parser/issues",
                 "source": "https://github.com/afragen/wordpress-plugin-readme-parser/tree/master"
             },
-            "time": "2024-01-25T16:41:35+00:00"
+            "time": "2024-02-02T17:46:48+00:00"
         },
         {
             "name": "automattic/vipwpcs",
@@ -3817,16 +3817,16 @@
         },
         {
             "name": "wp-cli/core-command",
-            "version": "v2.1.16",
+            "version": "v2.1.17",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-cli/core-command.git",
-                "reference": "9d6ebb4545df0b8bc7e688a49910ddcdd86dbe93"
+                "reference": "dcac4c36a3c596f1c81779bdbaa0c5f508f14075"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-cli/core-command/zipball/9d6ebb4545df0b8bc7e688a49910ddcdd86dbe93",
-                "reference": "9d6ebb4545df0b8bc7e688a49910ddcdd86dbe93",
+                "url": "https://api.github.com/repos/wp-cli/core-command/zipball/dcac4c36a3c596f1c81779bdbaa0c5f508f14075",
+                "reference": "dcac4c36a3c596f1c81779bdbaa0c5f508f14075",
                 "shasum": ""
             },
             "require": {
@@ -3882,9 +3882,9 @@
             "homepage": "https://github.com/wp-cli/core-command",
             "support": {
                 "issues": "https://github.com/wp-cli/core-command/issues",
-                "source": "https://github.com/wp-cli/core-command/tree/v2.1.16"
+                "source": "https://github.com/wp-cli/core-command/tree/v2.1.17"
             },
-            "time": "2023-11-10T23:54:33+00:00"
+            "time": "2024-01-11T11:03:57+00:00"
         },
         {
             "name": "wp-cli/eval-command",

--- a/includes/Checker/Checks/Plugin_Readme_Check.php
+++ b/includes/Checker/Checks/Plugin_Readme_Check.php
@@ -100,12 +100,11 @@ class Plugin_Readme_Check extends Abstract_File_Check {
 	 * @param Parser       $parser      The Parser object.
 	 */
 	private function check_name( Check_Result $result, string $readme_file, Parser $parser ) {
-		if ( isset( $parser->warnings['invalid_plugin_name_header'] ) ) {
+		if ( isset( $parser->warnings['invalid_plugin_name_header'] ) && false === $parser->name ) {
 			$message = sprintf(
-				/* translators: 1: 'Plugin Name' section title, 2: 'Plugin Name' */
-				__( 'Plugin name look like: "%1$s". Please change "%2$s" to reflect the actual name of your plugin.', 'plugin-check' ),
-				'=== Plugin Name ===',
-				'Plugin Name'
+				/* translators: %s: Example plugin name header */
+				__( 'Plugin name header in your readme is invalid. Please update your readme with a valid plugin name header. Eg: "%s"', 'plugin-check' ),
+				'=== Example Name ==='
 			);
 
 			$this->add_result_error_for_file( $result, $message, 'invalid_plugin_name', $readme_file );

--- a/includes/Checker/Checks/Plugin_Readme_Check.php
+++ b/includes/Checker/Checks/Plugin_Readme_Check.php
@@ -103,7 +103,7 @@ class Plugin_Readme_Check extends Abstract_File_Check {
 		if ( isset( $parser->warnings['invalid_plugin_name_header'] ) && false === $parser->name ) {
 			$message = sprintf(
 				/* translators: %s: Example plugin name header */
-				__( 'Plugin name header in your readme is invalid. Please update your readme with a valid plugin name header. Eg: "%s"', 'plugin-check' ),
+				__( 'Plugin name header in your readme is missing or invalid. Please update your readme with a valid plugin name header. Eg: "%s"', 'plugin-check' ),
 				'=== Example Name ==='
 			);
 

--- a/tests/phpunit/tests/Checker/Checks/Plugin_Readme_Check_Tests.php
+++ b/tests/phpunit/tests/Checker/Checks/Plugin_Readme_Check_Tests.php
@@ -67,8 +67,6 @@ class Plugin_Readme_Check_Tests extends WP_UnitTestCase {
 
 		$this->assertNotEmpty( $errors );
 		$this->assertArrayHasKey( 'readme.txt', $errors );
-		// Two errors are 'empty_plugin_name' and 'no_license'.
-		$this->assertEquals( 2, $check_result->get_error_count() );
 		$this->assertEmpty( $warnings );
 		$this->assertEquals( 0, $check_result->get_warning_count() );
 


### PR DESCRIPTION
Few changes are there regarding plugin name header in this update https://meta.trac.wordpress.org/changeset/13162

* Whenever `invalid_plugin_name_header` warning is triggered, `name` property is `false`.
* This warning is triggered in two cases: when there is no valid plugin name header (and there are other content to be parsed in the readme file) AND when header is `=== Plugin Name ===`. So I have updated the message considering both cases.
* When there is no warning `invalid_plugin_name_header` but `$parser->name` is still `empty()` then it means readme file is completely empty.  