### PR TITLE
Improve check for Requires Plugins header

### DIFF
--- a/includes/Checker/Checks/Plugin_Repo/Plugin_Header_Fields_Check.php
+++ b/includes/Checker/Checks/Plugin_Repo/Plugin_Header_Fields_Check.php
@@ -211,7 +211,7 @@ class Plugin_Header_Fields_Check implements Static_Check {
 		}
 
 		if ( ! empty( $plugin_header['RequiresPlugins'] ) ) {
-			if ( ! preg_match( '/^[a-z0-9-]+(?:,[a-z0-9-]+)*$/', $plugin_header['RequiresPlugins'] ) ) {
+			if ( ! preg_match( '/^[a-z0-9-]+(?:,\s*[a-z0-9-]+)*$/', $plugin_header['RequiresPlugins'] ) ) {
 				$this->add_result_warning_for_file(
 					$result,
 					sprintf(

--- a/tests/phpunit/testdata/plugins/test-plugin-unfiltered-uploads-with-errors/load.php
+++ b/tests/phpunit/testdata/plugins/test-plugin-unfiltered-uploads-with-errors/load.php
@@ -11,6 +11,7 @@
  * License: GPLv2 or later
  * License URI: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
  * Text Domain: test-plugin-unfiltered-uploads-errors
+ * Requires Plugins: woocommerce, contact-form-7
  *
  * @package test-plugin-unfiltered-uploads-errors
  */

--- a/tests/phpunit/tests/Checker/Checks/Plugin_Header_Fields_Check_Tests.php
+++ b/tests/phpunit/tests/Checker/Checks/Plugin_Header_Fields_Check_Tests.php
@@ -34,4 +34,23 @@ class Plugin_Header_Fields_Check_Tests extends WP_UnitTestCase {
 			$this->assertCount( 1, wp_list_filter( $warnings['load.php'][0][0], array( 'code' => 'plugin_header_invalid_requires_plugins' ) ) );
 		}
 	}
+
+	public function test_run_with_valid_requires_plugins_header() {
+		/*
+		 * Test plugin has following valid header.
+		 * Requires Plugins: woocommerce, contact-form-7
+		 */
+
+		$check         = new Plugin_Header_Fields_Check();
+		$check_context = new Check_Context( UNIT_TESTS_PLUGIN_DIR . 'test-plugin-unfiltered-uploads-with-errors/load.php' );
+		$check_result  = new Check_Result( $check_context );
+
+		$check->run( $check_result );
+
+		$warnings = $check_result->get_warnings();
+
+		if ( is_wp_version_compatible( '6.5' ) ) {
+			$this->assertCount( 0, wp_list_filter( $warnings['load.php'][0][0], array( 'code' => 'plugin_header_invalid_requires_plugins' ) ) );
+		}
+	}
 }


### PR DESCRIPTION
Current regex check was not allowing following header:

```
Requires Plugins: first-slug, second-slug
```
This should be valid.
So regex has been update to allow space between comma separated slugs.