### PR TITLE
Allow registering custom categories through filter

### DIFF
--- a/includes/Admin/Admin_Page.php
+++ b/includes/Admin/Admin_Page.php
@@ -194,7 +194,7 @@ final class Admin_Page {
 
 		$selected_plugin_basename = filter_input( INPUT_GET, 'plugin', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
 
-		$category_labels = Check_Categories::get_category_labels();
+		$category_labels = Check_Categories::get_categories();
 
 		// Get user settings for category preferences and set a default value to check plugin_repo by default.
 		$user_enabled_categories = get_user_setting( 'plugin_check_category_preferences', 'plugin_repo' );

--- a/includes/Admin/Admin_Page.php
+++ b/includes/Admin/Admin_Page.php
@@ -194,7 +194,7 @@ final class Admin_Page {
 
 		$selected_plugin_basename = filter_input( INPUT_GET, 'plugin', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
 
-		$category_labels = Check_Categories::get_categories();
+		$categories = Check_Categories::get_categories();
 
 		// Get user settings for category preferences and set a default value to check plugin_repo by default.
 		$user_enabled_categories = get_user_setting( 'plugin_check_category_preferences', 'plugin_repo' );

--- a/includes/CLI/Plugin_Check_Command.php
+++ b/includes/CLI/Plugin_Check_Command.php
@@ -400,11 +400,11 @@ final class Plugin_Check_Command {
 	 */
 	private function get_check_categories() {
 		$check_categories = new Check_Categories();
-		$category_labels  = $check_categories->get_category_labels();
+		$all_categories   = $check_categories->get_categories();
 
 		$categories = array();
 
-		foreach ( $category_labels as $slug => $label ) {
+		foreach ( $all_categories as $slug => $label ) {
 			$categories[] = array(
 				'slug' => $slug,
 				'name' => $label,

--- a/includes/Checker/Check_Categories.php
+++ b/includes/Checker/Check_Categories.php
@@ -64,7 +64,7 @@ class Check_Categories {
 		 *
 		 * @since 1.0.2
 		 *
-		 * @param array $default_categories An array of check categories.
+		 * @param array<string, string> $default_categories Associative array of category slugs to labels.
 		 */
 		$check_categories = (array) apply_filters( 'wp_plugin_check_categories', $default_categories );
 

--- a/includes/Checker/Check_Categories.php
+++ b/includes/Checker/Check_Categories.php
@@ -29,13 +29,7 @@ class Check_Categories {
 	 * @return array An array of available categories.
 	 */
 	public static function get_categories() {
-		return array(
-			self::CATEGORY_GENERAL,
-			self::CATEGORY_PLUGIN_REPO,
-			self::CATEGORY_SECURITY,
-			self::CATEGORY_PERFORMANCE,
-			self::CATEGORY_ACCESSIBILITY,
-		);
+		return array_keys( self::get_check_categories() );
 	}
 
 	/**
@@ -46,13 +40,35 @@ class Check_Categories {
 	 * @return array An array of category labels.
 	 */
 	public static function get_category_labels() {
-		return array(
+		return self::get_check_categories();
+	}
+
+	/**
+	 * Returns an array of check categories.
+	 *
+	 * @since 1.0.2
+	 *
+	 * @return array An array of check categories.
+	 */
+	public static function get_check_categories() {
+		$default_categories = array(
 			self::CATEGORY_GENERAL       => __( 'General', 'plugin-check' ),
 			self::CATEGORY_PLUGIN_REPO   => __( 'Plugin Repo', 'plugin-check' ),
 			self::CATEGORY_SECURITY      => __( 'Security', 'plugin-check' ),
 			self::CATEGORY_PERFORMANCE   => __( 'Performance', 'plugin-check' ),
 			self::CATEGORY_ACCESSIBILITY => __( 'Accessibility', 'plugin-check' ),
 		);
+
+		/**
+		 * Filters the check categories.
+		 *
+		 * @since 1.0.2
+		 *
+		 * @param array $default_categories An array of check categories.
+		 */
+		$check_categories = (array) apply_filters( 'wp_plugin_check_categories', $default_categories );
+
+		return $check_categories;
 	}
 
 	/**

--- a/includes/Checker/Check_Categories.php
+++ b/includes/Checker/Check_Categories.php
@@ -28,8 +28,8 @@ class Check_Categories {
 	 *
 	 * @return array An array of available categories.
 	 */
-	public static function get_categories() {
-		return array_keys( self::get_check_categories() );
+	public static function get_category_slugs() {
+		return array_keys( self::get_categories() );
 	}
 
 	/**
@@ -40,7 +40,7 @@ class Check_Categories {
 	 * @return array An array of category labels.
 	 */
 	public static function get_category_labels() {
-		return self::get_check_categories();
+		return self::get_categories();
 	}
 
 	/**
@@ -50,7 +50,7 @@ class Check_Categories {
 	 *
 	 * @return array An array of check categories.
 	 */
-	public static function get_check_categories() {
+	public static function get_categories() {
 		$default_categories = array(
 			self::CATEGORY_GENERAL       => __( 'General', 'plugin-check' ),
 			self::CATEGORY_PLUGIN_REPO   => __( 'Plugin Repo', 'plugin-check' ),

--- a/includes/Checker/Check_Categories.php
+++ b/includes/Checker/Check_Categories.php
@@ -40,7 +40,7 @@ class Check_Categories {
 	 * @return array An array of category labels.
 	 */
 	public static function get_category_labels() {
-		return self::get_categories();
+		return array_values( self::get_categories() );
 	}
 
 	/**

--- a/templates/admin-page.php
+++ b/templates/admin-page.php
@@ -37,11 +37,11 @@
 				<span id="plugin-check__spinner" class="spinner" style="float: none;"></span>
 				<h4><?php esc_attr_e( 'Categories', 'plugin-check' ); ?></h4>
 				<?php
-				if ( ! empty( $category_labels ) ) {
+				if ( ! empty( $categories ) ) {
 				?>
 				<table>
 				<?php
-				foreach ( $category_labels as $category => $label ) { ?>
+				foreach ( $categories as $category => $label ) { ?>
 					<tr>
 						<td>
 							<fieldset>

--- a/tests/phpunit/tests/Checker/Check_Categories_Tests.php
+++ b/tests/phpunit/tests/Checker/Check_Categories_Tests.php
@@ -41,12 +41,12 @@ class Check_Categories_Tests extends WP_UnitTestCase {
 
 	public function test_get_category_labels() {
 		$check_categories = new Check_Categories();
-		$category_slugs   = $check_categories->get_category_slugs();
+		$categories       = $check_categories->get_categories();
 		$category_labels  = $check_categories->get_category_labels();
 
 		$this->assertIsArray( $category_labels );
 		$this->assertNotEmpty( $category_labels );
-		$this->assertSame( $category_slugs, array_keys( $category_labels ) );
+		$this->assertSame( $category_labels, array_values( $categories ) );
 	}
 
 	public function test_filter_check_categories() {
@@ -67,11 +67,9 @@ class Check_Categories_Tests extends WP_UnitTestCase {
 			}
 		);
 
-		$category_slugs  = $check_categories->get_category_slugs();
-		$category_labels = $check_categories->get_category_labels();
+		$categories = $check_categories->get_categories();
 
-		$this->assertSame( array_keys( $custom_categories ), $category_slugs );
-		$this->assertSame( $custom_categories, $category_labels );
+		$this->assertSame( $custom_categories, $categories );
 
 		// Remove the filter to avoid interfering with other tests.
 		remove_filter(

--- a/tests/phpunit/tests/Checker/Check_Categories_Tests.php
+++ b/tests/phpunit/tests/Checker/Check_Categories_Tests.php
@@ -28,25 +28,25 @@ class Check_Categories_Tests extends WP_UnitTestCase {
 
 	public function test_get_categories() {
 		$check_categories = new Check_Categories();
-		$categories       = $check_categories->get_categories();
+		$category_slugs   = $check_categories->get_category_slugs();
 
 		$reflection_class   = new ReflectionClass( Check_Categories::class );
 		$category_constants = $reflection_class->getConstants();
 
 		// Assert that all the CATEGORY_* constants are included in the returned categories array.
 		foreach ( $category_constants as $constant_value ) {
-			$this->assertContains( $constant_value, $categories );
+			$this->assertContains( $constant_value, $category_slugs );
 		}
 	}
 
 	public function test_get_category_labels() {
 		$check_categories = new Check_Categories();
-		$categories       = $check_categories->get_categories();
+		$category_slugs   = $check_categories->get_category_slugs();
 		$category_labels  = $check_categories->get_category_labels();
 
 		$this->assertIsArray( $category_labels );
 		$this->assertNotEmpty( $category_labels );
-		$this->assertSame( $categories, array_keys( $category_labels ) );
+		$this->assertSame( $category_slugs, array_keys( $category_labels ) );
 	}
 
 	public function test_filter_check_categories() {
@@ -67,10 +67,10 @@ class Check_Categories_Tests extends WP_UnitTestCase {
 			}
 		);
 
-		$categories      = $check_categories->get_categories();
+		$category_slugs  = $check_categories->get_category_slugs();
 		$category_labels = $check_categories->get_category_labels();
 
-		$this->assertSame( array_keys( $custom_categories ), $categories );
+		$this->assertSame( array_keys( $custom_categories ), $category_slugs );
 		$this->assertSame( $custom_categories, $category_labels );
 
 		// Remove the filter to avoid interfering with other tests.

--- a/tests/phpunit/tests/Checker/Check_Categories_Tests.php
+++ b/tests/phpunit/tests/Checker/Check_Categories_Tests.php
@@ -49,6 +49,39 @@ class Check_Categories_Tests extends WP_UnitTestCase {
 		$this->assertSame( $categories, array_keys( $category_labels ) );
 	}
 
+	public function test_filter_check_categories() {
+		$check_categories = new Check_Categories();
+
+		$custom_categories = array(
+			'first_category'  => 'First Category',
+			'second_category' => 'Second Category',
+		);
+
+		$filter_name = 'wp_plugin_check_categories';
+
+		// Create a mock filter that will return our custom categories.
+		add_filter(
+			$filter_name,
+			static function () use ( $custom_categories ) {
+				return $custom_categories;
+			}
+		);
+
+		$categories      = $check_categories->get_categories();
+		$category_labels = $check_categories->get_category_labels();
+
+		$this->assertSame( array_keys( $custom_categories ), $categories );
+		$this->assertSame( $custom_categories, $category_labels );
+
+		// Remove the filter to avoid interfering with other tests.
+		remove_filter(
+			$filter_name,
+			static function () use ( $custom_categories ) {
+				return $custom_categories;
+			}
+		);
+	}
+
 	/**
 	 * @dataProvider data_checks_by_categories
 	 */

--- a/tests/phpunit/tests/Checker/Check_Categories_Tests.php
+++ b/tests/phpunit/tests/Checker/Check_Categories_Tests.php
@@ -39,16 +39,6 @@ class Check_Categories_Tests extends WP_UnitTestCase {
 		}
 	}
 
-	public function test_get_category_labels() {
-		$check_categories = new Check_Categories();
-		$categories       = $check_categories->get_categories();
-		$category_labels  = $check_categories->get_category_labels();
-
-		$this->assertIsArray( $category_labels );
-		$this->assertNotEmpty( $category_labels );
-		$this->assertSame( $category_labels, array_values( $categories ) );
-	}
-
 	public function test_filter_check_categories() {
 		$check_categories = new Check_Categories();
 


### PR DESCRIPTION
Fixes https://github.com/WordPress/plugin-check/issues/494

* Introduce filter wp_plugin_check_categories
* Add new method `get_check_categories()` in `Check_Categories` class
* Add test for related changes

Example implementation: https://github.com/ernilambar/fresh-check/blob/main/fresh-check.php