### PR TITLE
Fix `nullable is deprecated` PHP notice in 8.4

### DIFF
--- a/includes/Checker/Checks/Abstract_File_Check.php
+++ b/includes/Checker/Checks/Abstract_File_Check.php
@@ -130,7 +130,7 @@ abstract class Abstract_File_Check implements Static_Check {
 	 *                        have the text that matched the first captured parenthesized subpattern, and so on.
 	 * @return string|bool File path if a match was found, false otherwise.
 	 */
-	final protected static function file_preg_match( $pattern, array $files, array &$matches = null ) {
+	final protected static function file_preg_match( $pattern, array $files, ?array &$matches = null ) {
 		foreach ( $files as $file ) {
 			$contents = self::file_get_contents( $file );
 			if ( preg_match( $pattern, $contents, $m ) ) {

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -3,7 +3,7 @@
 	<description>Sniffs for WordPress plugins, with minor modifications for Performance</description>
 
 	<rule ref="PHPCompatibility"/>
-	<config name="testVersion" value="7.0-"/>
+	<config name="testVersion" value="7.2-"/>
 
 	<rule ref="WordPress-Core">
 		<exclude name="WordPress.Files.FileName"/>


### PR DESCRIPTION
Fixes https://github.com/WordPress/plugin-check/issues/534

* This will fix `nullable is deprecated` notice in PHP 8.4 

