### PR TITLE
Add missing global doc for `Runtime_Environment_Setup::clean_up`

### DIFF
--- a/includes/Checker/Runtime_Environment_Setup.php
+++ b/includes/Checker/Runtime_Environment_Setup.php
@@ -136,6 +136,8 @@ final class Runtime_Environment_Setup {
 	 *
 	 * @since 1.0.0
 	 *
+	 * @global WP_Filesystem_Base $wp_filesystem WordPress filesystem subclass.
+	 *
 	 * @return bool Returns true if the runtime environment can be set up, false if not.
 	 */
 	public function can_set_up() {


### PR DESCRIPTION
added missing `global` documentation in `includes/Checker/Runtime_Environment_Setup.php` file.

Fixes: https://github.com/WordPress/plugin-check/issues/671