### PR TITLE
Make default selected check category filterable

### DIFF
--- a/includes/Admin/Admin_Page.php
+++ b/includes/Admin/Admin_Page.php
@@ -310,7 +310,7 @@ final class Admin_Page {
 	 *
 	 * @return string Categories separated by double underscores.
 	 */
-	public static function get_default_check_categories_to_be_selected() {
+	public function get_default_check_categories_to_be_selected() {
 		$default_check_categories = array(
 			'plugin_repo',
 		);

--- a/includes/Admin/Admin_Page.php
+++ b/includes/Admin/Admin_Page.php
@@ -196,8 +196,8 @@ final class Admin_Page {
 
 		$category_labels = Check_Categories::get_category_labels();
 
-		// Get user settings for category preferences and set a default value to check plugin_repo by default.
-		$user_enabled_categories = get_user_setting( 'plugin_check_category_preferences', 'plugin_repo' );
+		// Get user settings for category preferences.
+		$user_enabled_categories = get_user_setting( 'plugin_check_category_preferences', $this->get_default_check_categories_to_be_selected() );
 		$user_enabled_categories = explode( '__', $user_enabled_categories );
 
 		require WP_PLUGIN_CHECK_PLUGIN_DIR_PATH . 'templates/admin-page.php';
@@ -299,5 +299,29 @@ final class Admin_Page {
 	 */
 	public function get_hook_suffix() {
 		return $this->hook_suffix;
+	}
+
+	/**
+	 * Gets default check categories to be selected.
+	 *
+	 * @since 1.0.2
+	 *
+	 * @return string Categories separated by double underscore.
+	 */
+	protected static function get_default_check_categories_to_be_selected() {
+		$default_check_categories = array(
+			'plugin_repo',
+		);
+
+		/**
+		 * Filters the default check categories to be selected.
+		 *
+		 * @since 1.0.2
+		 *
+		 * @param array $default_check_categories An array of categories.
+		 */
+		$default_categories = (array) apply_filters( 'wp_plugin_check_default_categories', $default_check_categories );
+
+		return ! empty( $default_categories ) ? implode( '__', $default_categories ) : '';
 	}
 }

--- a/includes/Admin/Admin_Page.php
+++ b/includes/Admin/Admin_Page.php
@@ -13,6 +13,8 @@ use WordPress\Plugin_Check\Checker\Check_Categories;
  * Class is handling admin tools page functionality.
  *
  * @since 1.0.0
+ *
+ * @SuppressWarnings(PHPMD.TooManyPublicMethods)
  */
 final class Admin_Page {
 
@@ -306,9 +308,9 @@ final class Admin_Page {
 	 *
 	 * @since 1.0.2
 	 *
-	 * @return string Categories separated by double underscore.
+	 * @return string Categories separated by double underscores.
 	 */
-	protected static function get_default_check_categories_to_be_selected() {
+	public static function get_default_check_categories_to_be_selected() {
 		$default_check_categories = array(
 			'plugin_repo',
 		);

--- a/includes/Admin/Admin_Page.php
+++ b/includes/Admin/Admin_Page.php
@@ -199,7 +199,7 @@ final class Admin_Page {
 		$category_labels = Check_Categories::get_category_labels();
 
 		// Get user settings for category preferences.
-		$user_enabled_categories = get_user_setting( 'plugin_check_category_preferences', $this->get_default_check_categories_to_be_selected() );
+		$user_enabled_categories = get_user_setting( 'plugin_check_category_preferences', implode( '__', $this->get_default_check_categories_to_be_selected() ) );
 		$user_enabled_categories = explode( '__', $user_enabled_categories );
 
 		require WP_PLUGIN_CHECK_PLUGIN_DIR_PATH . 'templates/admin-page.php';
@@ -308,9 +308,9 @@ final class Admin_Page {
 	 *
 	 * @since 1.0.2
 	 *
-	 * @return string Categories separated by double underscores.
+	 * @return string[] An array of category slugs.
 	 */
-	public function get_default_check_categories_to_be_selected() {
+	private function get_default_check_categories_to_be_selected() {
 		$default_check_categories = array(
 			'plugin_repo',
 		);
@@ -320,10 +320,10 @@ final class Admin_Page {
 		 *
 		 * @since 1.0.2
 		 *
-		 * @param array $default_check_categories An array of categories.
+		 * @param string[] $default_check_categories An array of category slugs.
 		 */
 		$default_categories = (array) apply_filters( 'wp_plugin_check_default_categories', $default_check_categories );
 
-		return ! empty( $default_categories ) ? implode( '__', $default_categories ) : '';
+		return $default_categories;
 	}
 }

--- a/tests/phpunit/tests/Admin/Admin_Page_Tests.php
+++ b/tests/phpunit/tests/Admin/Admin_Page_Tests.php
@@ -174,6 +174,35 @@ class Admin_Page_Tests extends WP_UnitTestCase {
 		$this->assertEmpty( $action_links );
 	}
 
+	public function test_filter_default_check_categories() {
+		$custom_categories = array(
+			'general',
+			'plugin_repo',
+		);
+
+		$filter_name = 'wp_plugin_check_default_categories';
+
+		// Create a mock filter that will return our custom categories.
+		add_filter(
+			$filter_name,
+			static function () use ( $custom_categories ) {
+				return $custom_categories;
+			}
+		);
+
+		$result = $this->admin_page->get_default_check_categories_to_be_selected();
+
+		$this->assertSame( 'general__plugin_repo', $result );
+
+		// Remove the filter to avoid interfering with other tests.
+		remove_filter(
+			$filter_name,
+			static function () use ( $custom_categories ) {
+				return $custom_categories;
+			}
+		);
+	}
+
 	/**
 	 * @dataProvider data_status_mustuse_and_dropins
 	 */

--- a/tests/phpunit/tests/Admin/Admin_Page_Tests.php
+++ b/tests/phpunit/tests/Admin/Admin_Page_Tests.php
@@ -190,9 +190,16 @@ class Admin_Page_Tests extends WP_UnitTestCase {
 			}
 		);
 
-		$result = $this->admin_page->get_default_check_categories_to_be_selected();
+		// Render the admin page.
+		ob_start();
+		$this->admin_page->render_page();
+		$output = ob_get_contents();
+		ob_end_clean();
 
-		$this->assertSame( 'general__plugin_repo', $result );
+		foreach ( $custom_categories as $category ) {
+			$this->assertStringContainsString( '<input type="checkbox" id="' . $category . '" name="categories" value="' . $category . '"  checked=\'checked\' />', $output );
+
+		}
 
 		// Remove the filter to avoid interfering with other tests.
 		remove_filter(


### PR DESCRIPTION
Related https://github.com/WordPress/plugin-check/issues/494

* Introduce filter `wp_plugin_check_default_categories`
* Add new method `get_default_check_categories_to_be_selected()` in `Admin_Page` class
* Add test for related changes