### PR TITLE
Restricted Headers: remove ones that are allowed, but leave the mech for checking in place for future use

### DIFF
--- a/includes/Checker/Checks/Plugin_Repo/Plugin_Header_Fields_Check.php
+++ b/includes/Checker/Checks/Plugin_Repo/Plugin_Header_Fields_Check.php
@@ -69,7 +69,9 @@ class Plugin_Header_Fields_Check implements Static_Check {
 			'RequiresPlugins' => 'Requires Plugins',
 		);
 
-		$restricted_labels = array(); // Reserved for future use.
+		$restricted_labels = array(
+			'RestrictedLabel' => 'Restricted Label',
+		); // Reserved for future use.
 
 		$plugin_header = $this->get_plugin_data( $plugin_main_file, array_merge( $labels, $restricted_labels ) );
 

--- a/includes/Checker/Checks/Plugin_Repo/Plugin_Header_Fields_Check.php
+++ b/includes/Checker/Checks/Plugin_Repo/Plugin_Header_Fields_Check.php
@@ -69,13 +69,7 @@ class Plugin_Header_Fields_Check implements Static_Check {
 			'RequiresPlugins' => 'Requires Plugins',
 		);
 
-		$restricted_labels = array(
-			'BitbucketPluginURI' => 'Bitbucket Plugin URI',
-			'GistPluginURI'      => 'Gist Plugin URI',
-			'GiteaPluginURI'     => 'Gitea Plugin URI',
-			'GitHubPluginURI'    => 'GitHub Plugin URI',
-			'GitLabPluginURI'    => 'GitLab Plugin URI',
-		);
+		$restricted_labels = array(); // Reserved for future use.
 
 		$plugin_header = $this->get_plugin_data( $plugin_main_file, array_merge( $labels, $restricted_labels ) );
 

--- a/tests/phpunit/tests/Checker/Checks/Plugin_Header_Fields_Check_Tests.php
+++ b/tests/phpunit/tests/Checker/Checks/Plugin_Header_Fields_Check_Tests.php
@@ -24,7 +24,7 @@ class Plugin_Header_Fields_Check_Tests extends WP_UnitTestCase {
 		$this->assertNotEmpty( $errors );
 		$this->assertNotEmpty( $warnings );
 
-		$this->assertCount( 1, wp_list_filter( $errors['load.php'][0][0], array( 'code' => 'plugin_header_restricted_fields' ) ) );
+		$this->assertCount( 0, wp_list_filter( $errors['load.php'][0][0], array( 'code' => 'plugin_header_restricted_fields' ) ) );
 		$this->assertCount( 1, wp_list_filter( $errors['load.php'][0][0], array( 'code' => 'plugin_header_invalid_requires_wp' ) ) );
 		$this->assertCount( 1, wp_list_filter( $errors['load.php'][0][0], array( 'code' => 'plugin_header_invalid_requires_php' ) ) );
 		$this->assertCount( 1, wp_list_filter( $warnings['load.php'][0][0], array( 'code' => 'plugin_header_invalid_plugin_uri_domain' ) ) );


### PR DESCRIPTION
Partly reverts the functionality of #670.
Resolves #718 

Per the conversation in #669, the presence of these headers—in and of themselves—do not create a third-party upgrader situation. The UpdateURI, which is already checked elsewhere, does prevent the updates from WordPress.org, but the headers originally included in this code are for information only.
