### PR TITLE
Issue with chars in plugin name

### DIFF
--- a/includes/Checker/Checks/Plugin_Repo/Plugin_Readme_Check.php
+++ b/includes/Checker/Checks/Plugin_Repo/Plugin_Readme_Check.php
@@ -152,13 +152,13 @@ class Plugin_Readme_Check extends Abstract_File_Check {
 			$plugin_readme_name = html_entity_decode( $parser->name, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401 );
 			$plugin_header_name = html_entity_decode( $plugin_data['Name'], ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401 );
 
-			if ( $plugin_name_readme !== $plugin_header_name ) {
+			if ( $plugin_readme_name !== $plugin_header_name ) {
 				$this->add_result_warning_for_file(
 					$result,
 					sprintf(
 						/* translators: 1: Plugin name, 2: Name in plugin header */
 						__( 'Plugin name "%1$s" is different from the name declared in plugin header "%2$s".', 'plugin-check' ),
-						$plugin_name_readme,
+						$plugin_readme_name,
 						$plugin_header_name
 					),
 					'mismatched_plugin_name',

--- a/includes/Checker/Checks/Plugin_Repo/Plugin_Readme_Check.php
+++ b/includes/Checker/Checks/Plugin_Repo/Plugin_Readme_Check.php
@@ -149,14 +149,17 @@ class Plugin_Readme_Check extends Abstract_File_Check {
 		} else {
 			$plugin_data = get_plugin_data( $result->plugin()->main_file() );
 
-			if ( html_entity_decode( $parser->name, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401 ) !== $plugin_data['Name'] ) {
+			$plugin_readme_name = html_entity_decode( $parser->name, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401 );
+			$plugin_header_name = html_entity_decode( $plugin_data['Name'], ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401 );
+
+			if ( $plugin_name_readme !== $plugin_header_name ) {
 				$this->add_result_warning_for_file(
 					$result,
 					sprintf(
 						/* translators: 1: Plugin name, 2: Name in plugin header */
 						__( 'Plugin name "%1$s" is different from the name declared in plugin header "%2$s".', 'plugin-check' ),
-						$parser->name,
-						$plugin_data['Name']
+						$plugin_name_readme,
+						$plugin_header_name
 					),
 					'mismatched_plugin_name',
 					$readme_file,

--- a/tests/behat/features/plugin-check.feature
+++ b/tests/behat/features/plugin-check.feature
@@ -116,19 +116,19 @@ Feature: Test that the WP-CLI command works.
       WordPress.Security.EscapeOutput.OutputNotEscaped
       """
 
-  Scenario: Check plugin with apostrophe in plugin name
+  Scenario: Check plugin with special chars in plugin name
     Given a WP install with the Plugin Check plugin
     And a wp-content/plugins/johns-post-counter/johns-post-counter.php file:
       """
       <?php
       /**
-       * Plugin Name: John's Post Counter
+       * Plugin Name: John's — Post & Counter
        */
 
       """
     And a wp-content/plugins/johns-post-counter/readme.txt file:
       """
-      === John's Post Counter ===
+      === John's — Post & Counter ===
       """
 
     When I run the WP-CLI command `plugin check johns-post-counter --format=csv --fields=code,type`


### PR DESCRIPTION
Fixes the encoding issue with `&`.

It seems get_plugin_data() gives `&amp;` for `&` character.