### PR TITLE
Allow `runtime-set` in Abstract_PHP_CodeSniffer_Check class and implement it in I18n_Usage_Check

### DIFF
--- a/includes/Checker/Checks/Abstract_PHP_CodeSniffer_Check.php
+++ b/includes/Checker/Checks/Abstract_PHP_CodeSniffer_Check.php
@@ -43,7 +43,6 @@ abstract class Abstract_PHP_CodeSniffer_Check implements Static_Check {
 	 * @since 1.0.0
 	 *
 	 * @param Check_Result $result The check result to amend, including the plugin context to check.
-	 *
 	 * @return array {
 	 *    An associative array of PHPCS CLI arguments. Can include one or more of the following options.
 	 *

--- a/includes/Checker/Checks/Abstract_PHP_CodeSniffer_Check.php
+++ b/includes/Checker/Checks/Abstract_PHP_CodeSniffer_Check.php
@@ -42,6 +42,8 @@ abstract class Abstract_PHP_CodeSniffer_Check implements Static_Check {
 	 *
 	 * @since 1.0.0
 	 *
+	 * @param Check_Result $result The check result to amend, including the plugin context to check.
+	 *
 	 * @return array {
 	 *    An associative array of PHPCS CLI arguments. Can include one or more of the following options.
 	 *
@@ -51,7 +53,7 @@ abstract class Abstract_PHP_CodeSniffer_Check implements Static_Check {
 	 *    @type string $exclude    A comma separated list of sniff codes to exclude from checks.
 	 * }
 	 */
-	abstract protected function get_args();
+	abstract protected function get_args( Check_Result $result );
 
 	/**
 	 * Amends the given result by running the check on the associated plugin.
@@ -84,7 +86,7 @@ abstract class Abstract_PHP_CodeSniffer_Check implements Static_Check {
 		$defaults = $this->get_argv_defaults( $result );
 
 		// Set the check arguments for PHPCS.
-		$_SERVER['argv'] = $this->parse_argv( $this->get_args(), $defaults );
+		$_SERVER['argv'] = $this->parse_argv( $this->get_args( $result ), $defaults );
 
 		// Reset PHP_CodeSniffer config.
 		$this->reset_php_codesniffer_config();

--- a/includes/Checker/Checks/Abstract_PHP_CodeSniffer_Check.php
+++ b/includes/Checker/Checks/Abstract_PHP_CodeSniffer_Check.php
@@ -30,10 +30,11 @@ abstract class Abstract_PHP_CodeSniffer_Check implements Static_Check {
 	 * @var array
 	 */
 	protected $allowed_args = array(
-		'standard'   => true,
-		'extensions' => true,
-		'sniffs'     => true,
-		'exclude'    => true, //phpcs:ignore WordPressVIPMinimum.Performance.WPQueryParams.PostNotIn_exclude
+		'standard'    => true,
+		'extensions'  => true,
+		'sniffs'      => true,
+		'runtime-set' => true,
+		'exclude'     => true, //phpcs:ignore WordPressVIPMinimum.Performance.WPQueryParams.PostNotIn_exclude
 	);
 
 	/**
@@ -145,7 +146,15 @@ abstract class Abstract_PHP_CodeSniffer_Check implements Static_Check {
 
 		// Format check arguments for PHPCS.
 		foreach ( $check_args as $key => $value ) {
-			$defaults[] = "--{$key}=$value";
+			if ( 'runtime-set' === $key ) {
+				if ( is_array( $value ) ) {
+					foreach ( $value as $item_key => $item_value ) {
+						$defaults = array_merge( $defaults, array( "--{$key}", $item_key, $item_value ) );
+					}
+				}
+			} else {
+				$defaults[] = "--{$key}=$value";
+			}
 		}
 
 		return $defaults;

--- a/includes/Checker/Checks/General/I18n_Usage_Check.php
+++ b/includes/Checker/Checks/General/I18n_Usage_Check.php
@@ -8,6 +8,7 @@
 namespace WordPress\Plugin_Check\Checker\Checks\General;
 
 use WordPress\Plugin_Check\Checker\Check_Categories;
+use WordPress\Plugin_Check\Checker\Check_Result;
 use WordPress\Plugin_Check\Checker\Checks\Abstract_PHP_CodeSniffer_Check;
 use WordPress\Plugin_Check\Traits\Stable_Check;
 
@@ -41,13 +42,17 @@ class I18n_Usage_Check extends Abstract_PHP_CodeSniffer_Check {
 	 *
 	 * @since 1.0.0
 	 *
+	 * @param Check_Result $result The check result to amend, including the plugin context to check.
 	 * @return array An associative array of PHPCS CLI arguments.
 	 */
-	protected function get_args() {
+	protected function get_args( Check_Result $result ) {
 		return array(
-			'extensions' => 'php',
-			'standard'   => 'WordPress',
-			'sniffs'     => 'WordPress.WP.I18n',
+			'extensions'  => 'php',
+			'standard'    => 'WordPress',
+			'sniffs'      => 'WordPress.WP.I18n',
+			'runtime-set' => array(
+				'text_domain' => $result->plugin()->slug(),
+			),
 		);
 	}
 

--- a/includes/Checker/Checks/Performance/Enqueued_Resources_Check.php
+++ b/includes/Checker/Checks/Performance/Enqueued_Resources_Check.php
@@ -8,6 +8,7 @@
 namespace WordPress\Plugin_Check\Checker\Checks\Performance;
 
 use WordPress\Plugin_Check\Checker\Check_Categories;
+use WordPress\Plugin_Check\Checker\Check_Result;
 use WordPress\Plugin_Check\Checker\Checks\Abstract_PHP_CodeSniffer_Check;
 use WordPress\Plugin_Check\Traits\Stable_Check;
 
@@ -38,9 +39,10 @@ class Enqueued_Resources_Check extends Abstract_PHP_CodeSniffer_Check {
 	 *
 	 * @since 1.0.2
 	 *
+	 * @param Check_Result $result The check result to amend, including the plugin context to check.
 	 * @return array An associative array of PHPCS CLI arguments.
 	 */
-	protected function get_args() {
+	protected function get_args( Check_Result $result ) {
 		return array(
 			'extensions' => 'php',
 			'standard'   => 'WordPress',

--- a/includes/Checker/Checks/Performance/Enqueued_Scripts_In_Footer_Check.php
+++ b/includes/Checker/Checks/Performance/Enqueued_Scripts_In_Footer_Check.php
@@ -8,6 +8,7 @@
 namespace WordPress\Plugin_Check\Checker\Checks\Performance;
 
 use WordPress\Plugin_Check\Checker\Check_Categories;
+use WordPress\Plugin_Check\Checker\Check_Result;
 use WordPress\Plugin_Check\Checker\Checks\Abstract_PHP_CodeSniffer_Check;
 use WordPress\Plugin_Check\Traits\Stable_Check;
 
@@ -38,9 +39,10 @@ class Enqueued_Scripts_In_Footer_Check extends Abstract_PHP_CodeSniffer_Check {
 	 *
 	 * @since 1.0.0
 	 *
+	 * @param Check_Result $result The check result to amend, including the plugin context to check.
 	 * @return array An associative array of PHPCS CLI arguments.
 	 */
-	protected function get_args() {
+	protected function get_args( Check_Result $result ) {
 		return array(
 			'extensions' => 'php',
 			'standard'   => 'WordPress',

--- a/includes/Checker/Checks/Performance/Performant_WP_Query_Params_Check.php
+++ b/includes/Checker/Checks/Performance/Performant_WP_Query_Params_Check.php
@@ -8,6 +8,7 @@
 namespace WordPress\Plugin_Check\Checker\Checks\Performance;
 
 use WordPress\Plugin_Check\Checker\Check_Categories;
+use WordPress\Plugin_Check\Checker\Check_Result;
 use WordPress\Plugin_Check\Checker\Checks\Abstract_PHP_CodeSniffer_Check;
 use WordPress\Plugin_Check\Traits\Stable_Check;
 
@@ -38,9 +39,10 @@ class Performant_WP_Query_Params_Check extends Abstract_PHP_CodeSniffer_Check {
 	 *
 	 * @since 1.0.0
 	 *
+	 * @param Check_Result $result The check result to amend, including the plugin context to check.
 	 * @return array An associative array of PHPCS CLI arguments.
 	 */
-	protected function get_args() {
+	protected function get_args( Check_Result $result ) {
 		return array(
 			'extensions' => 'php',
 			'standard'   => 'WordPress,WordPressVIPMinimum',

--- a/includes/Checker/Checks/Plugin_Repo/Offloading_Files_Check.php
+++ b/includes/Checker/Checks/Plugin_Repo/Offloading_Files_Check.php
@@ -8,6 +8,7 @@
 namespace WordPress\Plugin_Check\Checker\Checks\Plugin_Repo;
 
 use WordPress\Plugin_Check\Checker\Check_Categories;
+use WordPress\Plugin_Check\Checker\Check_Result;
 use WordPress\Plugin_Check\Checker\Checks\Abstract_PHP_CodeSniffer_Check;
 use WordPress\Plugin_Check\Traits\Amend_Check_Result;
 use WordPress\Plugin_Check\Traits\Stable_Check;
@@ -48,9 +49,10 @@ class Offloading_Files_Check extends Abstract_PHP_CodeSniffer_Check {
 	 *
 	 * @since 1.0.0
 	 *
+	 * @param Check_Result $result The check result to amend, including the plugin context to check.
 	 * @return array An associative array of PHPCS CLI arguments.
 	 */
-	protected function get_args() {
+	protected function get_args( Check_Result $result ) {
 		return array(
 			'extensions' => 'php',
 			'standard'   => 'PluginCheck',

--- a/includes/Checker/Checks/Plugin_Repo/Plugin_Review_PHPCS_Check.php
+++ b/includes/Checker/Checks/Plugin_Repo/Plugin_Review_PHPCS_Check.php
@@ -8,6 +8,7 @@
 namespace WordPress\Plugin_Check\Checker\Checks\Plugin_Repo;
 
 use WordPress\Plugin_Check\Checker\Check_Categories;
+use WordPress\Plugin_Check\Checker\Check_Result;
 use WordPress\Plugin_Check\Checker\Checks\Abstract_PHP_CodeSniffer_Check;
 use WordPress\Plugin_Check\Traits\Stable_Check;
 
@@ -38,9 +39,10 @@ class Plugin_Review_PHPCS_Check extends Abstract_PHP_CodeSniffer_Check {
 	 *
 	 * @since 1.0.0
 	 *
+	 * @param Check_Result $result The check result to amend, including the plugin context to check.
 	 * @return array An associative array of PHPCS CLI arguments.
 	 */
-	protected function get_args() {
+	protected function get_args( Check_Result $result ) {
 		return array(
 			'extensions' => 'php',
 			'standard'   => WP_PLUGIN_CHECK_PLUGIN_DIR_PATH . 'phpcs-rulesets/plugin-review.xml',

--- a/includes/Checker/Checks/Security/Direct_DB_Queries_Check.php
+++ b/includes/Checker/Checks/Security/Direct_DB_Queries_Check.php
@@ -8,6 +8,7 @@
 namespace WordPress\Plugin_Check\Checker\Checks\Security;
 
 use WordPress\Plugin_Check\Checker\Check_Categories;
+use WordPress\Plugin_Check\Checker\Check_Result;
 use WordPress\Plugin_Check\Checker\Checks\Abstract_PHP_CodeSniffer_Check;
 use WordPress\Plugin_Check\Traits\Stable_Check;
 
@@ -38,9 +39,10 @@ class Direct_DB_Queries_Check extends Abstract_PHP_CodeSniffer_Check {
 	 *
 	 * @since 1.0.0
 	 *
+	 * @param Check_Result $result The check result to amend, including the plugin context to check.
 	 * @return array An associative array of PHPCS CLI arguments.
 	 */
-	protected function get_args() {
+	protected function get_args( Check_Result $result ) {
 		return array(
 			'extensions' => 'php',
 			'standard'   => 'WordPress',

--- a/includes/Checker/Checks/Security/Late_Escaping_Check.php
+++ b/includes/Checker/Checks/Security/Late_Escaping_Check.php
@@ -8,6 +8,7 @@
 namespace WordPress\Plugin_Check\Checker\Checks\Security;
 
 use WordPress\Plugin_Check\Checker\Check_Categories;
+use WordPress\Plugin_Check\Checker\Check_Result;
 use WordPress\Plugin_Check\Checker\Checks\Abstract_PHP_CodeSniffer_Check;
 use WordPress\Plugin_Check\Traits\Stable_Check;
 
@@ -38,9 +39,10 @@ class Late_Escaping_Check extends Abstract_PHP_CodeSniffer_Check {
 	 *
 	 * @since 1.0.0
 	 *
+	 * @param Check_Result $result The check result to amend, including the plugin context to check.
 	 * @return array An associative array of PHPCS CLI arguments.
 	 */
-	protected function get_args() {
+	protected function get_args( Check_Result $result ) {
 		return array(
 			'extensions' => 'php',
 			'standard'   => 'WordPress',

--- a/tests/phpunit/testdata/plugins/test-plugin-i18n-usage-without-errors/load.php
+++ b/tests/phpunit/testdata/plugins/test-plugin-i18n-usage-without-errors/load.php
@@ -10,7 +10,7 @@
  * Author URI: https://make.wordpress.org/performance/
  * License: GPLv2 or later
  * License URI: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
- * Text Domain: test-plugin-check
+ * Text Domain: test-plugin-i18n-usage-without-errors
  *
  * @package test-plugin-check
  */
@@ -22,8 +22,8 @@ $city = 'Surat';
 
 sprintf(
 	/* translators: %s: Name of a city */
-	__( 'Your city is %s.', 'test-plugin-check' ),
+	__( 'Your city is %s.', 'test-plugin-i18n-usage-without-errors' ),
 	$city
 );
 
-esc_html__( 'Hello World!', 'test-plugin-check' );
+esc_html__( 'Hello World!', 'test-plugin-i18n-usage-without-errors' );

--- a/tests/phpunit/testdata/plugins/test-plugin-ignore-directories/custom_directory/error.php
+++ b/tests/phpunit/testdata/plugins/test-plugin-ignore-directories/custom_directory/error.php
@@ -8,11 +8,11 @@
 
  // This will cause a WordPress.WP.I18n.MissingTranslatorsComment error as it has no translators comment.
  sprintf(
-     __( 'Your city is %s.', 'test-plugin-check-errors' ),
+     __( 'Your city is %s.', 'test-plugin-ignore-directories' ),
      $city
  );
- 
- $text_domain = 'test-plugin-check-errors';
- 
+
+ $text_domain = 'test-plugin-ignore-directories';
+
  // This will cause a WordPress.WP.I18n.NonSingularStringLiteralDomain error as a variable is used for the text-domain.
  esc_html__( 'Hello World!', $text_domain );

--- a/tests/phpunit/testdata/plugins/test-plugin-ignore-directories/load.php
+++ b/tests/phpunit/testdata/plugins/test-plugin-ignore-directories/load.php
@@ -10,7 +10,7 @@
  * Author URI: https://make.wordpress.org/performance/
  * License: GPLv2 or later
  * License URI: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
- * Text Domain: test-plugin-check-errors
+ * Text Domain: test-plugin-ignore-directories
  *
- * @package test-plugin-check-errors
+ * @package test-plugin-ignore-directories
  */

--- a/tests/phpunit/testdata/plugins/test-plugin-ignore-files/bar.php
+++ b/tests/phpunit/testdata/plugins/test-plugin-ignore-files/bar.php
@@ -4,4 +4,4 @@
  */
 
 $city = 'Kathmandu';
-sprintf( __( 'Your city is %s.', 'test-plugin-check-errors' ), $city ); // This will trigger WordPress.WP.I18n.MissingTranslatorsComment error.
+sprintf( __( 'Your city is %s.', 'test-plugin-ignore-files' ), $city ); // This will trigger WordPress.WP.I18n.MissingTranslatorsComment error.

--- a/tests/phpunit/testdata/plugins/test-plugin-ignore-files/foobar.php
+++ b/tests/phpunit/testdata/plugins/test-plugin-ignore-files/foobar.php
@@ -4,4 +4,4 @@
  */
 
 $name = 'John Doe';
-esc_html__( 'Hello, ' . $name, 'plugin-check' ); // This will trigger WordPress.WP.I18n.NonSingularStringLiteralText error.
+esc_html__( 'Hello, ' . $name, 'test-plugin-ignore-files' ); // This will trigger WordPress.WP.I18n.NonSingularStringLiteralText error.

--- a/tests/phpunit/testdata/plugins/test-plugin-ignore-files/subdirectory/error.php
+++ b/tests/phpunit/testdata/plugins/test-plugin-ignore-files/subdirectory/error.php
@@ -3,5 +3,5 @@
  * File contains errors related to i18n translation issues.
  */
 
-$text_domain = 'test-plugin-check-errors';
+$text_domain = 'test-plugin-ignore-files';
 esc_html__( 'Hello World!', $text_domain ); // This will trigger WordPress.WP.I18n.NonSingularStringLiteralDomain error.

--- a/tests/phpunit/tests/Checker/Checks/I18n_Usage_Check_Tests.php
+++ b/tests/phpunit/tests/Checker/Checks/I18n_Usage_Check_Tests.php
@@ -22,19 +22,15 @@ class I18n_Usage_Check_Tests extends WP_UnitTestCase {
 
 		$this->assertNotEmpty( $errors );
 		$this->assertArrayHasKey( 'load.php', $errors );
-		$this->assertEquals( 2, $check_result->get_error_count() );
 
 		// Check for WordPress.WP.I18n.MissingTranslatorsComment error on Line no 26 and column no at 5.
-		$this->assertArrayHasKey( 26, $errors['load.php'] );
-		$this->assertArrayHasKey( 5, $errors['load.php'][26] );
-		$this->assertArrayHasKey( 'code', $errors['load.php'][26][5][0] );
-		$this->assertEquals( 'WordPress.WP.I18n.MissingTranslatorsComment', $errors['load.php'][26][5][0]['code'] );
+		$this->assertCount( 1, wp_list_filter( $errors['load.php'][26][5], array( 'code' => 'WordPress.WP.I18n.MissingTranslatorsComment' ) ) );
+
+		// Check for WordPress.WP.I18n.TextDomainMismatch error on Line no 26 and column no at 29.
+		$this->assertCount( 1, wp_list_filter( $errors['load.php'][26][29], array( 'code' => 'WordPress.WP.I18n.TextDomainMismatch' ) ) );
 
 		// Check for WordPress.WP.I18n.NonSingularStringLiteralDomain error on Line no 33 and column no at 29.
-		$this->assertArrayHasKey( 33, $errors['load.php'] );
-		$this->assertArrayHasKey( 29, $errors['load.php'][33] );
-		$this->assertArrayHasKey( 'code', $errors['load.php'][33][29][0] );
-		$this->assertEquals( 'WordPress.WP.I18n.NonSingularStringLiteralDomain', $errors['load.php'][33][29][0]['code'] );
+		$this->assertCount( 1, wp_list_filter( $errors['load.php'][33][29], array( 'code' => 'WordPress.WP.I18n.NonSingularStringLiteralDomain' ) ) );
 	}
 
 	public function test_run_without_errors() {


### PR DESCRIPTION
Fixes https://github.com/WordPress/plugin-check/issues/679

* Accepts **runtime-set** arguments in an array form( key value pair)

Example implementation:

```php

return array(
  'extensions'  => 'php',
  'standard'    => 'WordPress',
  'sniffs'      => 'WordPress.WP.I18n',
  'runtime-set' => array(
    'text_domain' => 'sample-domain',
  ),
);

```

**Edit:**
* Implement `runtime-set text_domain` in `I18n_Usage_Check` class
* Update i18n related tests as now errors will be increased
* Update other test files where `i18n_usage` check was used for the errors