### PR TITLE
Upgrade `@wordpress/env` to ^10.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "hasInstallScript": true,
       "license": "GPL-2.0-or-later",
       "devDependencies": {
-        "@wordpress/env": "^8.11.0",
+        "@wordpress/env": "^10.1.0",
         "@wordpress/scripts": "^26.19.0",
         "patch-package": "^8.0.0"
       },
@@ -4740,14 +4740,14 @@
       }
     },
     "node_modules/@wordpress/env": {
-      "version": "8.11.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/env/-/env-8.11.0.tgz",
-      "integrity": "sha512-9zE7HJNW1UenqfME/ao2+1kNrtFbj+jpAipgHwDOnJ+Xkg37mzQ3cb75QQzT/zM7WJ1r1ET4J2b7zbwOImTvAw==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/env/-/env-10.1.0.tgz",
+      "integrity": "sha512-kctjcTTWlQlG2IjjQGTLK/1Z6P4pl2W7Z34gbOR0eouqHlfJ7lJ44HXsHKUbNwIPzU7a/iLCT/N1B1b0TNu66Q==",
       "dev": true,
       "dependencies": {
         "chalk": "^4.0.0",
         "copy-dir": "^1.3.0",
-        "docker-compose": "^0.22.2",
+        "docker-compose": "^0.24.3",
         "extract-zip": "^1.6.7",
         "got": "^11.8.5",
         "inquirer": "^7.1.0",
@@ -4760,6 +4760,10 @@
       },
       "bin": {
         "wp-env": "bin/wp-env"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
       }
     },
     "node_modules/@wordpress/eslint-plugin": {
@@ -8033,12 +8037,27 @@
       }
     },
     "node_modules/docker-compose": {
-      "version": "0.22.2",
-      "resolved": "https://registry.npmjs.org/docker-compose/-/docker-compose-0.22.2.tgz",
-      "integrity": "sha512-iXWb5+LiYmylIMFXvGTYsjI1F+Xyx78Jm/uj1dxwwZLbWkUdH6yOXY5Nr3RjbYX15EgbGJCq78d29CmWQQQMPg==",
+      "version": "0.24.8",
+      "resolved": "https://registry.npmjs.org/docker-compose/-/docker-compose-0.24.8.tgz",
+      "integrity": "sha512-plizRs/Vf15H+GCVxq2EUvyPK7ei9b/cVesHvjnX4xaXjM9spHe2Ytq0BitndFgvTJ3E3NljPNUEl7BAN43iZw==",
       "dev": true,
+      "dependencies": {
+        "yaml": "^2.2.2"
+      },
       "engines": {
         "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/docker-compose/node_modules/yaml": {
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.4.5.tgz",
+      "integrity": "sha512-aBx2bnqDzVOyNKfsysjA2ms5ZlnjSAW2eG3/L5G/CSujfjLJTJsEw1bGw8kCf04KodQWk1pxlGnZ56CRxiawmg==",
+      "dev": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/doctrine": {
@@ -23259,14 +23278,14 @@
       }
     },
     "@wordpress/env": {
-      "version": "8.11.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/env/-/env-8.11.0.tgz",
-      "integrity": "sha512-9zE7HJNW1UenqfME/ao2+1kNrtFbj+jpAipgHwDOnJ+Xkg37mzQ3cb75QQzT/zM7WJ1r1ET4J2b7zbwOImTvAw==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/env/-/env-10.1.0.tgz",
+      "integrity": "sha512-kctjcTTWlQlG2IjjQGTLK/1Z6P4pl2W7Z34gbOR0eouqHlfJ7lJ44HXsHKUbNwIPzU7a/iLCT/N1B1b0TNu66Q==",
       "dev": true,
       "requires": {
         "chalk": "^4.0.0",
         "copy-dir": "^1.3.0",
-        "docker-compose": "^0.22.2",
+        "docker-compose": "^0.24.3",
         "extract-zip": "^1.6.7",
         "got": "^11.8.5",
         "inquirer": "^7.1.0",
@@ -25674,10 +25693,21 @@
       }
     },
     "docker-compose": {
-      "version": "0.22.2",
-      "resolved": "https://registry.npmjs.org/docker-compose/-/docker-compose-0.22.2.tgz",
-      "integrity": "sha512-iXWb5+LiYmylIMFXvGTYsjI1F+Xyx78Jm/uj1dxwwZLbWkUdH6yOXY5Nr3RjbYX15EgbGJCq78d29CmWQQQMPg==",
-      "dev": true
+      "version": "0.24.8",
+      "resolved": "https://registry.npmjs.org/docker-compose/-/docker-compose-0.24.8.tgz",
+      "integrity": "sha512-plizRs/Vf15H+GCVxq2EUvyPK7ei9b/cVesHvjnX4xaXjM9spHe2Ytq0BitndFgvTJ3E3NljPNUEl7BAN43iZw==",
+      "dev": true,
+      "requires": {
+        "yaml": "^2.2.2"
+      },
+      "dependencies": {
+        "yaml": {
+          "version": "2.4.5",
+          "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.4.5.tgz",
+          "integrity": "sha512-aBx2bnqDzVOyNKfsysjA2ms5ZlnjSAW2eG3/L5G/CSujfjLJTJsEw1bGw8kCf04KodQWk1pxlGnZ56CRxiawmg==",
+          "dev": true
+        }
+      }
     },
     "doctrine": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "npm": ">=10.2.3"
   },
   "devDependencies": {
-    "@wordpress/env": "^8.11.0",
+    "@wordpress/env": "^10.1.0",
     "@wordpress/scripts": "^26.19.0",
     "patch-package": "^8.0.0"
   },


### PR DESCRIPTION
This updates the version of the `@wordpress/env` package used for local development and in our CI workflows for PHPUnit tests.

See the changelog for this set of package updates: https://github.com/WordPress/gutenberg/blob/trunk/packages/env/CHANGELOG.md