### PR TITLE
Allow runtime initialization even when only addon checks are requested

### DIFF
--- a/includes/Checker/Check_Collection.php
+++ b/includes/Checker/Check_Collection.php
@@ -9,8 +9,8 @@ namespace WordPress\Plugin_Check\Checker;
 
 use ArrayAccess;
 use Countable;
-use Exception;
 use IteratorAggregate;
+use WordPress\Plugin_Check\Checker\Exception\Invalid_Check_Slug_Exception;
 
 /**
  * Check Collection interface.
@@ -82,7 +82,7 @@ interface Check_Collection extends ArrayAccess, Countable, IteratorAggregate {
 	 * @param array $check_slugs List of slugs to limit to only those. If empty, the same collection is returned.
 	 * @return Check_Collection The unchanged check collection.
 	 *
-	 * @throws Exception Thrown when any of the given check slugs is not present in the collection.
+	 * @throws Invalid_Check_Slug_Exception Thrown when any of the given check slugs is not present in the collection.
 	 */
 	public function require( array $check_slugs ): Check_Collection;
 }

--- a/includes/Checker/Default_Check_Collection.php
+++ b/includes/Checker/Default_Check_Collection.php
@@ -8,8 +8,8 @@
 namespace WordPress\Plugin_Check\Checker;
 
 use ArrayIterator;
-use Exception;
 use Traversable;
+use WordPress\Plugin_Check\Checker\Exception\Invalid_Check_Slug_Exception;
 
 /**
  * Default Check Collection class.
@@ -150,12 +150,12 @@ class Default_Check_Collection implements Check_Collection {
 	 * @param array $check_slugs List of slugs to limit to only those. If empty, the same collection is returned.
 	 * @return Check_Collection The unchanged check collection.
 	 *
-	 * @throws Exception Thrown when any of the given check slugs is not present in the collection.
+	 * @throws Invalid_Check_Slug_Exception Thrown when any of the given check slugs is not present in the collection.
 	 */
 	public function require( array $check_slugs ): Check_Collection {
 		foreach ( $check_slugs as $slug ) {
 			if ( ! isset( $this->checks[ $slug ] ) ) {
-				throw new Exception(
+				throw new Invalid_Check_Slug_Exception(
 					sprintf(
 						/* translators: %s: The Check slug. */
 						__( 'Check with the slug "%s" does not exist.', 'plugin-check' ),

--- a/includes/Checker/Exception/Invalid_Check_Slug_Exception.php
+++ b/includes/Checker/Exception/Invalid_Check_Slug_Exception.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * Class WordPress\Plugin_Check\Checker\Exception\Invalid_Check_Slug_Exception
+ *
+ * @package plugin-check
+ */
+
+namespace WordPress\Plugin_Check\Checker\Exception;
+
+use InvalidArgumentException;
+
+/**
+ * Class for an exception thrown when an invalid check slug is provided.
+ *
+ * @since n.e.x.t
+ */
+class Invalid_Check_Slug_Exception extends InvalidArgumentException {
+
+}

--- a/tests/behat/features/plugin-check.feature
+++ b/tests/behat/features/plugin-check.feature
@@ -514,8 +514,16 @@ Feature: Test that the WP-CLI command works.
       WordPress.WP.EnqueuedResourceParameters.NotInFooter,WARNING
       """
 
-# This doesn't currently work, because we are not actually loading any other plugins, including pcp-addon.
+    # This doesn't currently work, because we are not actually loading any other plugins, including pcp-addon.
 #    And STDOUT should contain:
+#      """
+#      ExampleRuntimeCheck.ForbiddenScript,WARNING
+#      """
+
+    # This doesn't currently work.
+    # Run one runtime check from PCP and one from pcp-addon.
+#    When I run the WP-CLI command `plugin check foo-sample --checks=non_blocking_scripts,example_runtime --fields=code,type --format=csv --require=./wp-content/plugins/plugin-check/cli.php`
+#    Then STDOUT should contain:
 #      """
 #      ExampleRuntimeCheck.ForbiddenScript,WARNING
 #      """


### PR DESCRIPTION
This should fix the 3rd problem outlined in https://github.com/WordPress/plugin-check/issues/597#issuecomment-2327483452. Also see [explanation of the approach](https://github.com/WordPress/plugin-check/issues/597#issuecomment-2332289958).

Note that this will only make sense to be tested in combination with #608.