### PR TITLE
Support passing a URL for individual check results

### DIFF
--- a/assets/js/plugin-check-admin.js
+++ b/assets/js/plugin-check-admin.js
@@ -431,6 +431,7 @@
 			for ( const column in results[ line ] ) {
 				for ( let i = 0; i < results[ line ][ column ].length; i++ ) {
 					const message = results[ line ][ column ][ i ].message;
+					const docs = results[ line ][ column ][ i ].docs;
 					const code = results[ line ][ column ][ i ].code;
 					const link = results[ line ][ column ][ i ].link;
 
@@ -441,6 +442,7 @@
 							column,
 							type,
 							message,
+							docs,
 							code,
 							link,
 							hasLinks,

--- a/includes/CLI/Plugin_Check_Command.php
+++ b/includes/CLI/Plugin_Check_Command.php
@@ -485,6 +485,7 @@ final class Plugin_Check_Command {
 			'column',
 			'code',
 			'message',
+			'docs',
 		);
 
 		// If both errors and warnings are included, display the type of each result too.
@@ -495,6 +496,7 @@ final class Plugin_Check_Command {
 				'type',
 				'code',
 				'message',
+				'docs',
 			);
 		}
 
@@ -518,6 +520,8 @@ final class Plugin_Check_Command {
 		foreach ( $file_errors as $line => $line_errors ) {
 			foreach ( $line_errors as $column => $column_errors ) {
 				foreach ( $column_errors as $column_error ) {
+
+					$column_error['message'] = str_replace( '<br>', "\n", $column_error['message'] );
 
 					$file_results[] = array_merge(
 						$column_error,

--- a/includes/Checker/Check_Result.php
+++ b/includes/Checker/Check_Result.php
@@ -100,6 +100,7 @@ final class Check_Result {
 			'line'   => 0,
 			'column' => 0,
 			'link'   => '',
+			'docs'   => '',
 		);
 
 		$data = array_merge(

--- a/includes/Checker/Checks/Plugin_Repo/Plugin_Readme_Check.php
+++ b/includes/Checker/Checks/Plugin_Repo/Plugin_Readme_Check.php
@@ -162,13 +162,17 @@ class Plugin_Readme_Check extends Abstract_File_Check {
 						$this->add_result_error_for_file(
 							$result,
 							sprintf(
-								/* translators: 1: currently used version, 2: latest stable WordPress version */
-								__( 'Tested up to: %1$s < %2$s', 'plugin-check' ),
+								/* translators: 1: currently used version, 2: latest stable WordPress version, 3: 'Tested up to' */
+								__( 'Tested up to: %1$s < %2$s.<br>The "%3$s" value in your plugin is not set to the current version of WordPress. This means your plugin will not show up in searches, as we require plugins to be compatible and documented as tested up to the most recent version of WordPress.', 'plugin-check' ),
 								$parser->{$field_key},
-								$latest_wordpress_version
+								$latest_wordpress_version,
+								'Tested up to'
 							),
 							'outdated_tested_upto_header',
-							$readme_file
+							$readme_file,
+							0,
+							0,
+							'https://developer.wordpress.org/plugins/wordpress-org/how-your-readme-txt-works/#readme-header-information'
 						);
 					}
 				} else {

--- a/includes/Checker/Checks/Plugin_Repo/Plugin_Readme_Check.php
+++ b/includes/Checker/Checks/Plugin_Repo/Plugin_Readme_Check.php
@@ -163,7 +163,7 @@ class Plugin_Readme_Check extends Abstract_File_Check {
 							$result,
 							sprintf(
 								/* translators: 1: currently used version, 2: latest stable WordPress version, 3: 'Tested up to' */
-								__( 'Tested up to: %1$s < %2$s.<br>The "%3$s" value in your plugin is not set to the current version of WordPress. This means your plugin will not show up in searches, as we require plugins to be compatible and documented as tested up to the most recent version of WordPress.', 'plugin-check' ),
+								__( '<strong>Tested up to: %1$s < %2$s.</strong><br>The "%3$s" value in your plugin is not set to the current version of WordPress. This means your plugin will not show up in searches, as we require plugins to be compatible and documented as tested up to the most recent version of WordPress.', 'plugin-check' ),
 								$parser->{$field_key},
 								$latest_wordpress_version,
 								'Tested up to'

--- a/includes/Traits/Amend_Check_Result.php
+++ b/includes/Traits/Amend_Check_Result.php
@@ -23,15 +23,16 @@ trait Amend_Check_Result {
 	 *
 	 * @since 1.0.0
 	 *
-	 * @param Check_Result $result  The check result to amend, including the plugin context to check.
-	 * @param bool         $error   Whether it is an error or notice.
-	 * @param string       $message Error message.
-	 * @param string       $code    Error code.
-	 * @param string       $file    Absolute path to the file where the issue was found.
-	 * @param int          $line    The line on which the message occurred. Default is 0 (unknown line).
-	 * @param int          $column  The column on which the message occurred. Default is 0 (unknown column).
+	 * @param Check_Result $result    The check result to amend, including the plugin context to check.
+	 * @param bool         $error     Whether it is an error or notice.
+	 * @param string       $message   Error message.
+	 * @param string       $code      Error code.
+	 * @param string       $file      Absolute path to the file where the issue was found.
+	 * @param int          $line      The line on which the message occurred. Default is 0 (unknown line).
+	 * @param int          $column    The column on which the message occurred. Default is 0 (unknown column).
+	 * @param string       $docs      URL for further information about the message.
 	 */
-	protected function add_result_message_for_file( Check_Result $result, $error, $message, $code, $file, $line = 0, $column = 0 ) {
+	protected function add_result_message_for_file( Check_Result $result, $error, $message, $code, $file, $line = 0, $column = 0, string $docs = '' ) {
 		$result->add_message(
 			(bool) $error,
 			$message,
@@ -41,6 +42,7 @@ trait Amend_Check_Result {
 				'line'   => $line,
 				'column' => $column,
 				'link'   => $this->get_file_editor_url( $result, $file, $line ),
+				'docs'   => $docs,
 			)
 		);
 	}
@@ -56,9 +58,10 @@ trait Amend_Check_Result {
 	 * @param string       $file    Absolute path to the file where the error was found.
 	 * @param int          $line    The line on which the error occurred. Default is 0 (unknown line).
 	 * @param int          $column  The column on which the error occurred. Default is 0 (unknown column).
+	 * @param string       $docs    URL for further information about the message.
 	 */
-	protected function add_result_error_for_file( Check_Result $result, $message, $code, $file, $line = 0, $column = 0 ) {
-		$this->add_result_message_for_file( $result, true, $message, $code, $file, $line, $column );
+	protected function add_result_error_for_file( Check_Result $result, $message, $code, $file, $line = 0, $column = 0, string $docs = '' ) {
+		$this->add_result_message_for_file( $result, true, $message, $code, $file, $line, $column, $docs );
 	}
 
 	/**
@@ -72,8 +75,9 @@ trait Amend_Check_Result {
 	 * @param string       $file    Absolute path to the file where the warning was found.
 	 * @param int          $line    The line on which the warning occurred. Default is 0 (unknown line).
 	 * @param int          $column  The column on which the warning occurred. Default is 0 (unknown column).
+	 * @param string       $docs    URL for further information about the message.
 	 */
-	protected function add_result_warning_for_file( Check_Result $result, $message, $code, $file, $line = 0, $column = 0 ) {
-		$this->add_result_message_for_file( $result, false, $message, $code, $file, $line, $column );
+	protected function add_result_warning_for_file( Check_Result $result, $message, $code, $file, $line = 0, $column = 0, string $docs = '' ) {
+		$this->add_result_message_for_file( $result, false, $message, $code, $file, $line, $column, $docs );
 	}
 }

--- a/templates/results-row.php
+++ b/templates/results-row.php
@@ -12,7 +12,15 @@
 		{{data.code}}
 	</td>
 	<td>
-		{{data.message}}
+		{{{data.message}}}
+		<# if ( data.docs ) { #>
+			<br>
+			<a href="{{data.docs}}" target="_blank">
+				<?php esc_html_e( 'Learn more', 'plugin-check' ); ?>
+				<span class="screen-reader-text"><?php esc_html_e( '(opens in a new tab)', 'plugin-check' ); ?></span>
+				<span aria-hidden="true" class="dashicons dashicons-external"></span>
+			</a>
+		<# } #>
 	</td>
 	<# if ( data.hasLinks ) { #>
 		<td>
@@ -20,6 +28,7 @@
 				<a href="{{data.link}}" target="_blank">
 					<?php esc_html_e( 'View in code editor', 'plugin-check' ); ?>
 					<span class="screen-reader-text"><?php esc_html_e( '(opens in a new tab)', 'plugin-check' ); ?></span>
+					<span aria-hidden="true" class="dashicons dashicons-external"></span>
 				</a>
 			<# } #>
 		</td>

--- a/tests/behat/features/plugin-check.feature
+++ b/tests/behat/features/plugin-check.feature
@@ -55,8 +55,8 @@ Feature: Test that the WP-CLI command works.
     When I run the WP-CLI command `plugin check foo-single.php --format=csv`
     Then STDOUT should contain:
       """
-      line,column,type,code,message
-      16,15,ERROR,WordPress.WP.AlternativeFunctions.rand_mt_rand,"mt_rand() is discouraged. Use the far less predictable wp_rand() instead."
+      line,column,type,code,message,docs
+      16,15,ERROR,WordPress.WP.AlternativeFunctions.rand_mt_rand,"mt_rand() is discouraged. Use the far less predictable wp_rand() instead.",
       """
 
     When I run the WP-CLI command `plugin check foo-single.php --format=csv --fields=line,column,code`

--- a/tests/behat/features/plugin-check.feature
+++ b/tests/behat/features/plugin-check.feature
@@ -69,7 +69,7 @@ Feature: Test that the WP-CLI command works.
     When I run the WP-CLI command `plugin check foo-single.php --format=json`
     Then STDOUT should contain:
       """
-      {"line":16,"column":15,"type":"ERROR","code":"WordPress.WP.AlternativeFunctions.rand_mt_rand","message":"mt_rand() is discouraged. Use the far less predictable wp_rand() instead."}
+      {"line":16,"column":15,"type":"ERROR","code":"WordPress.WP.AlternativeFunctions.rand_mt_rand","message":"mt_rand() is discouraged. Use the far less predictable wp_rand() instead.","docs":""}
       """
 
     When I run the WP-CLI command `plugin check foo-single.php --ignore-errors`

--- a/tests/phpunit/tests/Checker/Check_Result_Tests.php
+++ b/tests/phpunit/tests/Checker/Check_Result_Tests.php
@@ -60,6 +60,7 @@ class Check_Result_Tests extends WP_UnitTestCase {
 			'message' => 'Warning message',
 			'code'    => 'test_warning',
 			'link'    => '',
+			'docs'    => '',
 		);
 
 		$this->assertEquals( $expected, $warnings['test-plugin.php'][12][40][0] );
@@ -94,6 +95,7 @@ class Check_Result_Tests extends WP_UnitTestCase {
 			'message' => 'Error message',
 			'code'    => 'test_error',
 			'link'    => '',
+			'docs'    => '',
 		);
 
 		$this->assertEquals( $expected, $errors['test-plugin.php'][22][30][0] );
@@ -125,6 +127,7 @@ class Check_Result_Tests extends WP_UnitTestCase {
 			'message' => 'Error message',
 			'code'    => 'test_error',
 			'link'    => '',
+			'docs'    => '',
 		);
 
 		$this->assertEquals( $expected, $errors['test-plugin.php'][22][30][0] );
@@ -156,6 +159,7 @@ class Check_Result_Tests extends WP_UnitTestCase {
 			'message' => 'Warning message',
 			'code'    => 'test_warning',
 			'link'    => '',
+			'docs'    => '',
 		);
 
 		$this->assertEquals( $expected, $warnings['test-plugin.php'][22][30][0] );


### PR DESCRIPTION
Follow-up to #461, see #316. Fixes #355 by not escaping the result message in the admin.

Specifically implements [this suggestion](https://github.com/WordPress/plugin-check/pull/461#issuecomment-2258578037). Here's a screenshot:

<img width="1549" alt="Screenshot 2024-07-31 at 11 16 32" src="https://github.com/user-attachments/assets/aa46793a-c943-455e-9775-93767c594bc2">

It's up to the team to add longer error messages and add docs URLs where applicable (either in this PR or new PRs).