### PR TITLE
Use normalized path

### DIFF
--- a/includes/Checker/Checks/Abstract_File_Check.php
+++ b/includes/Checker/Checks/Abstract_File_Check.php
@@ -228,7 +228,7 @@ abstract class Abstract_File_Check implements Static_Check {
 				}
 
 				if ( $include_file ) {
-					self::$file_list_cache[ $location ][] = $file_path;
+					self::$file_list_cache[ $location ][] = wp_normalize_path( $file_path );
 				}
 			}
 		}

--- a/includes/Checker/Checks/Abstract_File_Check.php
+++ b/includes/Checker/Checks/Abstract_File_Check.php
@@ -193,7 +193,7 @@ abstract class Abstract_File_Check implements Static_Check {
 	 * @return array List of absolute file paths.
 	 */
 	private static function get_files( Check_Context $plugin ) {
-		$location = $plugin->location();
+		$location = wp_normalize_path( $plugin->location() );
 
 		if ( isset( self::$file_list_cache[ $location ] ) ) {
 			return self::$file_list_cache[ $location ];

--- a/includes/Checker/Default_Check_Collection.php
+++ b/includes/Checker/Default_Check_Collection.php
@@ -136,7 +136,7 @@ class Default_Check_Collection implements Check_Collection {
 		}
 
 		return $this->filter(
-			static function ( Check $check, $slug ) use( $check_slugs ) {
+			static function ( Check $check, $slug ) use ( $check_slugs ) {
 				return ! in_array( $slug, $check_slugs, true );
 			}
 		);

--- a/includes/Plugin_Context.php
+++ b/includes/Plugin_Context.php
@@ -42,7 +42,7 @@ class Plugin_Context {
 	 * @param string $main_file The absolute path to the plugin main file.
 	 */
 	public function __construct( $main_file ) {
-		$this->main_file = $main_file;
+		$this->main_file = wp_normalize_path( $main_file );
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -71,7 +71,7 @@ In any case, passing the checks in this tool likely helps to achieve a smooth pl
 
 = 1.0.2 =
 
-* Fix - Correct detection of readme files in Windows
+* Fix - Correct detection of readme files in Windows by normalizing file paths.
 
 = 1.0.1 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -69,6 +69,10 @@ In any case, passing the checks in this tool likely helps to achieve a smooth pl
 
 == Changelog ==
 
+= 1.0.2 =
+
+* Fix - Correct detection of readme files in Windows
+
 = 1.0.1 =
 
 * Fix - Add missing `test-content` folder needed for runtime checks.


### PR DESCRIPTION
Fixes https://github.com/WordPress/plugin-check/issues/434

* Use normalized path when fetching list files and folders