### PR TITLE
Allow parameter force-slug

### DIFF
--- a/includes/CLI/Plugin_Check_Command.php
+++ b/includes/CLI/Plugin_Check_Command.php
@@ -112,6 +112,9 @@ final class Plugin_Check_Command {
 	 *
 	 * [--warning-severity=<warning-severity>]
 	 * : Warning severity level.
+	 * 
+	 * [--force-slug=<slug>]
+	 * : Slug that would be sent as correct while reviewing.
 	 *
 	 * ## EXAMPLES
 	 *
@@ -145,6 +148,7 @@ final class Plugin_Check_Command {
 				'severity'             => '',
 				'error-severity'       => '',
 				'warning-severity'     => '',
+				'force-slug'           => '',
 			)
 		);
 
@@ -194,6 +198,7 @@ final class Plugin_Check_Command {
 			$runner->set_check_slugs( $checks );
 			$runner->set_plugin( $plugin );
 			$runner->set_categories( $categories );
+			$runner->set_forced_slug( $options['force-slug'] );
 
 			$checks_to_run = $runner->get_checks_to_run();
 		} catch ( Exception $error ) {

--- a/includes/CLI/Plugin_Check_Command.php
+++ b/includes/CLI/Plugin_Check_Command.php
@@ -112,7 +112,7 @@ final class Plugin_Check_Command {
 	 *
 	 * [--warning-severity=<warning-severity>]
 	 * : Warning severity level.
-	 * 
+	 *
 	 * [--force-slug=<slug>]
 	 * : Slug that would be sent as correct while reviewing.
 	 *

--- a/includes/Checker/Abstract_Check_Runner.php
+++ b/includes/Checker/Abstract_Check_Runner.php
@@ -18,6 +18,7 @@ use WordPress\Plugin_Check\Utilities\Plugin_Request_Utility;
  * @since 1.0.0
  *
  * @SuppressWarnings(PHPMD.ExcessiveClassComplexity)
+ * @SuppressWarnings(PHPMD.TooManyPublicMethods)
  */
 abstract class Abstract_Check_Runner implements Check_Runner {
 

--- a/includes/Checker/Abstract_Check_Runner.php
+++ b/includes/Checker/Abstract_Check_Runner.php
@@ -46,6 +46,14 @@ abstract class Abstract_Check_Runner implements Check_Runner {
 	protected $check_exclude_slugs;
 
 	/**
+	 * The forced slug to compare.
+	 *
+	 * @since 1.2.0
+	 * @var array
+	 */
+	protected $forced_slug;
+
+	/**
 	 * The plugin parameter.
 	 *
 	 * @since 1.0.0
@@ -280,6 +288,19 @@ abstract class Abstract_Check_Runner implements Check_Runner {
 			}
 		}
 		$this->check_categories = $categories;
+	}
+
+	/**
+	 * Sets the correct slug to compare in diferent checks.
+	 *
+	 * @since 1.2.0
+	 *
+	 * @param string $forced_slug Slug to compare.
+	 *
+	 * @throws Exception Thrown if the flag set does not match the original request parameter.
+	 */
+	final public function set_forced_slug( $forced_slug ) {
+		$this->forced_slug = $forced_slug;
 	}
 
 	/**

--- a/includes/Checker/Abstract_Check_Runner.php
+++ b/includes/Checker/Abstract_Check_Runner.php
@@ -49,7 +49,7 @@ abstract class Abstract_Check_Runner implements Check_Runner {
 	 * The forced slug to compare.
 	 *
 	 * @since 1.2.0
-	 * @var array
+	 * @var string
 	 */
 	protected $forced_slug;
 

--- a/includes/Checker/Abstract_Check_Runner.php
+++ b/includes/Checker/Abstract_Check_Runner.php
@@ -291,7 +291,7 @@ abstract class Abstract_Check_Runner implements Check_Runner {
 	}
 
 	/**
-	 * Sets the correct slug to compare in diferent checks.
+	 * Sets the correct slug to compare in different checks.
 	 *
 	 * @since 1.2.0
 	 *

--- a/includes/Checker/Checks/Abstract_PHP_CodeSniffer_Check.php
+++ b/includes/Checker/Checks/Abstract_PHP_CodeSniffer_Check.php
@@ -146,7 +146,7 @@ abstract class Abstract_PHP_CodeSniffer_Check implements Static_Check {
 
 		// Format check arguments for PHPCS.
 		foreach ( $check_args as $key => $value ) {
-			if ( $key === 'runtime-set' ) {
+			if ( 'runtime-set' === $key ) {
 				$defaults[] = "--{$key}";
 				$defaults   = array_merge( $defaults, explode( ' ', $value ) );
 			} else {

--- a/includes/Checker/Checks/Abstract_PHP_CodeSniffer_Check.php
+++ b/includes/Checker/Checks/Abstract_PHP_CodeSniffer_Check.php
@@ -30,10 +30,11 @@ abstract class Abstract_PHP_CodeSniffer_Check implements Static_Check {
 	 * @var array
 	 */
 	protected $allowed_args = array(
-		'standard'   => true,
-		'extensions' => true,
-		'sniffs'     => true,
-		'exclude'    => true, //phpcs:ignore WordPressVIPMinimum.Performance.WPQueryParams.PostNotIn_exclude
+		'standard'    => true,
+		'extensions'  => true,
+		'sniffs'      => true,
+		'runtime-set' => true,
+		'exclude'     => true, //phpcs:ignore WordPressVIPMinimum.Performance.WPQueryParams.PostNotIn_exclude
 	);
 
 	/**
@@ -145,7 +146,12 @@ abstract class Abstract_PHP_CodeSniffer_Check implements Static_Check {
 
 		// Format check arguments for PHPCS.
 		foreach ( $check_args as $key => $value ) {
-			$defaults[] = "--{$key}=$value";
+			if ( $key === 'runtime-set' ) {
+				$defaults[] = "--{$key}";
+				$defaults   = array_merge( $defaults, explode( ' ', $value ) );
+			} else {
+				$defaults[] = "--{$key}=$value";
+			}
 		}
 
 		return $defaults;

--- a/includes/Checker/Checks/General/I18n_Usage_Check.php
+++ b/includes/Checker/Checks/General/I18n_Usage_Check.php
@@ -51,7 +51,7 @@ class I18n_Usage_Check extends Abstract_PHP_CodeSniffer_Check {
 		$slug_prefix = '--force-slug=';
 		$result      = array_filter(
 			$argv,
-			function( $element ) use ( $slug_prefix ) {
+			function ( $element ) use ( $slug_prefix ) {
 				return strpos( $element, $slug_prefix ) === 0;
 			}
 		);

--- a/includes/Checker/Checks/General/I18n_Usage_Check.php
+++ b/includes/Checker/Checks/General/I18n_Usage_Check.php
@@ -41,11 +41,24 @@ class I18n_Usage_Check extends Abstract_PHP_CodeSniffer_Check {
 	 * @return array An associative array of PHPCS CLI arguments.
 	 */
 	protected function get_args() {
-		return array(
-			'extensions' => 'php',
+		$sniff_args = array(
 			'standard'   => 'WordPress',
+			'extensions' => 'php',
 			'sniffs'     => 'WordPress.WP.I18n',
 		);
+
+		global $argv;
+		$slug_prefix = '--force-slug=';
+		$result = array_filter( $argv, function( $element ) use ( $slug_prefix ) {
+			return strpos( $element, $slug_prefix ) === 0;
+		});
+
+		if ( ! empty( $result ) ) {
+			$forced_slug = str_replace( $slug_prefix, '', array_shift( $result ) );
+			$sniff_args['runtime-set'] = 'text_domain ' . $forced_slug;
+		}
+
+		return $sniff_args;
 	}
 
 	/**

--- a/includes/Checker/Checks/General/I18n_Usage_Check.php
+++ b/includes/Checker/Checks/General/I18n_Usage_Check.php
@@ -49,12 +49,15 @@ class I18n_Usage_Check extends Abstract_PHP_CodeSniffer_Check {
 
 		global $argv;
 		$slug_prefix = '--force-slug=';
-		$result = array_filter( $argv, function( $element ) use ( $slug_prefix ) {
-			return strpos( $element, $slug_prefix ) === 0;
-		});
+		$result      = array_filter(
+			$argv,
+			function( $element ) use ( $slug_prefix ) {
+				return strpos( $element, $slug_prefix ) === 0;
+			}
+		);
 
 		if ( ! empty( $result ) ) {
-			$forced_slug = str_replace( $slug_prefix, '', array_shift( $result ) );
+			$forced_slug               = str_replace( $slug_prefix, '', array_shift( $result ) );
 			$sniff_args['runtime-set'] = 'text_domain ' . $forced_slug;
 		}
 

--- a/tests/behat/features/plugin-check.feature
+++ b/tests/behat/features/plugin-check.feature
@@ -364,6 +364,37 @@ Feature: Test that the WP-CLI command works.
       no_plugin_readme
       """
 
+  Scenario: Check a plugin from external location with custom plugin slug
+    Given a WP install with the Plugin Check plugin
+    And an empty external-folder/pxzvccv345nhg directory
+    And a external-folder/pxzvccv345nhg/foo-sample.php file:
+      """
+      <?php
+      /**
+       * Plugin Name: Foo Sample
+       * Plugin URI:  https://foo-sample.com
+       * Description:
+       * Version:     0.1.0
+       * Author:
+       * Author URI:
+       * License:     GPL-2.0+
+       * License URI: http://www.gnu.org/licenses/gpl-2.0.txt
+       * Text Domain: foo-sample
+       */
+
+      """
+
+    When I run the WP-CLI command `plugin check {RUN_DIR}/external-folder/pxzvccv345nhg/ --format=csv --fields=code,type --force-slug=foo-sample`
+    Then STDERR should be empty
+    And STDOUT should not contain:
+      """
+      textdomain_mismatch,WARNING
+      """
+    And STDOUT should contain:
+      """
+      no_plugin_readme,WARNING
+      """
+
   Scenario: Check a plugin from external location but with invalid plugin
     Given a WP install with the Plugin Check plugin
     And an empty external-folder/foo-plugin directory


### PR DESCRIPTION
Fixes #644 and it's related with PR [#480](https://github.com/WordPress/plugin-check/pull/480)

This is a first approach to solve this issue. It works.

What I see is that phpcs allows to force the text_domain with a slug. It can be done like [explained here](https://github.com/WordPress/WordPress-Coding-Standards/blob/7f766304b0654cee7c1dfa8e548f65fce197e05c/WordPress/Sniffs/WP/I18nSniff.php#L30C46-L31C21) with the parameters:
`--runtime-set text_domain desired-slug`
So, we need to allow a new argument in PHPCS, and set the slug to check. 