### PR TITLE
Fix relative wp-env paths when host filepaths contain spaces

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,14 +19,14 @@
     "wp-env": "wp-env",
     "lint-js": "wp-scripts lint-js",
     "format-js": "npm run lint-js -- --fix",
-    "phpstan": "wp-env run tests-cli --env-cwd=wp-content/plugins/$(basename "$(pwd)")/ composer run-script phpstan",
-    "lint-php": "wp-env run tests-cli --env-cwd=wp-content/plugins/$(basename "$(pwd)")/ composer run-script lint",
-    "format-php": "wp-env run tests-cli --env-cwd=wp-content/plugins/$(basename "$(pwd)")/ composer run-script format",
-    "pretest-php": "wp-env run tests-cli --env-cwd=/var/www/html/wp-content/plugins/$(basename "$(pwd)") composer install --no-dev; wp-env run tests-cli --env-cwd=/var/www/html/wp-content/plugins/$(basename "$(pwd)") composer dump --dev; wp-env run tests-cli --env-cwd=/var/www/html/wp-content/plugins/$(basename "$(pwd)") composer --working-dir=build-phpunit update --no-interaction",
-    "test-php": "wp-env run tests-cli --env-cwd=/var/www/html/wp-content/plugins/$(basename "$(pwd)") build-phpunit/vendor/bin/phpunit -c phpunit.xml.dist --verbose",
-    "pretest-php-coverage": "wp-env run tests-cli --env-cwd=/var/www/html/wp-content/plugins/$(basename "$(pwd)") composer install --no-dev; wp-env run tests-cli --env-cwd=/var/www/html/wp-content/plugins/$(basename "$(pwd)") composer dump --dev; wp-env run tests-cli --env-cwd=/var/www/html/wp-content/plugins/$(basename "$(pwd)") composer --working-dir=build-phpunit update --no-interaction",
-    "test-php-coverage": "wp-env run tests-cli --env-cwd=/var/www/html/wp-content/plugins/$(basename "$(pwd)") build-phpunit/vendor/bin/phpunit -c phpunit.xml.dist --verbose --coverage-clover build/logs/php-coverage.xml",
-    "test-php-multisite": "wp-env run tests-cli --env-cwd=/var/www/html/wp-content/plugins/$(basename "$(pwd)") build-phpunit/vendor/bin/phpunit -c tests/phpunit/multisite.xml --verbose",
-    "test-php-multisite-coverage": "wp-env run tests-cli --env-cwd=/var/www/html/wp-content/plugins/$(basename "$(pwd)") build-phpunit/vendor/bin/phpunit -c tests/phpunit/multisite.xml --verbose --coverage-clover build/logs/php-coverage-multisite.xml"
+    "phpstan": "wp-env run tests-cli --env-cwd=wp-content/plugins/$(basename \"$(pwd)\")/ composer run-script phpstan",
+    "lint-php": "wp-env run tests-cli --env-cwd=wp-content/plugins/$(basename \"$(pwd)\")/ composer run-script lint",
+    "format-php": "wp-env run tests-cli --env-cwd=wp-content/plugins/$(basename \"$(pwd)\")/ composer run-script format",
+    "pretest-php": "wp-env run tests-cli --env-cwd=/var/www/html/wp-content/plugins/$(basename \"$(pwd)\") composer install --no-dev; wp-env run tests-cli --env-cwd=/var/www/html/wp-content/plugins/$(basename \"$(pwd)\") composer dump --dev; wp-env run tests-cli --env-cwd=/var/www/html/wp-content/plugins/$(basename \"$(pwd)\") composer --working-dir=build-phpunit update --no-interaction",
+    "test-php": "wp-env run tests-cli --env-cwd=/var/www/html/wp-content/plugins/$(basename \"$(pwd)\") build-phpunit/vendor/bin/phpunit -c phpunit.xml.dist --verbose",
+    "pretest-php-coverage": "wp-env run tests-cli --env-cwd=/var/www/html/wp-content/plugins/$(basename \"$(pwd)\") composer install --no-dev; wp-env run tests-cli --env-cwd=/var/www/html/wp-content/plugins/$(basename \"$(pwd)\") composer dump --dev; wp-env run tests-cli --env-cwd=/var/www/html/wp-content/plugins/$(basename \"$(pwd)\") composer --working-dir=build-phpunit update --no-interaction",
+    "test-php-coverage": "wp-env run tests-cli --env-cwd=/var/www/html/wp-content/plugins/$(basename \"$(pwd)\") build-phpunit/vendor/bin/phpunit -c phpunit.xml.dist --verbose --coverage-clover build/logs/php-coverage.xml",
+    "test-php-multisite": "wp-env run tests-cli --env-cwd=/var/www/html/wp-content/plugins/$(basename \"$(pwd)\") build-phpunit/vendor/bin/phpunit -c tests/phpunit/multisite.xml --verbose",
+    "test-php-multisite-coverage": "wp-env run tests-cli --env-cwd=/var/www/html/wp-content/plugins/$(basename \"$(pwd)\") build-phpunit/vendor/bin/phpunit -c tests/phpunit/multisite.xml --verbose --coverage-clover build/logs/php-coverage-multisite.xml"
   }
 }

--- a/package.json
+++ b/package.json
@@ -19,14 +19,14 @@
     "wp-env": "wp-env",
     "lint-js": "wp-scripts lint-js",
     "format-js": "npm run lint-js -- --fix",
-    "phpstan": "wp-env run tests-cli --env-cwd=wp-content/plugins/$(basename $(pwd))/ composer run-script phpstan",
-    "lint-php": "wp-env run tests-cli --env-cwd=wp-content/plugins/$(basename $(pwd))/ composer run-script lint",
-    "format-php": "wp-env run tests-cli --env-cwd=wp-content/plugins/$(basename $(pwd))/ composer run-script format",
-    "pretest-php": "wp-env run tests-cli --env-cwd=/var/www/html/wp-content/plugins/$(basename $(pwd)) composer install --no-dev; wp-env run tests-cli --env-cwd=/var/www/html/wp-content/plugins/$(basename $(pwd)) composer dump --dev; wp-env run tests-cli --env-cwd=/var/www/html/wp-content/plugins/$(basename $(pwd)) composer --working-dir=build-phpunit update --no-interaction",
-    "test-php": "wp-env run tests-cli --env-cwd=/var/www/html/wp-content/plugins/$(basename $(pwd)) build-phpunit/vendor/bin/phpunit -c phpunit.xml.dist --verbose",
-    "pretest-php-coverage": "wp-env run tests-cli --env-cwd=/var/www/html/wp-content/plugins/$(basename $(pwd)) composer install --no-dev; wp-env run tests-cli --env-cwd=/var/www/html/wp-content/plugins/$(basename $(pwd)) composer dump --dev; wp-env run tests-cli --env-cwd=/var/www/html/wp-content/plugins/$(basename $(pwd)) composer --working-dir=build-phpunit update --no-interaction",
-    "test-php-coverage": "wp-env run tests-cli --env-cwd=/var/www/html/wp-content/plugins/$(basename $(pwd)) build-phpunit/vendor/bin/phpunit -c phpunit.xml.dist --verbose --coverage-clover build/logs/php-coverage.xml",
-    "test-php-multisite": "wp-env run tests-cli --env-cwd=/var/www/html/wp-content/plugins/$(basename $(pwd)) build-phpunit/vendor/bin/phpunit -c tests/phpunit/multisite.xml --verbose",
-    "test-php-multisite-coverage": "wp-env run tests-cli --env-cwd=/var/www/html/wp-content/plugins/$(basename $(pwd)) build-phpunit/vendor/bin/phpunit -c tests/phpunit/multisite.xml --verbose --coverage-clover build/logs/php-coverage-multisite.xml"
+    "phpstan": "wp-env run tests-cli --env-cwd=wp-content/plugins/$(basename "$(pwd)")/ composer run-script phpstan",
+    "lint-php": "wp-env run tests-cli --env-cwd=wp-content/plugins/$(basename "$(pwd)")/ composer run-script lint",
+    "format-php": "wp-env run tests-cli --env-cwd=wp-content/plugins/$(basename "$(pwd)")/ composer run-script format",
+    "pretest-php": "wp-env run tests-cli --env-cwd=/var/www/html/wp-content/plugins/$(basename "$(pwd)") composer install --no-dev; wp-env run tests-cli --env-cwd=/var/www/html/wp-content/plugins/$(basename "$(pwd)") composer dump --dev; wp-env run tests-cli --env-cwd=/var/www/html/wp-content/plugins/$(basename "$(pwd)") composer --working-dir=build-phpunit update --no-interaction",
+    "test-php": "wp-env run tests-cli --env-cwd=/var/www/html/wp-content/plugins/$(basename "$(pwd)") build-phpunit/vendor/bin/phpunit -c phpunit.xml.dist --verbose",
+    "pretest-php-coverage": "wp-env run tests-cli --env-cwd=/var/www/html/wp-content/plugins/$(basename "$(pwd)") composer install --no-dev; wp-env run tests-cli --env-cwd=/var/www/html/wp-content/plugins/$(basename "$(pwd)") composer dump --dev; wp-env run tests-cli --env-cwd=/var/www/html/wp-content/plugins/$(basename "$(pwd)") composer --working-dir=build-phpunit update --no-interaction",
+    "test-php-coverage": "wp-env run tests-cli --env-cwd=/var/www/html/wp-content/plugins/$(basename "$(pwd)") build-phpunit/vendor/bin/phpunit -c phpunit.xml.dist --verbose --coverage-clover build/logs/php-coverage.xml",
+    "test-php-multisite": "wp-env run tests-cli --env-cwd=/var/www/html/wp-content/plugins/$(basename "$(pwd)") build-phpunit/vendor/bin/phpunit -c tests/phpunit/multisite.xml --verbose",
+    "test-php-multisite-coverage": "wp-env run tests-cli --env-cwd=/var/www/html/wp-content/plugins/$(basename "$(pwd)") build-phpunit/vendor/bin/phpunit -c tests/phpunit/multisite.xml --verbose --coverage-clover build/logs/php-coverage-multisite.xml"
   }
 }


### PR DESCRIPTION
This fixes the path passed to `wp-env` via the --env-cwd arg when `pwd` returns a file path containing a space.

## Testing instructions

1. Clone this repo to a folder locally that includes a space, like `~/Local Sites/plugin-check`.
2. Run a script like `npm run lint-php` and see that it's trying to run from `/var/www/html/wp-content/plugins/Local`
3. Check out this PR
4. Run the same script and see that it is running successful from `/var/www/html/wp-content/plugins/plugin-check`