### PR TITLE
Fix addon checks not being executed when running runtime checks

### DIFF
--- a/includes/Checker/Default_Check_Repository.php
+++ b/includes/Checker/Default_Check_Repository.php
@@ -20,7 +20,7 @@ class Default_Check_Repository extends Empty_Check_Repository {
 	 * If the class is instantiated before plugins are loaded, this will be set to false.
 	 * This way the checks will be re-initialized once plugins have been loaded, and only then it is set to true.
 	 *
-	 * @since n.e.x.t
+	 * @since 1.3.0
 	 * @var bool
 	 */
 	protected $fully_initialized;

--- a/includes/Checker/Default_Check_Repository.php
+++ b/includes/Checker/Default_Check_Repository.php
@@ -31,7 +31,7 @@ class Default_Check_Repository extends Empty_Check_Repository {
 	 * @since 1.0.0
 	 */
 	public function __construct() {
-		$this->fully_initialized = did_action( 'plugins_loaded' );
+		$this->fully_initialized = did_action( 'plugins_loaded' ) === 0;
 		$this->register_default_checks();
 	}
 

--- a/includes/Checker/Default_Check_Repository.php
+++ b/includes/Checker/Default_Check_Repository.php
@@ -31,7 +31,7 @@ class Default_Check_Repository extends Empty_Check_Repository {
 	 * @since 1.0.0
 	 */
 	public function __construct() {
-		$this->fully_initialized = did_action( 'plugins_loaded' ) === 0;
+		$this->fully_initialized = did_action( 'plugins_loaded' ) > 0;
 		$this->register_default_checks();
 	}
 

--- a/includes/Checker/Default_Check_Repository.php
+++ b/includes/Checker/Default_Check_Repository.php
@@ -15,12 +15,44 @@ namespace WordPress\Plugin_Check\Checker;
 class Default_Check_Repository extends Empty_Check_Repository {
 
 	/**
+	 * True if the class was fully initialized.
+	 *
+	 * If the class is instantiated before plugins are loaded, this will be set to false.
+	 * This way the checks will be re-initialized once plugins have been loaded, and only then it is set to true.
+	 *
+	 * @since n.e.x.t
+	 * @var bool
+	 */
+	protected $fully_initialized;
+
+	/**
 	 * Initializes checks.
 	 *
 	 * @since 1.0.0
 	 */
 	public function __construct() {
+		$this->fully_initialized = did_action( 'plugins_loaded' );
 		$this->register_default_checks();
+	}
+
+	/**
+	 * Returns an array of checks.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param int $flags The check type flag.
+	 * @return Check_Collection Check collection providing an indexed array of check instances.
+	 */
+	public function get_checks( $flags = self::TYPE_ALL ) {
+		// Once plugins have been loaded, re-initialize the checks.
+		if ( ! $this->fully_initialized && did_action( 'plugins_loaded' ) ) {
+			$this->fully_initialized = true;
+			$this->runtime_checks    = array();
+			$this->static_checks     = array();
+			$this->register_default_checks();
+		}
+
+		return parent::get_checks( $flags );
 	}
 
 	/**

--- a/tests/behat/features/plugin-check.feature
+++ b/tests/behat/features/plugin-check.feature
@@ -556,14 +556,14 @@ Feature: Test that the WP-CLI command works.
       ExampleRuntimeCheck.ForbiddenScript,WARNING
       """
 
-    # Same again, to verify object-cache.php was properly cleared again
-    When I run the WP-CLI command `plugin check foo-sample --fields=code,type --format=csv --require=./wp-content/plugins/plugin-check/cli.php`
+    # Same again but without requiring the cli.php file, to verify object-cache.php was properly cleared again
+    When I run the WP-CLI command `plugin check foo-sample --fields=code,type --format=csv`
     Then STDOUT should contain:
       """
       WordPress.WP.EnqueuedResourceParameters.NotInFooter,WARNING
       """
 
-    And STDOUT should contain:
+    And STDOUT should not contain:
       """
       ExampleRuntimeCheck.ForbiddenScript,WARNING
       """

--- a/tests/behat/features/plugin-check.feature
+++ b/tests/behat/features/plugin-check.feature
@@ -551,11 +551,10 @@ Feature: Test that the WP-CLI command works.
       """
       WordPress.WP.EnqueuedResourceParameters.NotInFooter,WARNING
       """
-# This doesn't currently work, because we are not actually loading any other plugins, including pcp-addon.
-#    And STDOUT should contain:
-#      """
-#      ExampleRuntimeCheck.ForbiddenScript,WARNING
-#      """
+    And STDOUT should contain:
+      """
+      ExampleRuntimeCheck.ForbiddenScript,WARNING
+      """
 
     # Same again, to verify object-cache.php was properly cleared again
     When I run the WP-CLI command `plugin check foo-sample --fields=code,type --format=csv --require=./wp-content/plugins/plugin-check/cli.php`
@@ -564,27 +563,24 @@ Feature: Test that the WP-CLI command works.
       WordPress.WP.EnqueuedResourceParameters.NotInFooter,WARNING
       """
 
-    # This doesn't currently work, because we are not actually loading any other plugins, including pcp-addon.
-#    And STDOUT should contain:
-#      """
-#      ExampleRuntimeCheck.ForbiddenScript,WARNING
-#      """
+    And STDOUT should contain:
+      """
+      ExampleRuntimeCheck.ForbiddenScript,WARNING
+      """
 
-    # This doesn't currently work.
     # Run one runtime check from PCP and one from pcp-addon.
-#    When I run the WP-CLI command `plugin check foo-sample --checks=non_blocking_scripts,example_runtime --fields=code,type --format=csv --require=./wp-content/plugins/plugin-check/cli.php`
-#    Then STDOUT should contain:
-#      """
-#      ExampleRuntimeCheck.ForbiddenScript,WARNING
-#      """
+    When I run the WP-CLI command `plugin check foo-sample --checks=non_blocking_scripts,example_runtime --fields=code,type --format=csv --require=./wp-content/plugins/plugin-check/cli.php`
+    Then STDOUT should contain:
+      """
+      ExampleRuntimeCheck.ForbiddenScript,WARNING
+      """
 
-    # This doesn't currently work, because we are not actually loading any other plugins, including pcp-addon.
     # Run only the runtime check from pcp-addon, no others
-#    When I run the WP-CLI command `plugin check foo-sample --checks=example_runtime --fields=code,type --format=csv --require=./wp-content/plugins/plugin-check/cli.php`
-#    Then STDOUT should contain:
-#      """
-#      ExampleRuntimeCheck.ForbiddenScript,WARNING
-#      """
+    When I run the WP-CLI command `plugin check foo-sample --checks=example_runtime --fields=code,type --format=csv --require=./wp-content/plugins/plugin-check/cli.php`
+    Then STDOUT should contain:
+      """
+      ExampleRuntimeCheck.ForbiddenScript,WARNING
+      """
 
   Scenario: Check custom single file plugin that has no errors or warnings
     Given a WP install with the Plugin Check plugin


### PR DESCRIPTION
**This is a child PR of #749. Please merge that one first.**

Fixes #607.

As noted prior, despite our various fixes related to e.g. #597, addon runtime checks still don't work as of today. This PR aims to fix that.

It looks like the underlying problem is that the `Default_Check_Repository` runs the `wp_plugin_check_checks` filter too early when any runtime checks are being run. Now that I noticed it, it seems like an obvious oversight, but was kind of hard to spot 😅 

To address this problem, we simply need to ensure the filter is run again after plugins have been loaded.

For the scenario where the `Default_Check_Repository` is instantiated when plugins are already loaded, no change is needed, in this case we can set a flag that the checks are "fully initialized" from the start.