### PR TITLE
Allow static checks to be run against an arbitrary path

### DIFF
--- a/includes/Checker/Abstract_Check_Runner.php
+++ b/includes/Checker/Abstract_Check_Runner.php
@@ -481,8 +481,13 @@ abstract class Abstract_Check_Runner implements Check_Runner {
 	 */
 	final public function get_plugin_basename() {
 		if ( null === $this->plugin_basename ) {
-			$plugin                = null !== $this->plugin ? $this->plugin : $this->get_plugin_param();
-			$this->plugin_basename = Plugin_Request_Utility::get_plugin_basename_from_input( $plugin );
+			$plugin = null !== $this->plugin ? $this->plugin : $this->get_plugin_param();
+
+			if ( is_dir( $plugin ) ) {
+				$this->plugin_basename = $plugin;
+			} else {
+				$this->plugin_basename = Plugin_Request_Utility::get_plugin_basename_from_input( $plugin );
+			}
 		}
 
 		return $this->plugin_basename;

--- a/includes/Checker/Abstract_Check_Runner.php
+++ b/includes/Checker/Abstract_Check_Runner.php
@@ -525,7 +525,9 @@ abstract class Abstract_Check_Runner implements Check_Runner {
 	 * @return Check_Context The check context for the plugin file.
 	 */
 	private function get_check_context() {
-		return new Check_Context( WP_PLUGIN_DIR . '/' . $this->get_plugin_basename() );
+		$plugin_basename = $this->get_plugin_basename();
+		$plugin_path     = is_dir( $plugin_basename ) ? $plugin_basename : WP_PLUGIN_DIR . '/' . $plugin_basename;
+		return new Check_Context( $plugin_path );
 	}
 
 	/**

--- a/includes/Checker/Checks/Plugin_Header_Text_Domain_Check.php
+++ b/includes/Checker/Checks/Plugin_Header_Text_Domain_Check.php
@@ -57,7 +57,7 @@ class Plugin_Header_Text_Domain_Check implements Static_Check {
 			require_once ABSPATH . 'wp-admin/includes/plugin.php';
 		}
 
-		$plugin_main_file = WP_PLUGIN_DIR . '/' . $result->plugin()->basename();
+		$plugin_main_file = $result->plugin()->main_file();
 		$plugin_header    = get_plugin_data( $plugin_main_file );
 		$plugin_slug      = basename( $result->plugin()->path() );
 

--- a/includes/Checker/Checks/Plugin_Readme_Check.php
+++ b/includes/Checker/Checks/Plugin_Readme_Check.php
@@ -365,7 +365,7 @@ class Plugin_Readme_Check extends Abstract_File_Check {
 		}
 
 		// Check the readme file Stable tag against the plugin's main file version.
-		$plugin_data = get_plugin_data( WP_PLUGIN_DIR . '/' . $result->plugin()->basename() );
+		$plugin_data = get_plugin_data( $result->plugin()->main_file() );
 
 		if (
 			! empty( $plugin_data['Version'] ) &&

--- a/includes/Checker/Checks/Plugin_Readme_Check.php
+++ b/includes/Checker/Checks/Plugin_Readme_Check.php
@@ -225,7 +225,7 @@ class Plugin_Readme_Check extends Abstract_File_Check {
 	private function check_license( Check_Result $result, string $readme_file, Parser $parser ) {
 		$license          = $parser->license;
 		$matches_license  = array();
-		$plugin_main_file = WP_PLUGIN_DIR . '/' . $result->plugin()->basename();
+		$plugin_main_file = $result->plugin()->main_file();
 
 		// Filter the readme files.
 		if ( empty( $license ) ) {

--- a/includes/Checker/Checks/Plugin_Updater_Check.php
+++ b/includes/Checker/Checks/Plugin_Updater_Check.php
@@ -108,7 +108,7 @@ class Plugin_Updater_Check extends Abstract_File_Check {
 			require_once ABSPATH . 'wp-admin/includes/plugin.php';
 		}
 
-		$plugin_main_file = WP_PLUGIN_DIR . '/' . $result->plugin()->basename();
+		$plugin_main_file = $result->plugin()->main_file();
 		$plugin_header    = get_plugin_data( $plugin_main_file );
 		if ( ! empty( $plugin_header['UpdateURI'] ) ) {
 			$this->add_result_error_for_file(

--- a/includes/Checker/Checks/Trademarks_Check.php
+++ b/includes/Checker/Checks/Trademarks_Check.php
@@ -277,7 +277,7 @@ class Trademarks_Check extends Abstract_File_Check {
 			require_once ABSPATH . 'wp-admin/includes/plugin.php';
 		}
 
-		$plugin_main_file = WP_PLUGIN_DIR . '/' . $result->plugin()->basename();
+		$plugin_main_file = $result->plugin()->main_file();
 		$plugin_header    = get_plugin_data( $plugin_main_file );
 
 		if ( ! empty( $plugin_header['Name'] ) ) {

--- a/includes/Checker/Checks/Trademarks_Check.php
+++ b/includes/Checker/Checks/Trademarks_Check.php
@@ -316,7 +316,7 @@ class Trademarks_Check extends Abstract_File_Check {
 				$result,
 				$e->getMessage(),
 				'trademarked_term',
-				WP_PLUGIN_DIR . '/' . $result->plugin()->basename()
+				$result->plugin()->main_file()
 			);
 		}
 	}

--- a/includes/Plugin_Context.php
+++ b/includes/Plugin_Context.php
@@ -83,7 +83,7 @@ class Plugin_Context {
 	/**
 	 * Returns the plugin main file.
 	 *
-	 * @since 1.0.0
+	 * @since 1.0.2
 	 *
 	 * @return string Plugin main file.
 	 */

--- a/includes/Plugin_Context.php
+++ b/includes/Plugin_Context.php
@@ -70,6 +70,26 @@ class Plugin_Context {
 	}
 
 	/**
+	 * Returns the plugin main file.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return string Plugin main file.
+	 */
+	public function main_file() {
+		if ( false === strpos( $this->main_file, '.php' ) ) {
+			$files = glob( $this->main_file . '/*.php' );
+			foreach ( $files as $file ) {
+				$plugin_data = get_plugin_data( $file );
+				if ( ! empty( $plugin_data['Name'] ) ) {
+					return $file;
+				}
+			}
+		}
+		return $this->main_file;
+	}
+
+	/**
 	 * Returns the absolute path for a relative path to the plugin directory.
 	 *
 	 * @since 1.0.0

--- a/includes/Plugin_Context.php
+++ b/includes/Plugin_Context.php
@@ -78,7 +78,11 @@ class Plugin_Context {
 	 * @return string Absolute path.
 	 */
 	public function path( $relative_path = '/' ) {
-		return plugin_dir_path( $this->main_file ) . ltrim( $relative_path, '/' );
+		if ( is_dir( $this->main_file ) ) {
+			return trailingslashit( $this->main_file ) . ltrim( $relative_path, '/' );
+		} else {
+			return plugin_dir_path( $this->main_file ) . ltrim( $relative_path, '/' );
+		}
 	}
 
 	/**

--- a/includes/Plugin_Context.php
+++ b/includes/Plugin_Context.php
@@ -56,6 +56,17 @@ class Plugin_Context {
 				__( 'Unknown environment, normalize_path function not found', 'plugin-check' )
 			);
 		}
+
+		if ( false === strpos( $this->main_file, '.php' ) ) {
+			$files = glob( $this->main_file . '/*.php' );
+			foreach ( $files as $file ) {
+				$plugin_data = get_plugin_data( $file );
+				if ( ! empty( $plugin_data['Name'] ) ) {
+					$this->main_file = $file;
+					break;
+				}
+			}
+		}
 	}
 
 	/**
@@ -77,15 +88,6 @@ class Plugin_Context {
 	 * @return string Plugin main file.
 	 */
 	public function main_file() {
-		if ( false === strpos( $this->main_file, '.php' ) ) {
-			$files = glob( $this->main_file . '/*.php' );
-			foreach ( $files as $file ) {
-				$plugin_data = get_plugin_data( $file );
-				if ( ! empty( $plugin_data['Name'] ) ) {
-					return $file;
-				}
-			}
-		}
 		return $this->main_file;
 	}
 

--- a/includes/Utilities/Plugin_Request_Utility.php
+++ b/includes/Utilities/Plugin_Request_Utility.php
@@ -40,12 +40,16 @@ class Plugin_Request_Utility {
 	 *
 	 * @since 1.0.0
 	 *
-	 * @param string $plugin_slug The plugin slug or basename.
+	 * @param string $plugin_slug The plugin slug, basename or arbitrary path.
 	 * @return string The plugin basename.
 	 *
 	 * @throws Exception Thrown if an invalid basename or plugin slug is provided.
 	 */
 	public static function get_plugin_basename_from_input( $plugin_slug ) {
+		if ( is_dir( $plugin_slug ) ) {
+			return $plugin_slug;
+		}
+
 		require_once ABSPATH . 'wp-admin/includes/plugin.php';
 
 		if ( empty( $plugin_slug ) ) {

--- a/includes/Utilities/Plugin_Request_Utility.php
+++ b/includes/Utilities/Plugin_Request_Utility.php
@@ -46,10 +46,6 @@ class Plugin_Request_Utility {
 	 * @throws Exception Thrown if an invalid basename or plugin slug is provided.
 	 */
 	public static function get_plugin_basename_from_input( $plugin_slug ) {
-		if ( is_dir( $plugin_slug ) ) {
-			return $plugin_slug;
-		}
-
 		require_once ABSPATH . 'wp-admin/includes/plugin.php';
 
 		if ( empty( $plugin_slug ) ) {

--- a/includes/Utilities/Plugin_Request_Utility.php
+++ b/includes/Utilities/Plugin_Request_Utility.php
@@ -40,7 +40,7 @@ class Plugin_Request_Utility {
 	 *
 	 * @since 1.0.0
 	 *
-	 * @param string $plugin_slug The plugin slug, basename or arbitrary path.
+	 * @param string $plugin_slug The plugin slug or basename.
 	 * @return string The plugin basename.
 	 *
 	 * @throws Exception Thrown if an invalid basename or plugin slug is provided.

--- a/tests/behat/features/plugin-check.feature
+++ b/tests/behat/features/plugin-check.feature
@@ -186,3 +186,35 @@ Feature: Test that the WP-CLI command works.
       """
       mt_rand() is discouraged.
       """
+
+  Scenario: Check a plugin from external location
+    Given a WP install with the Plugin Check plugin
+    And an empty external-folder/foo-plugin directory
+    And a external-folder/foo-plugin/foo-plugin.php file:
+      """
+      <?php
+      /**
+       * Plugin Name: Foo Plugin
+       * Plugin URI:  https://example.com
+       * Description:
+       * Version:     0.1.0
+       * Author:
+       * Author URI:
+       * License:     GPL-2.0+
+       * License URI: http://www.gnu.org/licenses/gpl-2.0.txt
+       * Text Domain: foo-plugin
+       * Domain Path: /languages
+       */
+
+      """
+
+    When I run the WP-CLI command `plugin check {RUN_DIR}/external-folder/foo-plugin`
+    Then STDERR should be empty
+    And STDOUT should contain:
+      """
+      trademarked_term
+      """
+    And STDOUT should contain:
+      """
+      no_plugin_readme
+      """


### PR DESCRIPTION
What we need for the [submission form from wordpress.org](https://wordpress.org/plugins/developers/add/) is run static checks in an arbitrary path. It's helpful as well for any developer user to directly run static checks in any directory.

Resolves #478 