### PR TITLE
Fix bad filename issue

### DIFF
--- a/includes/Checker/Checks/Plugin_Repo/File_Type_Check.php
+++ b/includes/Checker/Checks/Plugin_Repo/File_Type_Check.php
@@ -264,7 +264,7 @@ class File_Type_Check extends Abstract_File_Check {
 
 		$files = array_map(
 			function ( $file ) use ( $plugin_path ) {
-				return substr( $file, strlen( $plugin_path ) );
+				return str_replace( $plugin_path, '', $file );
 			},
 			$files
 		);

--- a/includes/Checker/Checks/Plugin_Repo/File_Type_Check.php
+++ b/includes/Checker/Checks/Plugin_Repo/File_Type_Check.php
@@ -260,6 +260,15 @@ class File_Type_Check extends Abstract_File_Check {
 	protected function look_for_badly_named_files( Check_Result $result, array $files ) {
 		$conflict_chars = '!@#$%^&*()+=[]{};:"\'<>,?/\\|`~';
 
+		$plugin_path = $result->plugin()->path();
+
+		$files = array_map(
+			function ( $file ) use ( $plugin_path ) {
+				return substr( $file, strlen( $plugin_path ) );
+			},
+			$files
+		);
+
 		foreach ( $files as $file ) {
 			$badly_name = false;
 			if ( preg_match( '/\s/', $file ) ) {


### PR DESCRIPTION
Related https://github.com/WordPress/plugin-check/issues/628

This removes the path before the plugin so that we dont worry about badly named folder issue out of plugin scope.