### PR TITLE
Update message for mismatched stable tag to make it more clear

### DIFF
--- a/includes/Checker/Checks/Plugin_Repo/Plugin_Readme_Check.php
+++ b/includes/Checker/Checks/Plugin_Repo/Plugin_Readme_Check.php
@@ -463,6 +463,8 @@ class Plugin_Readme_Check extends Abstract_File_Check {
 				'https://developer.wordpress.org/plugins/wordpress-org/common-issues/#incorrect-stable-tag',
 				9
 			);
+
+			return;
 		}
 
 		// Check the readme file Stable tag against the plugin's main file version.
@@ -474,7 +476,11 @@ class Plugin_Readme_Check extends Abstract_File_Check {
 		) {
 			$this->add_result_error_for_file(
 				$result,
-				__( "<strong>The Stable Tag in your readme file does not match the version in your main plugin file.</strong><br>Your Stable Tag is meant to be the stable version of your plugin, not of WordPress. For your plugin to be properly downloaded from WordPress.org, those values need to be the same. If they're out of sync, your users won't get the right version of your code.", 'plugin-check' ),
+				sprintf(
+					/* translators: %s: versions comparison */
+					__( "<strong>Mismatched Stable Tag: %s.</strong><br>The Stable Tag in your readme file does not match the version in your main plugin file. Your Stable Tag is meant to be the stable version of your plugin, not of WordPress. For your plugin to be properly downloaded from WordPress.org, those values need to be the same. If they're out of sync, your users won't get the right version of your code.", 'plugin-check' ),
+					esc_html( $stable_tag ) . ' != ' . esc_html( $plugin_data['Version'] )
+				),
 				'stable_tag_mismatch',
 				$readme_file,
 				0,

--- a/includes/Checker/Checks/Plugin_Repo/Plugin_Readme_Check.php
+++ b/includes/Checker/Checks/Plugin_Repo/Plugin_Readme_Check.php
@@ -463,8 +463,6 @@ class Plugin_Readme_Check extends Abstract_File_Check {
 				'https://developer.wordpress.org/plugins/wordpress-org/common-issues/#incorrect-stable-tag',
 				9
 			);
-
-			return;
 		}
 
 		// Check the readme file Stable tag against the plugin's main file version.


### PR DESCRIPTION
Earlier:

```
The Stable Tag in your readme file does not match the version in your main plugin file. Your Stable Tag is meant to be the stable version of your plugin, not of WordPress. For your plugin to be properly downloaded from WordPress.org, those values need to be the same. If they're out of sync, your users won't get the right version of your code.
```

Now:

```
Mismatched Stable Tag: 1.0.0 != 1.0.1. The Stable Tag in your readme file does not match the version in your main plugin file. Your Stable Tag is meant to be the stable version of your plugin, not of WordPress. For your plugin to be properly downloaded from WordPress.org, those values need to be the same. If they're out of sync, your users won't get the right version of your code.
```

Note: I have also added `return` inside `if ( 'trunk' === $stable_tag )` because we were not supposed to go for comparison if the value is `trunk`. Since task and the issue is quite related and in the same place, I have kept in the same PR.

Edit: On the second thought, I will create separate PR for that issue as it is breaking other several unit tests.

Screenshot:
![Screenshot 2024-09-26 at 11 25 10 AM](https://github.com/user-attachments/assets/32588eec-8397-4b51-952c-92c24e2cd413)
