### PR TITLE
Modifies i18n_usage check to consider explicit default textdomain usage a warning

### DIFF
--- a/includes/Checker/Checks/General/I18n_Usage_Check.php
+++ b/includes/Checker/Checks/General/I18n_Usage_Check.php
@@ -81,4 +81,28 @@ class I18n_Usage_Check extends Abstract_PHP_CodeSniffer_Check {
 	public function get_documentation_url(): string {
 		return __( 'https://developer.wordpress.org/plugins/internationalization/how-to-internationalize-your-plugin/', 'plugin-check' );
 	}
+
+	/**
+	 * Amends the given result with a message for the specified file, including error information.
+	 *
+	 * @since 1.3.0
+	 *
+	 * @param Check_Result $result   The check result to amend, including the plugin context to check.
+	 * @param bool         $error    Whether it is an error or notice.
+	 * @param string       $message  Error message.
+	 * @param string       $code     Error code.
+	 * @param string       $file     Absolute path to the file where the issue was found.
+	 * @param int          $line     The line on which the message occurred. Default is 0 (unknown line).
+	 * @param int          $column   The column on which the message occurred. Default is 0 (unknown column).
+	 * @param string       $docs     URL for further information about the message.
+	 * @param int          $severity Severity level. Default is 5.
+	 */
+	protected function add_result_message_for_file( Check_Result $result, $error, $message, $code, $file, $line = 0, $column = 0, string $docs = '', $severity = 5 ) {
+		// Downgrade errors about usage of the 'default' text domain from WordPress Core to warnings.
+		if ( $error && str_ends_with( $message, " but got 'default'." ) ) {
+			$error = false;
+		}
+
+		parent::add_result_message_for_file( $result, $error, $message, $code, $file, $line, $column, $docs, $severity );
+	}
 }

--- a/tests/phpunit/testdata/plugins/test-plugin-i18n-usage-with-default/load.php
+++ b/tests/phpunit/testdata/plugins/test-plugin-i18n-usage-with-default/load.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * Plugin Name: Test Plugin i18n usage with default for Plugin Check
+ * Plugin URI: https://github.com/WordPress/plugin-check
+ * Description: Some plugin description.
+ * Requires at least: 6.0
+ * Requires PHP: 5.6
+ * Version: 1.0.0
+ * Author: WordPress Performance Team
+ * Author URI: https://make.wordpress.org/performance/
+ * License: GPLv2 or later
+ * License URI: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+ * Text Domain: test-plugin-i18n-usage-without-errors
+ *
+ * @package test-plugin-check
+ */
+
+// This explicitly uses the 'default' WordPress Core text domain which should cause a warning.
+esc_html__( 'Log In', 'default' );
+
+// This omits the text domain though, which will lead to the same behavior but is not allowed and thus an error.
+esc_html__( 'Log In' );

--- a/tests/phpunit/tests/Checker/Checks/I18n_Usage_Check_Tests.php
+++ b/tests/phpunit/tests/Checker/Checks/I18n_Usage_Check_Tests.php
@@ -48,4 +48,18 @@ class I18n_Usage_Check_Tests extends WP_UnitTestCase {
 		$this->assertEquals( 0, $check_result->get_error_count() );
 		$this->assertEquals( 0, $check_result->get_warning_count() );
 	}
+
+	public function test_run_without_default_textdomain() {
+		$i18n_usage_check = new I18n_Usage_Check();
+		$check_context    = new Check_Context( UNIT_TESTS_PLUGIN_DIR . 'test-plugin-i18n-usage-with-default/load.php' );
+		$check_result     = new Check_Result( $check_context );
+
+		$i18n_usage_check->run( $check_result );
+
+		// Explicitly using the 'default' text domain is a warning, omitting a text domain is an error.
+		$this->assertNotEmpty( $check_result->get_errors() );
+		$this->assertNotEmpty( $check_result->get_warnings() );
+		$this->assertEquals( 1, $check_result->get_error_count() );
+		$this->assertEquals( 1, $check_result->get_warning_count() );
+	}
 }


### PR DESCRIPTION
Fixes #713.

Note: There's no way to do this via WPCS flags, so we need to rely on the error message to detect the relevant violation and downgrade it to a warning accordingly. This can be done with minimal additional code by overriding the relevant parent method.