### PR TITLE
Revert "Update yoast/phpunit-polyfills requirement from ^1.0 to ^2.0 in /build-phpunit"

### DIFF
--- a/build-phpunit/composer.json
+++ b/build-phpunit/composer.json
@@ -1,6 +1,6 @@
 {
   "require-dev": {
     "wp-phpunit/wp-phpunit": "^6.1",
-    "yoast/phpunit-polyfills": "^2.0"
+    "yoast/phpunit-polyfills": "^1.0"
   }
 }


### PR DESCRIPTION
Reverts WordPress/plugin-check#497

After the merge the unit tests goes failed so need some more debugging.