### PR TITLE
Convert readme check warnings `no_plugin_readme` and `default_readme_text` to errors

### DIFF
--- a/includes/Checker/Checks/Plugin_Repo/Plugin_Readme_Check.php
+++ b/includes/Checker/Checks/Plugin_Repo/Plugin_Readme_Check.php
@@ -61,9 +61,9 @@ class Plugin_Readme_Check extends Abstract_File_Check {
 		// Filter the readme files.
 		$readme = $this->filter_files_for_readme( $files, $plugin_relative_path );
 
-		// If the readme file does not exist, add a warning and skip other tests.
+		// If the readme file does not exist, add an error and skip other tests.
 		if ( empty( $readme ) ) {
-			$this->add_result_warning_for_file(
+			$this->add_result_error_for_file(
 				$result,
 				__( 'The plugin readme.txt does not exist.', 'plugin-check' ),
 				'no_plugin_readme',
@@ -277,7 +277,7 @@ class Plugin_Readme_Check extends Abstract_File_Check {
 			|| str_contains( $short_description, 'Here is a short description of the plugin.' )
 			|| str_contains( $donate_link, '//example.com/' )
 		) {
-			$this->add_result_warning_for_file(
+			$this->add_result_error_for_file(
 				$result,
 				__( '<strong>The readme appears to contain default text.</strong><br>This means your readme has to have headers as well as a proper description and documentation as to how it works and how one can use it.', 'plugin-check' ),
 				'default_readme_text',

--- a/tests/behat/features/plugin-check-severity.feature
+++ b/tests/behat/features/plugin-check-severity.feature
@@ -81,7 +81,7 @@ Feature: Test that the severity level in plugin check works.
       """
     And STDOUT should contain:
       """
-      default_readme_text,WARNING,7
+      default_readme_text,ERROR,7
       """
     And STDOUT should contain:
       """
@@ -107,7 +107,7 @@ Feature: Test that the severity level in plugin check works.
       """
     And STDOUT should contain:
       """
-      default_readme_text,WARNING,7
+      default_readme_text,ERROR,7
       """
     And STDOUT should not contain:
       """
@@ -133,7 +133,7 @@ Feature: Test that the severity level in plugin check works.
       """
     And STDOUT should contain:
       """
-      default_readme_text,WARNING,7
+      default_readme_text,ERROR,7
       """
     And STDOUT should not contain:
       """
@@ -159,7 +159,7 @@ Feature: Test that the severity level in plugin check works.
       """
     And STDOUT should contain:
       """
-      default_readme_text,WARNING,7
+      default_readme_text,ERROR,7
       """
     And STDOUT should contain:
       """
@@ -185,7 +185,7 @@ Feature: Test that the severity level in plugin check works.
       """
     And STDOUT should contain:
       """
-      default_readme_text,WARNING,7
+      default_readme_text,ERROR,7
       """
     And STDOUT should not contain:
       """

--- a/tests/behat/features/plugin-check.feature
+++ b/tests/behat/features/plugin-check.feature
@@ -332,7 +332,7 @@ Feature: Test that the WP-CLI command works.
       """
     And STDOUT should contain:
       """
-      no_plugin_readme,WARNING
+      no_plugin_readme,ERROR
       """
 
   Scenario: Check a plugin from external location
@@ -395,7 +395,7 @@ Feature: Test that the WP-CLI command works.
       """
     And STDOUT should contain:
       """
-      no_plugin_readme,WARNING
+      no_plugin_readme,ERROR
       """
 
     When I run the WP-CLI command `plugin check {RUN_DIR}/external-folder/pxzvccv345nhg/ --format=csv --fields=code,type --slug=foo-sample`
@@ -406,7 +406,7 @@ Feature: Test that the WP-CLI command works.
       """
     And STDOUT should contain:
       """
-      no_plugin_readme,WARNING
+      no_plugin_readme,ERROR
       """
 
   Scenario: Check a plugin from external location but with invalid plugin

--- a/tests/phpunit/tests/Checker/Checks/Plugin_Readme_Check_Tests.php
+++ b/tests/phpunit/tests/Checker/Checks/Plugin_Readme_Check_Tests.php
@@ -18,17 +18,17 @@ class Plugin_Readme_Check_Tests extends WP_UnitTestCase {
 
 		$readme_check->run( $check_result );
 
-		$warnings = $check_result->get_warnings();
+		$errors = $check_result->get_errors();
 
-		$this->assertNotEmpty( $warnings );
-		$this->assertArrayHasKey( 'readme.txt', $warnings );
-		$this->assertEquals( 1, $check_result->get_warning_count() );
+		$this->assertNotEmpty( $errors );
+		$this->assertArrayHasKey( 'readme.txt', $errors );
+		$this->assertEquals( 1, $check_result->get_error_count() );
 
-		// Check for no readme file warning.
-		$this->assertArrayHasKey( 0, $warnings['readme.txt'] );
-		$this->assertArrayHasKey( 0, $warnings['readme.txt'][0] );
-		$this->assertArrayHasKey( 'code', $warnings['readme.txt'][0][0][0] );
-		$this->assertEquals( 'no_plugin_readme', $warnings['readme.txt'][0][0][0]['code'] );
+		// Check for no readme file error.
+		$this->assertArrayHasKey( 0, $errors['readme.txt'] );
+		$this->assertArrayHasKey( 0, $errors['readme.txt'][0] );
+		$this->assertArrayHasKey( 'code', $errors['readme.txt'][0][0][0] );
+		$this->assertEquals( 'no_plugin_readme', $errors['readme.txt'][0][0][0]['code'] );
 	}
 
 	public function test_run_with_errors_invalid_readme_files() {
@@ -38,16 +38,16 @@ class Plugin_Readme_Check_Tests extends WP_UnitTestCase {
 
 		$readme_check->run( $check_result );
 
-		$warnings = $check_result->get_warnings();
+		$errors = $check_result->get_errors();
 
-		$this->assertNotEmpty( $warnings );
-		$this->assertArrayHasKey( 'readme.txt', $warnings );
-		$this->assertEquals( 1, $check_result->get_warning_count() );
+		$this->assertNotEmpty( $errors );
+		$this->assertArrayHasKey( 'readme.txt', $errors );
+		$this->assertEquals( 1, $check_result->get_error_count() );
 
-		$this->assertArrayHasKey( 0, $warnings['readme.txt'] );
-		$this->assertArrayHasKey( 0, $warnings['readme.txt'][0] );
-		$this->assertArrayHasKey( 'code', $warnings['readme.txt'][0][0][0] );
-		$this->assertSame( 'no_plugin_readme', $warnings['readme.txt'][0][0][0]['code'] );
+		$this->assertArrayHasKey( 0, $errors['readme.txt'] );
+		$this->assertArrayHasKey( 0, $errors['readme.txt'][0] );
+		$this->assertArrayHasKey( 'code', $errors['readme.txt'][0][0][0] );
+		$this->assertSame( 'no_plugin_readme', $errors['readme.txt'][0][0][0]['code'] );
 	}
 
 	public function test_run_with_errors_invalid_name() {
@@ -93,13 +93,13 @@ class Plugin_Readme_Check_Tests extends WP_UnitTestCase {
 
 		$readme_check->run( $check_result );
 
-		$warnings = $check_result->get_warnings();
+		$errors = $check_result->get_errors();
 
-		$this->assertNotEmpty( $warnings );
-		$this->assertArrayHasKey( 'readme.txt', $warnings );
+		$this->assertNotEmpty( $errors );
+		$this->assertArrayHasKey( 'readme.txt', $errors );
 
-		// Check for default text file warning.
-		$this->assertCount( 1, wp_list_filter( $warnings['readme.txt'][0][0], array( 'code' => 'default_readme_text' ) ) );
+		// Check for default readme text error.
+		$this->assertCount( 1, wp_list_filter( $errors['readme.txt'][0][0], array( 'code' => 'default_readme_text' ) ) );
 	}
 
 	public function test_run_with_errors_stable_tag() {
@@ -213,10 +213,11 @@ class Plugin_Readme_Check_Tests extends WP_UnitTestCase {
 
 		$this->assertCount( 1, wp_list_filter( $errors['readme.md'][0][0], array( 'code' => 'trunk_stable_tag' ) ) );
 		$this->assertCount( 1, wp_list_filter( $errors['readme.md'][0][0], array( 'code' => 'outdated_tested_upto_header' ) ) );
+		$this->assertCount( 1, wp_list_filter( $errors['readme.md'][0][0], array( 'code' => 'default_readme_text' ) ) );
 
 		$this->assertNotEmpty( $warnings );
 		$this->assertArrayHasKey( 'readme.md', $warnings );
-		$this->assertCount( 1, wp_list_filter( $warnings['readme.md'][0][0], array( 'code' => 'default_readme_text' ) ) );
+
 		$this->assertCount( 1, wp_list_filter( $warnings['readme.md'][0][0], array( 'code' => 'invalid_license' ) ) );
 		$this->assertCount( 1, wp_list_filter( $warnings['readme.md'][0][0], array( 'code' => 'license_mismatch' ) ) );
 		$this->assertCount( 1, wp_list_filter( $warnings['readme.md'][0][0], array( 'code' => 'mismatched_plugin_name' ) ) );


### PR DESCRIPTION
Fixes https://github.com/WordPress/plugin-check/issues/728