### PR TITLE
Prevent that runtime checks are allowed in CLI context when they cannot be used

### DIFF
--- a/includes/Checker/Abstract_Check_Runner.php
+++ b/includes/Checker/Abstract_Check_Runner.php
@@ -416,14 +416,11 @@ abstract class Abstract_Check_Runner implements Check_Runner {
 	 * @throws Exception Thrown when invalid flag is passed, or Check slug does not exist.
 	 */
 	final public function get_checks_to_run() {
-		// Include file to use is_plugin_active() in CLI context.
-		require_once ABSPATH . 'wp-admin/includes/plugin.php';
-
 		$check_slugs = $this->get_check_slugs();
 		$check_flags = Check_Repository::TYPE_STATIC;
 
 		// Check if conditions are met in order to perform Runtime Checks.
-		if ( ( $this->initialized_early || $this->runtime_environment->can_set_up() ) && is_plugin_active( $this->get_plugin_basename() ) ) {
+		if ( $this->allow_runtime_checks() ) {
 			$check_flags = Check_Repository::TYPE_ALL;
 		}
 
@@ -446,6 +443,21 @@ abstract class Abstract_Check_Runner implements Check_Runner {
 		}
 
 		return $collection->to_map();
+	}
+
+	/**
+	 * Checks whether the current environment allows for runtime checks to be used.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @return bool True if runtime checks are allowed, false otherwise.
+	 */
+	protected function allow_runtime_checks(): bool {
+		// Ensure that is_plugin_active() is available.
+		require_once ABSPATH . 'wp-admin/includes/plugin.php';
+
+		return ( $this->initialized_early || $this->runtime_environment->can_set_up() )
+			&& is_plugin_active( $this->get_plugin_basename() );
 	}
 
 	/**

--- a/includes/Checker/CLI_Runner.php
+++ b/includes/Checker/CLI_Runner.php
@@ -154,4 +154,23 @@ class CLI_Runner extends Abstract_Check_Runner {
 
 		return $categories;
 	}
+
+	/**
+	 * Checks whether the current environment allows for runtime checks to be used.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @return bool True if runtime checks are allowed, false otherwise.
+	 */
+	protected function allow_runtime_checks(): bool {
+		/*
+		 * For WP-CLI, everything happens in one request. So if the runner was not initialized early, we won't be
+		 * able to set that up, since the object-cache.php drop-in would only become effective in subsequent requests.
+		 */
+		if ( ! $this->initialized_early ) {
+			return false;
+		}
+
+		return parent::allow_runtime_checks();
+	}
 }


### PR DESCRIPTION
The `Abstract_Check_Runner::get_checks_to_run()` method has logic to determine whether to allow runtime checks, depending on the environment. Generally, runtime checks can only be used if the `object-cache.php` drop-in is already present (which will lead to early initialization) or if we know that the `object-cache.php` file _can_ be placed.

This works as expected for the WP Admin flow, but not for WP-CLI: In WP-CLI, everything happens in a single request, so we can't just place the `object-cache.php` drop-in later. This means PCP will currently attempt to include runtime checks in WP-CLI context even when it should not.

This PR fixes this by moving the logic into its own method, which the `CLI_Runner` class then overrides to make the logic "stricter": It can only use runtime checks if the `object-cache.php` drop-in is already present, i.e. the runner was initialized early.