### PR TITLE
Ensure test-content folder is in plugin zip

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -8,7 +8,6 @@ build-phpunit
 docs
 node_modules
 patches
-test-content
 tests
 
 *.DS_Store


### PR DESCRIPTION
I realized the file was erroneously excluded from the plugin zip file as I thought it's only used for tests. Wrong! Turns out it's used for runtime checks.