### PR TITLE
Add localhost sniff

### DIFF
--- a/phpcs-sniffs/PluginCheck/Sniffs/CodeAnalysis/LocalhostSniff.php
+++ b/phpcs-sniffs/PluginCheck/Sniffs/CodeAnalysis/LocalhostSniff.php
@@ -18,7 +18,7 @@ use WordPressCS\WordPress\Sniff;
  *
  * @link https://developer.wordpress.org/plugins/wordpress-org/detailed-plugin-guidelines/
  *
- * @since 1.1.0
+ * @since 1.3.0
  */
 final class LocalhostSniff extends Sniff {
 

--- a/phpcs-sniffs/PluginCheck/Sniffs/CodeAnalysis/LocalhostSniff.php
+++ b/phpcs-sniffs/PluginCheck/Sniffs/CodeAnalysis/LocalhostSniff.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * LocalhostSniff
+ *
+ * Based on code from {@link https://github.com/WordPress/WordPress-Coding-Standards}
+ * which is licensed under {@link https://opensource.org/licenses/MIT}.
+ *
+ * @package PluginCheck
+ */
+
+namespace PluginCheckCS\PluginCheck\Sniffs\CodeAnalysis;
+
+use PHP_CodeSniffer\Util\Tokens;
+use WordPressCS\WordPress\Sniff;
+
+/**
+ * Detect localhost.
+ *
+ * @link https://developer.wordpress.org/plugins/wordpress-org/detailed-plugin-guidelines/
+ *
+ * @since 1.1.0
+ */
+final class LocalhostSniff extends Sniff {
+
+	/**
+	 * Returns an array of tokens this test wants to listen for.
+	 *
+	 * @since 1.3.0
+	 *
+	 * @return array
+	 */
+	public function register() {
+		return Tokens::$textStringTokens;
+	}
+
+	/**
+	 * Processes this test, when one of its tokens is encountered.
+	 *
+	 * @since 1.3.0
+	 *
+	 * @param int $stackPtr The position of the current token in the stack.
+	 * @return int|void Integer stack pointer to skip forward or void to continue normal file processing.
+	 */
+	public function process_token( $stackPtr ) {
+		$end_ptr = $stackPtr;
+		$content = $this->tokens[ $stackPtr ]['content'];
+
+		if ( false === stripos( $content, '//' ) ) {
+			return;
+		}
+
+		if ( preg_match_all( '#https?:\/\/(localhost|127.0.0.1|(.*\.local(host)?))\/#', $content, $matches, PREG_OFFSET_CAPTURE ) > 0 ) {
+			foreach ( $matches[0] as $match ) {
+				$this->phpcsFile->addError(
+					'Do not use Localhost/127.0.0.1 in your code. Found: %s',
+					$this->find_token_in_multiline_string( $stackPtr, $content, $match[1] ),
+					'Found',
+					[ $match[0] ]
+				);
+			}
+		}
+
+		return ( $end_ptr + 1 );
+	}
+
+	/**
+	 * Find the exact token on which the error should be reported for multi-line strings.
+	 *
+	 * @since 1.3.0
+	 *
+	 * @param int    $stackPtr     The position of the current token in the stack.
+	 * @param string $content      The complete, potentially multi-line, text string.
+	 * @param int    $match_offset The offset within the content at which the match was found.
+	 * @return int The stack pointer to the token containing the start of the match.
+	 */
+	private function find_token_in_multiline_string( $stackPtr, $content, $match_offset ) {
+		$newline_count = 0;
+		if ( $match_offset > 0 ) {
+			$newline_count = substr_count( $content, "\n", 0, $match_offset );
+		}
+
+		// Account for heredoc/nowdoc text starting at the token *after* the opener.
+		if ( isset( Tokens::$heredocTokens[ $this->tokens[ $stackPtr ]['code'] ] ) === true ) {
+			++$newline_count;
+		}
+
+		return ( $stackPtr + $newline_count );
+	}
+}

--- a/phpcs-sniffs/PluginCheck/Tests/CodeAnalysis/LocalhostUnitTest.inc
+++ b/phpcs-sniffs/PluginCheck/Tests/CodeAnalysis/LocalhostUnitTest.inc
@@ -1,0 +1,30 @@
+<?php
+
+$var            = 'This file contains https://127.0.0.1/example url.'; // Error.
+$sample_url     = 'Sample URL is http://docker.local/example here.'; // Error.
+$custom_url     = 'Custom URL https://docker.localhost/example here.'; // Error.
+$custom_content = file_get_contents("http://127.0.0.1/api.php?url=".$url); // Error.
+
+wp_register_script( 'custom-js', 'https://127.0.0.1/dist/custom.js' ); // Error.
+wp_enqueue_script( 'custom-js', 'https://127.0.0.1/dist/custom.js' ); // Error.
+wp_register_style( 'custom-css', 'http://localhost/dist/custom.css' ); // Error.
+wp_enqueue_style( 'custom-css', 'http://localhost/dist/custom.css' ); // Error.
+
+$important_links = array(
+  'view-pro'      => array(
+    'link' => esc_url( 'https://staging.local/resources' ), // Error.
+  ),
+);
+
+// This file contains https://localhost/test-plugin-localhost-with-errors url. Good.
+
+/*
+ * Another comment https://localhost/test-plugin-localhost-with-errors URL.
+ */
+
+$multiple_urls = 'Custom URL https://docker.localhost/example and https://localhost/example.php here.'; // Error.
+?>
+
+<img src="<?php echo "http://localhost/image.png"; ?>" alt="" /><!-- Error. -->
+
+<p>URL in inline HTML is http://localhost/example2.php bad.</p><!-- Error. -->

--- a/phpcs-sniffs/PluginCheck/Tests/CodeAnalysis/LocalhostUnitTest.php
+++ b/phpcs-sniffs/PluginCheck/Tests/CodeAnalysis/LocalhostUnitTest.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * Unit tests for LocalhostSniff.
+ *
+ * @package PluginCheck
+ */
+
+namespace PluginCheckCS\PluginCheck\Tests\CodeAnalysis;
+
+use PluginCheckCS\PluginCheck\Sniffs\CodeAnalysis\LocalhostSniff;
+use PluginCheckCS\PluginCheck\Tests\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Sniffs\Sniff;
+
+/**
+ * Unit tests for LocalhostSniff.
+ */
+final class LocalhostUnitTest extends AbstractSniffUnitTest {
+
+	/**
+	 * Returns the lines where errors should occur.
+	 *
+	 * @return array <int line number> => <int number of errors>
+	 */
+	public function getErrorList() {
+		return array(
+			3  => 1,
+			4  => 1,
+			5  => 1,
+			6  => 1,
+			8  => 1,
+			9  => 1,
+			10 => 1,
+			11 => 1,
+			15 => 1,
+			25 => 2,
+			28 => 1,
+			30 => 1,
+		);
+	}
+
+	/**
+	 * Returns the lines where warnings should occur.
+	 *
+	 * @return array <int line number> => <int number of warnings>
+	 */
+	public function getWarningList() {
+		return array();
+	}
+
+	/**
+	 * Returns the fully qualified class name (FQCN) of the sniff.
+	 *
+	 * @return string The fully qualified class name of the sniff.
+	 */
+	protected function get_sniff_fqcn() {
+		return LocalhostSniff::class;
+	}
+
+	/**
+	 * Sets the parameters for the sniff.
+	 *
+	 * @throws \RuntimeException If unable to set the ruleset parameters required for the test.
+	 *
+	 * @param Sniff $sniff The sniff being tested.
+	 */
+	public function set_sniff_parameters( Sniff $sniff ) {
+	}
+}

--- a/phpcs-sniffs/PluginCheck/ruleset.xml
+++ b/phpcs-sniffs/PluginCheck/ruleset.xml
@@ -4,7 +4,8 @@
 	<description>Plugin Check Sniffs</description>
 
 	<rule ref="PluginCheck.CodeAnalysis.EnqueuedResourceOffloading" />
-	<rule ref="PluginCheck.CodeAnalysis.Offloading" />
 	<rule ref="PluginCheck.CodeAnalysis.ImageFunctions" />
+	<rule ref="PluginCheck.CodeAnalysis.Localhost" />
+	<rule ref="PluginCheck.CodeAnalysis.Offloading" />
 
 </ruleset>

--- a/tests/phpunit/tests/Checker/Checks/Localhost_Check_Tests.php
+++ b/tests/phpunit/tests/Checker/Checks/Localhost_Check_Tests.php
@@ -21,24 +21,11 @@ class Localhost_Check_Tests extends WP_UnitTestCase {
 		$errors = $check_result->get_errors();
 
 		$this->assertNotEmpty( $errors );
-		$this->assertArrayHasKey( 'load.php', $errors );
+		$this->assertArrayNotHasKey( 'load.php', $errors ); // Localhost in comment should not be error.
 		$this->assertArrayHasKey( 'another.php', $errors );
-		$this->assertSame( 4, $check_result->get_error_count() );
 
-		$this->assertArrayHasKey( 19, $errors['load.php'] );
-		$this->assertArrayHasKey( 24, $errors['load.php'][19] );
-		$this->assertCount( 1, wp_list_filter( $errors['load.php'][19][24], array( 'code' => 'localhost_code_detected' ) ) );
-
-		$this->assertArrayHasKey( 2, $errors['another.php'] );
-		$this->assertArrayHasKey( 35, $errors['another.php'][2] );
-		$this->assertCount( 1, wp_list_filter( $errors['another.php'][2][35], array( 'code' => 'localhost_code_detected' ) ) );
-
-		$this->assertArrayHasKey( 3, $errors['another.php'] );
-		$this->assertArrayHasKey( 30, $errors['another.php'][3] );
-		$this->assertCount( 1, wp_list_filter( $errors['another.php'][3][30], array( 'code' => 'localhost_code_detected' ) ) );
-
-		$this->assertArrayHasKey( 4, $errors['another.php'] );
-		$this->assertArrayHasKey( 27, $errors['another.php'][4] );
-		$this->assertCount( 1, wp_list_filter( $errors['another.php'][4][27], array( 'code' => 'localhost_code_detected' ) ) );
+		$this->assertCount( 1, wp_list_filter( $errors['another.php'][2][15], array( 'code' => 'PluginCheck.CodeAnalysis.Localhost.Found' ) ) );
+		$this->assertCount( 1, wp_list_filter( $errors['another.php'][3][15], array( 'code' => 'PluginCheck.CodeAnalysis.Localhost.Found' ) ) );
+		$this->assertCount( 1, wp_list_filter( $errors['another.php'][4][15], array( 'code' => 'PluginCheck.CodeAnalysis.Localhost.Found' ) ) );
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/WordPress/plugin-check/issues/267

- Add sniff `PluginCheck.CodeAnalysis.Localhost`
- Update `Localhost_Check` to use new sniff
- Localhost in comments will be ignored now