### PR TITLE
Improve `active_plugins` filter

### DIFF
--- a/includes/Checker/Abstract_Check_Runner.php
+++ b/includes/Checker/Abstract_Check_Runner.php
@@ -10,6 +10,7 @@ namespace WordPress\Plugin_Check\Checker;
 use Exception;
 use WordPress\Plugin_Check\Checker\Preparations\Universal_Runtime_Preparation;
 use WordPress\Plugin_Check\Utilities\Plugin_Request_Utility;
+use WP_CLI;
 
 /**
  * Abstract Check Runner class.
@@ -293,9 +294,17 @@ abstract class Abstract_Check_Runner implements Check_Runner {
 	final public function prepare() {
 		$cleanup_functions = array();
 
-		if ( $this->has_runtime_check( $this->get_checks_to_run() ) ) {
-			$preparation         = new Universal_Runtime_Preparation( $this->get_check_context() );
-			$cleanup_functions[] = $preparation->prepare();
+		try {
+			if ( $this->has_runtime_check( $this->get_checks_to_run() ) ) {
+				$preparation         = new Universal_Runtime_Preparation( $this->get_check_context() );
+				$cleanup_functions[] = $preparation->prepare();
+			}
+		} catch ( Exception $error ) {
+			if ( defined( 'WP_CLI' ) && WP_CLI ) {
+				WP_CLI::error( $error->getMessage() );
+			} else {
+				throw $error;
+			}
 		}
 
 		if ( $this->delete_plugin_folder ) {

--- a/includes/Checker/Preparations/Force_Single_Plugin_Preparation.php
+++ b/includes/Checker/Preparations/Force_Single_Plugin_Preparation.php
@@ -129,8 +129,7 @@ class Force_Single_Plugin_Preparation implements Preparation {
 				array_filter(
 					WP_Plugin_Dependencies::get_dependents( dirname( $plugin_check_basename ) ),
 					static function ( $dependent ) use ( $active_plugins, $new_active_plugins ) {
-						return in_array( $dependent, $active_plugins, true ) ||
-								in_array( $dependent, $new_active_plugins, true );
+						return in_array( $dependent, $active_plugins, true );
 					}
 				)
 			);

--- a/includes/Checker/Preparations/Force_Single_Plugin_Preparation.php
+++ b/includes/Checker/Preparations/Force_Single_Plugin_Preparation.php
@@ -103,8 +103,7 @@ class Force_Single_Plugin_Preparation implements Preparation {
 		if ( defined( 'WP_PLUGIN_CHECK_MAIN_FILE' ) ) {
 			$plugin_check_file = WP_PLUGIN_CHECK_MAIN_FILE;
 		} else {
-			$plugins_dir       = defined( 'WP_PLUGIN_DIR' ) ? WP_PLUGIN_DIR : WP_CONTENT_DIR . '/plugins';
-			$plugin_check_file = $plugins_dir . '/plugin-check/plugin.php';
+			$plugin_check_file = basename( dirname( __DIR__, 3 ) ) . '/plugin.php';
 		}
 
 		$plugin_check_basename = plugin_basename( $plugin_check_file );

--- a/includes/Checker/Preparations/Force_Single_Plugin_Preparation.php
+++ b/includes/Checker/Preparations/Force_Single_Plugin_Preparation.php
@@ -127,7 +127,7 @@ class Force_Single_Plugin_Preparation implements Preparation {
 				// Include any dependents of Plugin Check, but only if they were already active.
 				array_filter(
 					WP_Plugin_Dependencies::get_dependents( dirname( $plugin_check_basename ) ),
-					static function ( $dependent ) use ( $active_plugins, $new_active_plugins ) {
+					static function ( $dependent ) use ( $active_plugins ) {
 						return in_array( $dependent, $active_plugins, true );
 					}
 				)

--- a/includes/Checker/Preparations/Force_Single_Plugin_Preparation.php
+++ b/includes/Checker/Preparations/Force_Single_Plugin_Preparation.php
@@ -113,24 +113,27 @@ class Force_Single_Plugin_Preparation implements Preparation {
 			$plugin_check_basename, // Plugin Check itself.
 		);
 
-		WP_Plugin_Dependencies::initialize();
+		// Plugin dependencies support was added in WordPress 6.5.
+		if ( class_exists( 'WP_Plugin_Dependencies' ) ) {
+			WP_Plugin_Dependencies::initialize();
 
-		$new_active_plugins = array_merge(
-			$new_active_plugins,
-			WP_Plugin_Dependencies::get_dependencies( $this->plugin_basename )
-		);
+			$new_active_plugins = array_merge(
+				$new_active_plugins,
+				WP_Plugin_Dependencies::get_dependencies( $this->plugin_basename )
+			);
 
-		$new_active_plugins = array_merge(
-			$new_active_plugins,
-			// Include any dependents of Plugin Check, but only if they were already active.
-			array_filter(
-				WP_Plugin_Dependencies::get_dependents( dirname( $plugin_check_basename ) ),
-				static function ( $dependent ) use ( $active_plugins, $new_active_plugins ) {
-					return in_array( $dependent, $active_plugins, true ) ||
-							in_array( $dependent, $new_active_plugins, true );
-				}
-			)
-		);
+			$new_active_plugins = array_merge(
+				$new_active_plugins,
+				// Include any dependents of Plugin Check, but only if they were already active.
+				array_filter(
+					WP_Plugin_Dependencies::get_dependents( dirname( $plugin_check_basename ) ),
+					static function ( $dependent ) use ( $active_plugins, $new_active_plugins ) {
+						return in_array( $dependent, $active_plugins, true ) ||
+								in_array( $dependent, $new_active_plugins, true );
+					}
+				)
+			);
+		}
 
 		// Removes duplicates, for example if Plugin Check is the plugin being tested.
 		return array_unique( $new_active_plugins );

--- a/includes/Checker/Preparations/Force_Single_Plugin_Preparation.php
+++ b/includes/Checker/Preparations/Force_Single_Plugin_Preparation.php
@@ -9,6 +9,7 @@ namespace WordPress\Plugin_Check\Checker\Preparations;
 
 use Exception;
 use WordPress\Plugin_Check\Checker\Preparation;
+use WP_Plugin_Dependencies;
 
 /**
  * Class for the preparation to force the plugin to be checked as the only active plugin.
@@ -20,7 +21,7 @@ use WordPress\Plugin_Check\Checker\Preparation;
 class Force_Single_Plugin_Preparation implements Preparation {
 
 	/**
-	 * Plugin slug.
+	 * Plugin slug of the plugin to check.
 	 *
 	 * @since 1.0.0
 	 * @var string
@@ -74,39 +75,64 @@ class Force_Single_Plugin_Preparation implements Preparation {
 	}
 
 	/**
-	 * Filter active plugins.
+	 * Filters active plugins to only include required ones.
+	 *
+	 * This means:
+	 *
+	 * * The plugin being tested
+	 * * All dependencies of the plugin being tested
+	 * * Plugin Check itself
+	 * * All plugins depending on Plugin Check (they could be adding new checks)
 	 *
 	 * @since 1.0.0
 	 *
-	 * @param array $active_plugins List of active plugins.
-	 * @return array List of active plugins.
+	 * @param mixed $active_plugins List of active plugins.
+	 * @return mixed List of active plugins.
 	 */
 	public function filter_active_plugins( $active_plugins ) {
-		if ( is_array( $active_plugins ) && in_array( $this->plugin_basename, $active_plugins, true ) ) {
-
-			if ( defined( 'WP_PLUGIN_CHECK_MAIN_FILE' ) ) {
-				$plugin_check_file = WP_PLUGIN_CHECK_MAIN_FILE;
-			} else {
-				$plugins_dir       = defined( 'WP_PLUGIN_DIR' ) ? WP_PLUGIN_DIR : WP_CONTENT_DIR . '/plugins';
-				$plugin_check_file = $plugins_dir . '/plugin-check/plugin.php';
-			}
-
-			$plugin_base_file = plugin_basename( $plugin_check_file );
-
-			// If the plugin-check is the only available plugin then return that one only.
-			if ( $this->plugin_basename === $plugin_base_file ) {
-
-				return array(
-					$plugin_base_file,
-				);
-			}
-
-			return array(
-				$this->plugin_basename,
-				$plugin_base_file,
-			);
+		if ( ! is_array( $active_plugins ) ) {
+			return $active_plugins;
 		}
 
-		return $active_plugins;
+		// The plugin being tested isn't actually active yet.
+		if ( ! in_array( $this->plugin_basename, $active_plugins, true ) ) {
+			return $active_plugins;
+		}
+
+		if ( defined( 'WP_PLUGIN_CHECK_MAIN_FILE' ) ) {
+			$plugin_check_file = WP_PLUGIN_CHECK_MAIN_FILE;
+		} else {
+			$plugins_dir       = defined( 'WP_PLUGIN_DIR' ) ? WP_PLUGIN_DIR : WP_CONTENT_DIR . '/plugins';
+			$plugin_check_file = $plugins_dir . '/plugin-check/plugin.php';
+		}
+
+		$plugin_check_basename = plugin_basename( $plugin_check_file );
+
+		$new_active_plugins = array(
+			$this->plugin_basename, // Plugin to test.
+			$plugin_check_basename, // Plugin Check itself.
+		);
+
+		WP_Plugin_Dependencies::initialize();
+
+		$new_active_plugins = array_merge(
+			$new_active_plugins,
+			WP_Plugin_Dependencies::get_dependencies( $this->plugin_basename )
+		);
+
+		$new_active_plugins = array_merge(
+			$new_active_plugins,
+			// Include any dependents of Plugin Check, but only if they were already active.
+			array_filter(
+				WP_Plugin_Dependencies::get_dependents( dirname( $plugin_check_basename ) ),
+				static function ( $dependent ) use ( $active_plugins, $new_active_plugins ) {
+					return in_array( $dependent, $active_plugins, true ) ||
+							in_array( $dependent, $new_active_plugins, true );
+				}
+			)
+		);
+
+		// Removes duplicates, for example if Plugin Check is the plugin being tested.
+		return array_unique( $new_active_plugins );
 	}
 }

--- a/includes/Checker/Preparations/Force_Single_Plugin_Preparation.php
+++ b/includes/Checker/Preparations/Force_Single_Plugin_Preparation.php
@@ -85,6 +85,7 @@ class Force_Single_Plugin_Preparation implements Preparation {
 	 * * All plugins depending on Plugin Check (they could be adding new checks)
 	 *
 	 * @since 1.0.0
+	 * @since 1.2.0 Now includes dependencies and dependents.
 	 *
 	 * @param mixed $active_plugins List of active plugins.
 	 * @return mixed List of active plugins.

--- a/tests/behat/features/plugin-check.feature
+++ b/tests/behat/features/plugin-check.feature
@@ -440,6 +440,20 @@ Feature: Test that the WP-CLI command works.
     Given a WP install with the Plugin Check plugin
     And a Plugin Check add-on being installed
 
+    And a wp-content/plugins/foo-dependency/foo-dependency.php file:
+      """
+      <?php
+      /**
+       * Plugin Name: Foo Dependency
+       * Plugin URI: https://example.com
+       * Description: Sample plugin.
+       * Version: 0.1.0
+       * Author: WordPress Performance Team
+       * Author URI: https://make.wordpress.org/performance/
+       * License: GPL-2.0+
+       * License URI: https://www.gnu.org/licenses/gpl-2.0.txt
+       */
+      """
     And a wp-content/plugins/foo-sample/foo-sample.php file:
       """
       <?php
@@ -451,7 +465,8 @@ Feature: Test that the WP-CLI command works.
        * Author: WordPress Performance Team
        * Author URI: https://make.wordpress.org/performance/
        * License: GPL-2.0+
-       * License URI: http://www.gnu.org/licenses/gpl-2.0.txt
+       * License URI: https://www.gnu.org/licenses/gpl-2.0.txt
+       * Requires Plugins: foo-dependency
        */
 
       // This should trigger the error.
@@ -462,7 +477,7 @@ Feature: Test that the WP-CLI command works.
         }
       );
       """
-    And I run the WP-CLI command `plugin activate foo-sample`
+    And I run the WP-CLI command `plugin activate foo-dependency foo-sample`
 
     # Running runtime checks, including the one from pcp-addon
     When I run the WP-CLI command `plugin check foo-sample --fields=code,type --format=csv --require=./wp-content/plugins/plugin-check/cli.php`


### PR DESCRIPTION
See #518 and #597.

Filters active plugins to only include required ones. This means:

* The plugin being tested
* All dependencies of the plugin being tested
* Plugin Check itself
* All active dependents of Plugin Check (they could be adding new checks)

To-do:

* [x] Add Behat tests (ideally after #518 is merged).
	* IMO such end-to-end tests are best for testing this scenario.