### PR TITLE
Add validation for Network plugin header field

### DIFF
--- a/includes/Checker/Checks/Plugin_Repo/Plugin_Header_Fields_Check.php
+++ b/includes/Checker/Checks/Plugin_Repo/Plugin_Header_Fields_Check.php
@@ -174,6 +174,25 @@ class Plugin_Header_Fields_Check implements Static_Check {
 			}
 		}
 
+		if ( ! empty( $plugin_header['Network'] ) ) {
+			if ( 'true' !== strtolower( $plugin_header['Network'] ) ) {
+				$this->add_result_warning_for_file(
+					$result,
+					sprintf(
+						/* translators: %s: plugin header field */
+						__( 'The "%s" header in the plugin file is not valid. Can only be set to true, and should be left out when not needed.', 'plugin-check' ),
+						esc_html( $labels['Network'] )
+					),
+					'plugin_header_invalid_network',
+					$plugin_main_file,
+					0,
+					0,
+					'https://developer.wordpress.org/plugins/plugin-basics/header-requirements/#header-fields',
+					6
+				);
+			}
+		}
+
 		if ( ! empty( $plugin_header['RequiresWP'] ) ) {
 			if ( ! preg_match( '!^\d+\.\d(\.\d+)?$!', $plugin_header['RequiresWP'] ) ) {
 				$this->add_result_warning_for_file(

--- a/tests/phpunit/testdata/plugins/test-plugin-header-fields-with-errors/load.php
+++ b/tests/phpunit/testdata/plugins/test-plugin-header-fields-with-errors/load.php
@@ -12,6 +12,7 @@
  * License URI: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
  * Text Domain: test-mismathed-textdomain-here
  * Domain Path: /nonexistent-folder
+ * Network: random-value
  * GitHub Plugin URI: johndoe/package
  * Requires Plugins: Example Plugin, OtherPlugin
  *

--- a/tests/phpunit/tests/Checker/Checks/Plugin_Header_Fields_Check_Tests.php
+++ b/tests/phpunit/tests/Checker/Checks/Plugin_Header_Fields_Check_Tests.php
@@ -32,6 +32,7 @@ class Plugin_Header_Fields_Check_Tests extends WP_UnitTestCase {
 		$this->assertCount( 1, wp_list_filter( $warnings['load.php'][0][0], array( 'code' => 'plugin_header_invalid_requires_php' ) ) );
 		$this->assertCount( 1, wp_list_filter( $warnings['load.php'][0][0], array( 'code' => 'textdomain_mismatch' ) ) );
 		$this->assertCount( 1, wp_list_filter( $warnings['load.php'][0][0], array( 'code' => 'plugin_header_nonexistent_domain_path' ) ) );
+		$this->assertCount( 1, wp_list_filter( $warnings['load.php'][0][0], array( 'code' => 'plugin_header_invalid_network' ) ) );
 
 		if ( is_wp_version_compatible( '6.5' ) ) {
 			$this->assertCount( 1, wp_list_filter( $warnings['load.php'][0][0], array( 'code' => 'plugin_header_invalid_requires_plugins' ) ) );


### PR DESCRIPTION
Follow up to https://github.com/WordPress/plugin-check/pull/670

Only valid value of `Network` plugin header is `true`. Warn if other value found.