### PR TITLE
When checking for excluded files, use the normalized path to ensure that it works in Windows environments.

### DIFF
--- a/includes/Checker/Checks/Abstract_File_Check.php
+++ b/includes/Checker/Checks/Abstract_File_Check.php
@@ -311,7 +311,7 @@ abstract class Abstract_File_Check implements Static_Check {
 				}
 
 				if ( $include_file ) {
-					self::$file_list_cache[ $location ][] = wp_normalize_path( $file_path );
+					self::$file_list_cache[ $location ][] = $file_path;
 				}
 			}
 		}

--- a/includes/Checker/Checks/Abstract_File_Check.php
+++ b/includes/Checker/Checks/Abstract_File_Check.php
@@ -304,7 +304,7 @@ abstract class Abstract_File_Check implements Static_Check {
 				$files_to_ignore = Plugin_Request_Utility::get_files_to_ignore();
 
 				foreach ( $files_to_ignore as $ignore_file ) {
-					if ( str_ends_with( $file, "/$ignore_file" ) ) {
+					if ( str_ends_with( $file_path, "/$ignore_file" ) ) {
 						$include_file = false;
 						break;
 					}


### PR DESCRIPTION
Fixes #693