### PR TITLE
Output a success message if no errors or warnings are found.

### DIFF
--- a/includes/CLI/Plugin_Check_Command.php
+++ b/includes/CLI/Plugin_Check_Command.php
@@ -244,7 +244,7 @@ final class Plugin_Check_Command {
 		}
 
 		if ( empty( $errors ) && empty( $warnings ) ) {
-			WP_CLI::success( 'Checks complete. No errors found.' );
+			WP_CLI::success( __( 'Checks complete. No errors found.', 'plugin-check' ) );
 
 			return;
 		}

--- a/includes/CLI/Plugin_Check_Command.php
+++ b/includes/CLI/Plugin_Check_Command.php
@@ -243,6 +243,12 @@ final class Plugin_Check_Command {
 			$warnings = $result->get_warnings();
 		}
 
+		if ( empty( $errors ) && empty( $warnings ) ) {
+			WP_CLI::success( 'Checks complete. No errors found.' );
+
+			return;
+		}
+
 		// Default fields.
 		$default_fields = $this->get_check_default_fields( $assoc_args );
 

--- a/tests/behat/features/plugin-check.feature
+++ b/tests/behat/features/plugin-check.feature
@@ -601,3 +601,33 @@ Feature: Test that the WP-CLI command works.
 #      """
 #      ExampleRuntimeCheck.ForbiddenScript,WARNING
 #      """
+
+  Scenario: Check custom single file plugin that has no errors or warnings
+    Given a WP install with the Plugin Check plugin
+    And a wp-content/plugins/foo-single.php file:
+      """
+      <?php
+      /**
+       * Plugin Name: Foo Single
+       * Plugin URI: https://foo-single.com
+       * Description: Custom plugin.
+       * Version: 0.1.0
+       * Author: WordPress Performance Team
+       * Author URI: https://make.wordpress.org/performance/
+       * License: GPL-2.0+
+       * License URI: http://www.gnu.org/licenses/gpl-2.0.txt
+       */
+
+      add_action(
+        'init',
+        function () {
+          echo esc_html( 'this is a test.' );
+        }
+      );
+      """
+
+    When I run the WP-CLI command `plugin check foo-single.php`
+    Then STDOUT should contain:
+	  """
+	  Success: Checks complete. No errors found.
+	  """

--- a/tests/behat/features/plugin-check.feature
+++ b/tests/behat/features/plugin-check.feature
@@ -73,7 +73,10 @@ Feature: Test that the WP-CLI command works.
       """
 
     When I run the WP-CLI command `plugin check foo-single.php --ignore-errors`
-    Then STDOUT should be empty
+    Then STDOUT should contain:
+      """
+      Success: Checks complete. No errors found.
+      """
 
     When I run the WP-CLI command `plugin check foo-single.php --ignore-warnings`
     Then STDOUT should not be empty

--- a/tests/phpstan/stubs/wp-cli.php
+++ b/tests/phpstan/stubs/wp-cli.php
@@ -10,6 +10,9 @@ namespace {
 
 		public static function warning( $text ) {
 		}
+
+		public static function success( $text ) {
+		}
 	}
 }
 


### PR DESCRIPTION
fixes #685

When no errors or warnings are found, output a success message with that same text that is used in `Tools > Plugin Check`.

Before merging this, please verify that producing output on success doesn't cause problems with [plugin-check-action](https://github.com/WordPress/plugin-check-action).
