### PR TITLE
Add admin notice for live preview blueprint

### DIFF
--- a/.wordpress-org/blueprints/blueprint.json
+++ b/.wordpress-org/blueprints/blueprint.json
@@ -19,6 +19,11 @@
       "options": {
         "activate": true
       }
+    },
+    {
+      "step": "writeFile",
+      "path": "/wordpress/wp-content/mu-plugins/playground-notice.php",
+      "data": "<?php add_action( 'admin_notices', function() { echo '<div class=\"notice notice-info is-dismissible\"><p>This is a live preview of <strong>Plugin Check</strong>, powered by <a href=\"https://wordpress.org/playground/\" target=\"_blank\">WordPress Playground</a>.</p></div>'; } );"
     }
   ]
 }


### PR DESCRIPTION
This pull request introduces an admin notice to the live preview blueprint, designed to remind users that they are viewing a preview and to highlight the Playground feature.

![Huzaifa-20240902094322](https://github.com/user-attachments/assets/4921e96c-4e02-45b8-9ae3-4b6c434f0e7a)


### Testing Instructions:
To test this feature:
1. Navigate to the [Blueprint Builder](https://playground.wordpress.net/builder/builder.html) tool.
2. Replace the default JSON with the `blueprint.json` file from this plugin.
3. Click `Run It` to see the preview in action.
