### PR TITLE
Fix apostrophe issue in plugin name

### DIFF
--- a/includes/Checker/Checks/Plugin_Repo/Plugin_Readme_Check.php
+++ b/includes/Checker/Checks/Plugin_Repo/Plugin_Readme_Check.php
@@ -146,7 +146,7 @@ class Plugin_Readme_Check extends Abstract_File_Check {
 		} else {
 			$plugin_data = get_plugin_data( $result->plugin()->main_file() );
 
-			if ( html_entity_decode( $parser->name ) !== $plugin_data['Name'] ) {
+			if ( html_entity_decode( $parser->name, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401 ) !== $plugin_data['Name'] ) {
 				$this->add_result_warning_for_file(
 					$result,
 					sprintf(

--- a/includes/Checker/Checks/Plugin_Repo/Plugin_Readme_Check.php
+++ b/includes/Checker/Checks/Plugin_Repo/Plugin_Readme_Check.php
@@ -146,7 +146,7 @@ class Plugin_Readme_Check extends Abstract_File_Check {
 		} else {
 			$plugin_data = get_plugin_data( $result->plugin()->main_file() );
 
-			if ( $parser->name !== $plugin_data['Name'] ) {
+			if ( html_entity_decode( $parser->name ) !== $plugin_data['Name'] ) {
 				$this->add_result_warning_for_file(
 					$result,
 					sprintf(

--- a/tests/behat/features/plugin-check.feature
+++ b/tests/behat/features/plugin-check.feature
@@ -116,6 +116,27 @@ Feature: Test that the WP-CLI command works.
       WordPress.Security.EscapeOutput.OutputNotEscaped
       """
 
+  Scenario: Check plugin with apostrophe in plugin name
+    Given a WP install with the Plugin Check plugin
+    And a wp-content/plugins/johns-post-counter/johns-post-counter.php file:
+      """
+      <?php
+      /**
+       * Plugin Name: John's Post Counter
+       */
+
+      """
+    And a wp-content/plugins/johns-post-counter/readme.txt file:
+      """
+      === John's Post Counter ===
+      """
+
+    When I run the WP-CLI command `plugin check johns-post-counter --format=csv --fields=code,type`
+    Then STDOUT should not contain:
+      """
+      mismatched_plugin_name,WARNING
+      """
+
   Scenario: Exclude directories in plugin check
     Given a WP install with the Plugin Check plugin
     And an empty wp-content/plugins/foo-plugin directory


### PR DESCRIPTION
Fixes https://github.com/WordPress/plugin-check/issues/634