### PR TITLE
Always use prefixed tables during runtime check requests

### DIFF
--- a/includes/Checker/Abstract_Check_Runner.php
+++ b/includes/Checker/Abstract_Check_Runner.php
@@ -358,22 +358,12 @@ abstract class Abstract_Check_Runner implements Check_Runner {
 	 *
 	 * @since 1.0.0
 	 *
-	 * @global wpdb   $wpdb         WordPress database abstraction object.
-	 * @global string $table_prefix The database table prefix.
-	 *
 	 * @return Check_Result An object containing all check results.
 	 */
 	final public function run() {
-		global $wpdb, $table_prefix;
 		$checks       = $this->get_checks_to_run();
 		$preparations = $this->get_shared_preparations( $checks );
 		$cleanups     = array();
-		$old_prefix   = null;
-
-		// Set the correct test database prefix if required.
-		if ( $this->has_runtime_check( $checks ) ) {
-			$old_prefix = $wpdb->set_prefix( $table_prefix . 'pc_' );
-		}
 
 		// Prepare all shared preparations.
 		foreach ( $preparations as $preparation ) {
@@ -387,11 +377,6 @@ abstract class Abstract_Check_Runner implements Check_Runner {
 			foreach ( $cleanups as $cleanup ) {
 				$cleanup();
 			}
-		}
-
-		// Restore the old prefix.
-		if ( $old_prefix ) {
-			$wpdb->set_prefix( $old_prefix );
 		}
 
 		return $results;

--- a/includes/Checker/Preparations/Universal_Runtime_Preparation.php
+++ b/includes/Checker/Preparations/Universal_Runtime_Preparation.php
@@ -61,11 +61,17 @@ class Universal_Runtime_Preparation implements Preparation {
 			$theme_folder = WP_PLUGIN_CHECK_PLUGIN_DIR_PATH . 'runtime-content/themes';
 		}
 
+		$use_custom_db_tables_preparation = new Use_Custom_DB_Tables_Preparation();
+		$cleanup_functions[]              = $use_custom_db_tables_preparation->prepare();
+
 		$use_minimal_theme_preparation = new Use_Minimal_Theme_Preparation( 'wp-empty-theme', $theme_folder );
 		$cleanup_functions[]           = $use_minimal_theme_preparation->prepare();
 
 		$force_single_plugin_preparation = new Force_Single_Plugin_Preparation( $this->check_context->basename() );
 		$cleanup_functions[]             = $force_single_plugin_preparation->prepare();
+
+		// Revert order so that earlier preparations are cleaned up later.
+		$cleanup_functions = array_reverse( $cleanup_functions );
 
 		// Return the cleanup function.
 		return function () use ( $cleanup_functions ) {

--- a/includes/Checker/Preparations/Use_Custom_DB_Tables_Preparation.php
+++ b/includes/Checker/Preparations/Use_Custom_DB_Tables_Preparation.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Class WordPress\Plugin_Check\Checker\Preparations\Use_Custom_DB_Tables_Preparation
+ *
+ * @package plugin-check
+ */
+
+namespace WordPress\Plugin_Check\Checker\Preparations;
+
+use Exception;
+use WordPress\Plugin_Check\Checker\Preparation;
+
+/**
+ * Class for the preparation step to use the custom database tables.
+ *
+ * This ensures no side effects on the actual database tables are possible.
+ *
+ * @since 1.3.0
+ */
+class Use_Custom_DB_Tables_Preparation implements Preparation {
+
+	/**
+	 * Runs this preparation step for the environment and returns a cleanup function.
+	 *
+	 * @since 1.3.0
+	 *
+	 * @global wpdb   $wpdb         WordPress database abstraction object.
+	 * @global string $table_prefix The database table prefix.
+	 *
+	 * @return callable Cleanup function to revert any changes made here.
+	 *
+	 * @throws Exception Thrown when preparation fails.
+	 */
+	public function prepare() {
+		global $wpdb, $table_prefix;
+
+		$old_prefix = $wpdb->set_prefix( $table_prefix . 'pc_' );
+
+		// Return the cleanup function.
+		return function () use ( $old_prefix ) {
+			global $wpdb;
+
+			$wpdb->set_prefix( $old_prefix );
+		};
+	}
+}

--- a/includes/Checker/Runtime_Environment_Setup.php
+++ b/includes/Checker/Runtime_Environment_Setup.php
@@ -138,6 +138,37 @@ final class Runtime_Environment_Setup {
 	}
 
 	/**
+	 * Tests if the runtime environment is currently set up.
+	 *
+	 * This returns true when the plugin's object-cache.php drop-in is active in the current request and/or when the
+	 * custom runtime environment database tables are present.
+	 *
+	 * @since 1.3.0
+	 *
+	 * @global wpdb   $wpdb         WordPress database abstraction object.
+	 * @global string $table_prefix The database table prefix.
+	 *
+	 * @return bool True if the runtime environment is set up, false if not.
+	 */
+	public function is_set_up() {
+		global $wpdb, $table_prefix;
+
+		if ( defined( 'WP_PLUGIN_CHECK_OBJECT_CACHE_DROPIN_VERSION' ) ) {
+			return true;
+		}
+
+		// Set the custom prefix to check for the runtime environment tables.
+		$old_prefix = $wpdb->set_prefix( $table_prefix . 'pc_' );
+
+		$tables_present = $wpdb->posts === $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $wpdb->posts ) );
+
+		// Restore the old prefix.
+		$wpdb->set_prefix( $old_prefix );
+
+		return $tables_present;
+	}
+
+	/**
 	 * Checks if the WordPress Environment can be set up for runtime checks.
 	 *
 	 * @since 1.0.0

--- a/tests/phpunit/tests/Utilities/Plugin_Request_Utility_Tests.php
+++ b/tests/phpunit/tests/Utilities/Plugin_Request_Utility_Tests.php
@@ -19,10 +19,21 @@ class Plugin_Request_Utility_Tests extends WP_UnitTestCase {
 
 	use With_Mock_Filesystem;
 
+	/**
+	 * Storage for preparation cleanups that need to be run after a test.
+	 *
+	 * @var array
+	 */
+	private $cleanups = array();
+
 	public function tear_down() {
-		// Force reset the database prefix after runner prepare method called.
-		global $wpdb, $table_prefix;
-		$wpdb->set_prefix( $table_prefix );
+		if ( count( $this->cleanups ) > 0 ) {
+			$this->cleanups = array_reverse( $this->cleanups );
+			foreach ( $this->cleanups as $cleanup ) {
+				$cleanup();
+			}
+			$this->cleanups = array();
+		}
 		parent::tear_down();
 	}
 
@@ -61,6 +72,9 @@ class Plugin_Request_Utility_Tests extends WP_UnitTestCase {
 		);
 
 		Plugin_Request_Utility::initialize_runner();
+		$this->cleanups[] = function () {
+			Plugin_Request_Utility::destroy_runner();
+		};
 
 		do_action( 'muplugins_loaded' );
 
@@ -77,6 +91,9 @@ class Plugin_Request_Utility_Tests extends WP_UnitTestCase {
 		$_REQUEST['plugin'] = 'plugin-check';
 
 		Plugin_Request_Utility::initialize_runner();
+		$this->cleanups[] = function () {
+			Plugin_Request_Utility::destroy_runner();
+		};
 
 		do_action( 'muplugins_loaded' );
 
@@ -117,6 +134,9 @@ class Plugin_Request_Utility_Tests extends WP_UnitTestCase {
 		unset( $wp_actions['muplugins_loaded'] );
 
 		Plugin_Request_Utility::initialize_runner();
+		$this->cleanups[] = function () {
+			Plugin_Request_Utility::destroy_runner();
+		};
 
 		do_action( 'muplugins_loaded' );
 
@@ -161,6 +181,9 @@ class Plugin_Request_Utility_Tests extends WP_UnitTestCase {
 		unset( $wp_actions['muplugins_loaded'] );
 
 		Plugin_Request_Utility::initialize_runner();
+		$this->cleanups[] = function () {
+			Plugin_Request_Utility::destroy_runner();
+		};
 
 		do_action( 'muplugins_loaded' );
 


### PR DESCRIPTION
Related to #597 (see 2nd point in the description, also see [this doc comment](https://docs.google.com/document/d/1wDGZBwWB2WAxfbHE3lygIzQFK8IssCa5apOyaBolukQ/edit?disco=AAABUzHEE-g)).

While for the checks itself it's fine to only use the custom database prefix right when the checks are run, this poses some risks because certain parts of the environment (e.g. active plugins, active theme) are already filtered. This could lead to problematic side effects on the actual database tables depending on what plugins do - potentially disastrous, if it was a live site.

Therefore this PR sets the custom database prefix as part of overall runtime preparations (via `Universal_Runtime_Preparation`) so that it remains for the duration of more or less the entire request:
* The relevant process of setting the prefix in the `Abstract_Check_Runner::run()` method has been removed as it is now unnecessary there.
* This change led to the PHPUnit test `AJAX_Runner_Tests::test_prepare_with_runtime_check()` to fail, which however was exactly _because_ of the problem this PR is fixing: The `Use_Minimal_Theme_Preparation` may modify the database with the custom theme root, and this would so far have updated the _actual_ database. So the test now initially sets up the runtime environment, which is needed to execute runtime checks in any case, and the runtime preparations then operate on the "fake tables".
* A similar fix needed to be added to `Runtime_Check_UnitTestCase`, which was also missing the runtime environment setup bit.

Additionally, it makes a few minor code improvements:
* Move check whether runtime environment is set up into its own method on `Runtime_Environment_Setup`.
* Improve PHPUnit tests to only clean up what is actually needed, rather than a "catch-all" cleanup, as the latter could lead to potential cleanup related problems to go unnoticed.