### PR TITLE
License check improvements

### DIFF
--- a/includes/Checker/Checks/Plugin_Repo/Plugin_Readme_Check.php
+++ b/includes/Checker/Checks/Plugin_Repo/Plugin_Readme_Check.php
@@ -327,6 +327,22 @@ class Plugin_Readme_Check extends Abstract_File_Check {
 			$this->add_result_warning_for_file(
 				$result,
 				__( '<strong>Your plugin has an invalid license declared.</strong><br>Please update your readme with a valid SPDX license identifier.', 'plugin-check' ),
+				'invalid_license_identifier',
+				$readme_file,
+				0,
+				0,
+				'https://developer.wordpress.org/plugins/wordpress-org/common-issues/#no-gpl-compatible-license-declared',
+				9
+			);
+
+			return;
+		}
+
+		// Test for a valid GPL compatible license.
+		if ( ! $this->is_gpl_compatible_license( $license ) ) {
+			$this->add_result_warning_for_file(
+				$result,
+				__( '<strong>Your plugin has an invalid license declared.</strong><br>Please update your readme with a valid GPL compatible license identifier.', 'plugin-check' ),
 				'invalid_license',
 				$readme_file,
 				0,

--- a/includes/Traits/License_Utils.php
+++ b/includes/Traits/License_Utils.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * Trait WordPress\Plugin_Check\Traits\License_Utils
+ *
+ * @package plugin-check
+ */
+
+namespace WordPress\Plugin_Check\Traits;
+
+/**
+ * Trait for license utilities.
+ *
+ * @since 1.0.0
+ */
+trait License_Utils {
+
+	/**
+	 * Returns normalized license.
+	 *
+	 * @since 1.3.0
+	 *
+	 * @param string $license The license to normalize.
+	 * @return string Normalized license.
+	 */
+	protected function get_normalized_license( $license ) {
+		$license = trim( $license );
+		$license = str_replace( '  ', ' ', $license );
+
+		// Remove some strings at the end.
+		$strings_to_remove = array(
+			'.',
+			'http://www.gnu.org/licenses/old-licenses/gpl-2.0.html',
+			'https://www.gnu.org/licenses/old-licenses/gpl-2.0.html',
+			'https://www.gnu.org/licenses/gpl-3.0.html',
+			' or later',
+			'-or-later',
+			'+',
+		);
+		foreach ( $strings_to_remove as $string_to_remove ) {
+			$position = strrpos( $license, $string_to_remove );
+
+			if ( false !== $position ) {
+				// To remove from the end, the string to remove must be at the end.
+				if ( $position + strlen( $string_to_remove ) === strlen( $license ) ) {
+					$license = trim( substr( $license, 0, $position ) );
+				}
+			}
+		}
+
+		// Versions.
+		$license = str_replace( '-', '', $license );
+		$license = str_replace( 'GNU General Public License (GPL)', 'GPL', $license );
+		$license = str_replace( 'GNU General Public License', 'GPL', $license );
+		$license = str_replace( ' version ', 'v', $license );
+		$license = preg_replace( '/GPL\s*[-|\.]*\s*[v]?([0-9])(\.[0])?/i', 'GPL$1', $license, 1 );
+		$license = str_replace( '.', '', $license );
+
+		return $license;
+	}
+
+	/**
+	 * Checks if the license is valid identifier.
+	 *
+	 * @since 1.3.0
+	 *
+	 * @param string $license License text.
+	 * @return bool true if the license is valid identifier, otherwise false.
+	 */
+	protected function is_valid_license_identifier( $license ) {
+		$match = preg_match( '/^([a-z0-9\-\+\.]+)(\sor\s([a-z0-9\-\+\.]+))*$/i', $license );
+
+		return ( false === $match || 0 === $match ) ? false : true;
+	}
+
+	/**
+	 * Checks if the license is GPL compatible.
+	 *
+	 * @since 1.3.0
+	 *
+	 * @param string $license License text.
+	 * @return bool true if the license is GPL compatible, otherwise false.
+	 */
+	protected function is_gpl_compatible_license( $license ) {
+		$match = preg_match( '/GPL|GNU|MIT|FreeBSD|New BSD|BSD-3-Clause|BSD 3 Clause|OpenLDAP|Expat|Apache/im', $license );
+
+		return ( false === $match || 0 === $match ) ? false : true;
+	}
+}

--- a/tests/behat/features/plugin-check.feature
+++ b/tests/behat/features/plugin-check.feature
@@ -611,3 +611,25 @@ Feature: Test that the WP-CLI command works.
 	  """
 	  Success: Checks complete. No errors found.
 	  """
+
+  Scenario: Check for missing license in single file plugin
+    Given a WP install with the Plugin Check plugin
+    And a wp-content/plugins/foo-single.php file:
+      """
+      <?php
+      /**
+       * Plugin Name: Foo Single
+       * Plugin URI: https://foo-single.com
+       * Description: Custom plugin.
+       * Version: 0.1.0
+       * Author: WordPress Performance Team
+       * Author URI: https://make.wordpress.org/performance/
+       */
+
+      """
+
+    When I run the WP-CLI command `plugin check foo-single.php`
+    Then STDOUT should contain:
+      """
+      plugin_header_no_license
+      """

--- a/tests/phpunit/testdata/plugins/test-plugin-plugin-readme-errors-invalid-license/load.php
+++ b/tests/phpunit/testdata/plugins/test-plugin-plugin-readme-errors-invalid-license/load.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Plugin Name: Test Plugin Readme Errors (no license)
+ * Plugin Name: Test Plugin Readme Errors (invalid license)
  * Plugin URI: https://github.com/WordPress/plugin-check
  * Description: Test plugin for the Readme check.
  * Requires at least: 6.0
@@ -8,7 +8,8 @@
  * Version: 1.0.0
  * Author: WordPress Performance Team
  * Author URI: https://make.wordpress.org/performance/
- * Text Domain: test-plugin-check-errors-no-license
+ * License: Oculus VR Inc. Software Development Kit License
+ * Text Domain: test-plugin-check-errors-invalid-license
  *
- * @package test-plugin-check-errors-no-license
+ * @package test-plugin-check-errors-invalid-license
  */

--- a/tests/phpunit/testdata/plugins/test-plugin-plugin-readme-errors-invalid-license/readme.txt
+++ b/tests/phpunit/testdata/plugins/test-plugin-plugin-readme-errors-invalid-license/readme.txt
@@ -1,0 +1,11 @@
+=== Test Plugin with readme ===
+
+Contributors:      plugin-check
+Requires at least: 6.0
+Tested up to:      6.6
+Requires PHP:      5.6
+Stable tag:        1.0.0
+Tags:              testing, security
+License:           Oculus VR Inc. Software Development Kit License
+
+Plugin description.

--- a/tests/phpunit/tests/Checker/Checks/Plugin_Header_Fields_Check_Tests.php
+++ b/tests/phpunit/tests/Checker/Checks/Plugin_Header_Fields_Check_Tests.php
@@ -57,4 +57,49 @@ class Plugin_Header_Fields_Check_Tests extends WP_UnitTestCase {
 			$this->assertCount( 0, wp_list_filter( $warnings['load.php'][0][0], array( 'code' => 'plugin_header_invalid_requires_plugins' ) ) );
 		}
 	}
+
+	public function test_run_with_errors_no_license() {
+		$check         = new Plugin_Header_Fields_Check();
+		$check_context = new Check_Context( UNIT_TESTS_PLUGIN_DIR . 'test-plugin-plugin-readme-errors-no-license/load.php' );
+		$check_result  = new Check_Result( $check_context );
+
+		$check->run( $check_result );
+
+		$errors = $check_result->get_errors();
+
+		$this->assertNotEmpty( $errors );
+		$this->assertArrayHasKey( 'load.php', $errors );
+
+		$this->assertCount( 1, wp_list_filter( $errors['load.php'][0][0], array( 'code' => 'plugin_header_no_license' ) ) );
+	}
+
+	public function test_run_with_errors_mismatched_license() {
+		$check         = new Plugin_Header_Fields_Check();
+		$check_context = new Check_Context( UNIT_TESTS_PLUGIN_DIR . 'test-plugin-plugin-readme-errors-license/load.php' );
+		$check_result  = new Check_Result( $check_context );
+
+		$check->run( $check_result );
+
+		$warnings = $check_result->get_warnings();
+
+		$this->assertNotEmpty( $warnings );
+		$this->assertArrayHasKey( 'load.php', $warnings );
+
+		$this->assertCount( 1, wp_list_filter( $warnings['load.php'][0][0], array( 'code' => 'license_mismatch' ) ) );
+	}
+
+	public function test_run_with_errors_invalid_license() {
+		$check         = new Plugin_Header_Fields_Check();
+		$check_context = new Check_Context( UNIT_TESTS_PLUGIN_DIR . 'test-plugin-plugin-readme-errors-invalid-license/load.php' );
+		$check_result  = new Check_Result( $check_context );
+
+		$check->run( $check_result );
+
+		$errors = $check_result->get_errors();
+
+		$this->assertNotEmpty( $errors );
+		$this->assertArrayHasKey( 'load.php', $errors );
+
+		$this->assertCount( 1, wp_list_filter( $errors['load.php'][0][0], array( 'code' => 'plugin_header_invalid_license' ) ) );
+	}
 }

--- a/tests/phpunit/tests/Checker/Checks/Plugin_Readme_Check_Tests.php
+++ b/tests/phpunit/tests/Checker/Checks/Plugin_Readme_Check_Tests.php
@@ -157,9 +157,6 @@ class Plugin_Readme_Check_Tests extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 0, $warnings['readme.txt'] );
 		$this->assertArrayHasKey( 0, $warnings['readme.txt'][0] );
 		$this->assertCount( 1, wp_list_filter( $warnings['readme.txt'][0][0], array( 'code' => 'invalid_license' ) ) );
-
-		// Check for not same license warning.
-		$this->assertCount( 1, wp_list_filter( $warnings['readme.txt'][0][0], array( 'code' => 'license_mismatch' ) ) );
 	}
 
 	public function test_run_with_errors_no_license() {
@@ -178,6 +175,21 @@ class Plugin_Readme_Check_Tests extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 0, $errors['readme.txt'] );
 		$this->assertArrayHasKey( 0, $errors['readme.txt'][0] );
 		$this->assertCount( 1, wp_list_filter( $errors['readme.txt'][0][0], array( 'code' => 'no_license' ) ) );
+	}
+
+	public function test_run_with_errors_invalid_license() {
+		$readme_check  = new Plugin_Readme_Check();
+		$check_context = new Check_Context( UNIT_TESTS_PLUGIN_DIR . 'test-plugin-plugin-readme-errors-invalid-license/load.php' );
+		$check_result  = new Check_Result( $check_context );
+
+		$readme_check->run( $check_result );
+
+		$warnings = $check_result->get_warnings();
+
+		$this->assertNotEmpty( $warnings );
+		$this->assertArrayHasKey( 'readme.txt', $warnings );
+
+		$this->assertCount( 1, wp_list_filter( $warnings['readme.txt'][0][0], array( 'code' => 'invalid_license' ) ) );
 	}
 
 	public function test_run_with_errors_tested_upto() {
@@ -219,7 +231,6 @@ class Plugin_Readme_Check_Tests extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'readme.md', $warnings );
 
 		$this->assertCount( 1, wp_list_filter( $warnings['readme.md'][0][0], array( 'code' => 'invalid_license' ) ) );
-		$this->assertCount( 1, wp_list_filter( $warnings['readme.md'][0][0], array( 'code' => 'license_mismatch' ) ) );
 		$this->assertCount( 1, wp_list_filter( $warnings['readme.md'][0][0], array( 'code' => 'mismatched_plugin_name' ) ) );
 		$this->assertCount( 1, wp_list_filter( $warnings['readme.md'][0][0], array( 'code' => 'readme_invalid_contributors' ) ) );
 	}

--- a/tests/phpunit/tests/Checker/Checks/Plugin_Readme_Check_Tests.php
+++ b/tests/phpunit/tests/Checker/Checks/Plugin_Readme_Check_Tests.php
@@ -156,7 +156,7 @@ class Plugin_Readme_Check_Tests extends WP_UnitTestCase {
 		// Check for invalid license warning.
 		$this->assertArrayHasKey( 0, $warnings['readme.txt'] );
 		$this->assertArrayHasKey( 0, $warnings['readme.txt'][0] );
-		$this->assertCount( 1, wp_list_filter( $warnings['readme.txt'][0][0], array( 'code' => 'invalid_license' ) ) );
+		$this->assertCount( 1, wp_list_filter( $warnings['readme.txt'][0][0], array( 'code' => 'invalid_license_identifier' ) ) );
 	}
 
 	public function test_run_with_errors_no_license() {
@@ -189,7 +189,7 @@ class Plugin_Readme_Check_Tests extends WP_UnitTestCase {
 		$this->assertNotEmpty( $warnings );
 		$this->assertArrayHasKey( 'readme.txt', $warnings );
 
-		$this->assertCount( 1, wp_list_filter( $warnings['readme.txt'][0][0], array( 'code' => 'invalid_license' ) ) );
+		$this->assertCount( 1, wp_list_filter( $warnings['readme.txt'][0][0], array( 'code' => 'invalid_license_identifier' ) ) );
 	}
 
 	public function test_run_without_error_mpl2_license() {
@@ -199,9 +199,10 @@ class Plugin_Readme_Check_Tests extends WP_UnitTestCase {
 
 		$readme_check->run( $check_result );
 
-		$errors = $check_result->get_errors();
+		$warnings = $check_result->get_warnings();
 
-		$this->assertEmpty( $errors );
+		$this->assertNotEmpty( $warnings );
+		$this->assertCount( 0, wp_list_filter( $warnings['readme.txt'][0][0], array( 'code' => 'invalid_license' ) ) );
 	}
 
 	public function test_run_with_errors_mpl1_license() {
@@ -211,15 +212,15 @@ class Plugin_Readme_Check_Tests extends WP_UnitTestCase {
 
 		$readme_check->run( $check_result );
 
-		$errors = $check_result->get_errors();
+		$warnings = $check_result->get_warnings();
 
-		$this->assertNotEmpty( $errors );
-		$this->assertArrayHasKey( 'load.php', $errors );
+		$this->assertNotEmpty( $warnings );
+		$this->assertArrayHasKey( 'readme.txt', $warnings );
 
 		// Check for invalid license.
-		$this->assertArrayHasKey( 0, $errors['load.php'] );
-		$this->assertArrayHasKey( 0, $errors['load.php'][0] );
-		$this->assertCount( 1, wp_list_filter( $errors['load.php'][0][0], array( 'code' => 'invalid_license' ) ) );
+		$this->assertArrayHasKey( 0, $warnings['readme.txt'] );
+		$this->assertArrayHasKey( 0, $warnings['readme.txt'][0] );
+		$this->assertCount( 1, wp_list_filter( $warnings['readme.txt'][0][0], array( 'code' => 'invalid_license' ) ) );
 	}
 
 	public function test_run_with_errors_tested_upto() {
@@ -260,7 +261,7 @@ class Plugin_Readme_Check_Tests extends WP_UnitTestCase {
 		$this->assertNotEmpty( $warnings );
 		$this->assertArrayHasKey( 'readme.md', $warnings );
 
-		$this->assertCount( 1, wp_list_filter( $warnings['readme.md'][0][0], array( 'code' => 'invalid_license' ) ) );
+		$this->assertCount( 1, wp_list_filter( $warnings['readme.md'][0][0], array( 'code' => 'invalid_license_identifier' ) ) );
 		$this->assertCount( 1, wp_list_filter( $warnings['readme.md'][0][0], array( 'code' => 'mismatched_plugin_name' ) ) );
 		$this->assertCount( 1, wp_list_filter( $warnings['readme.md'][0][0], array( 'code' => 'readme_invalid_contributors' ) ) );
 	}


### PR DESCRIPTION
Fixes https://github.com/WordPress/plugin-check/issues/737

* Add `License_Utils` trait
* New trait is used in `Plugin_Readme_Check` and `Plugin_Header_Fields_Check`
* Add new error codes: `plugin_header_no_license` and `plugin_header_invalid_license` (Earlier same error code `no_license` was used for missing license in readme and plugin header which is confusing)
* `license_mismatch` error code is moved from `Plugin_Readme_Check` to `Plugin_Header_Fields_Check`
* Update unit tests to reflect changes
* Add unit test for invalid license
* Add scenario for missing license in single file plugin