### PR TITLE
Make `Contributors` regex check less strict

### DIFF
--- a/includes/Checker/Checks/Plugin_Repo/Plugin_Readme_Check.php
+++ b/includes/Checker/Checks/Plugin_Repo/Plugin_Readme_Check.php
@@ -691,7 +691,7 @@ class Plugin_Readme_Check extends Abstract_File_Check {
 		$valid = true;
 
 		foreach ( $usernames as $username ) {
-			if ( 1 !== preg_match( '/^[a-z0-9\s_.\-@]+$/', $username ) ) {
+			if ( 1 !== preg_match( '/^[a-z0-9_.\-@ ]+$/i', $username ) ) {
 				$valid = false;
 				break;
 			}


### PR DESCRIPTION
After feedback from Meta team, we are going to make regex check for `Contributors` less strict.

* Make case insensitive
* Replace `\s` with actual space