### PR TITLE
Add separate license error codes for Plugin Header

### DIFF
--- a/includes/Checker/Checks/Plugin_Repo/Plugin_Header_Fields_Check.php
+++ b/includes/Checker/Checks/Plugin_Repo/Plugin_Header_Fields_Check.php
@@ -67,6 +67,8 @@ class Plugin_Header_Fields_Check implements Static_Check {
 			'RequiresPHP'     => 'Requires PHP',
 			'UpdateURI'       => 'Update URI',
 			'RequiresPlugins' => 'Requires Plugins',
+			'License'         => 'License',
+			'LicenseURI'      => 'License URI',
 		);
 
 		$restricted_labels = array(
@@ -247,6 +249,19 @@ class Plugin_Header_Fields_Check implements Static_Check {
 					6
 				);
 			}
+		}
+
+		if ( empty( $plugin_header['License'] ) ) {
+			$this->add_result_error_for_file(
+				$result,
+				__( '<strong>Your plugin has no license declared in Plugin Header.</strong><br>Please update your plugin header with a GPLv2 (or later) compatible license.', 'plugin-check' ),
+				'plugin_header_no_license',
+				$plugin_main_file,
+				0,
+				0,
+				'https://developer.wordpress.org/plugins/wordpress-org/common-issues/#no-gpl-compatible-license-declared',
+				9
+			);
 		}
 
 		$found_headers = array();

--- a/includes/Checker/Checks/Plugin_Repo/Plugin_Header_Fields_Check.php
+++ b/includes/Checker/Checks/Plugin_Repo/Plugin_Header_Fields_Check.php
@@ -12,6 +12,7 @@ use WordPress\Plugin_Check\Checker\Check_Categories;
 use WordPress\Plugin_Check\Checker\Check_Result;
 use WordPress\Plugin_Check\Checker\Static_Check;
 use WordPress\Plugin_Check\Traits\Amend_Check_Result;
+use WordPress\Plugin_Check\Traits\License_Utils;
 use WordPress\Plugin_Check\Traits\Stable_Check;
 
 /**
@@ -21,6 +22,7 @@ use WordPress\Plugin_Check\Traits\Stable_Check;
  */
 class Plugin_Header_Fields_Check implements Static_Check {
 
+	use License_Utils;
 	use Amend_Check_Result;
 	use Stable_Check;
 
@@ -254,7 +256,11 @@ class Plugin_Header_Fields_Check implements Static_Check {
 		if ( empty( $plugin_header['License'] ) ) {
 			$this->add_result_error_for_file(
 				$result,
-				__( '<strong>Your plugin has no license declared in Plugin Header.</strong><br>Please update your plugin header with a GPLv2 (or later) compatible license.', 'plugin-check' ),
+				sprintf(
+					/* translators: %s: plugin header field */
+					__( '<strong>Missing "%s" in Plugin Header.</strong><br>Please update your Plugin Header with a valid GPLv2 (or later) compatible license.', 'plugin-check' ),
+					esc_html( $labels['License'] )
+				),
 				'plugin_header_no_license',
 				$plugin_main_file,
 				0,
@@ -262,6 +268,25 @@ class Plugin_Header_Fields_Check implements Static_Check {
 				'https://developer.wordpress.org/plugins/wordpress-org/common-issues/#no-gpl-compatible-license-declared',
 				9
 			);
+		} else {
+			$plugin_license = $this->get_normalized_license( $plugin_header['License'] );
+			if ( ! $this->is_license_gpl_compatible( $plugin_license ) ) {
+				$this->add_result_error_for_file(
+					$result,
+					sprintf(
+						/* translators: 1: plugin header field, 2: license */
+						__( '<strong>Invalid %1$s: %2$s.</strong><br>Please update your Plugin Header with a valid GPLv2 (or later) compatible license.', 'plugin-check' ),
+						esc_html( $labels['License'] ),
+						esc_html( $plugin_header['License'] )
+					),
+					'plugin_header_invalid_license',
+					$plugin_main_file,
+					0,
+					0,
+					'https://developer.wordpress.org/plugins/wordpress-org/common-issues/#no-gpl-compatible-license-declared',
+					9
+				);
+			}
 		}
 
 		$found_headers = array();

--- a/includes/Checker/Checks/Plugin_Repo/Plugin_Header_Fields_Check.php
+++ b/includes/Checker/Checks/Plugin_Repo/Plugin_Header_Fields_Check.php
@@ -22,8 +22,8 @@ use WordPress\Plugin_Check\Traits\Stable_Check;
  */
 class Plugin_Header_Fields_Check implements Static_Check {
 
-	use License_Utils;
 	use Amend_Check_Result;
+	use License_Utils;
 	use Stable_Check;
 
 	/**

--- a/includes/Checker/Checks/Plugin_Repo/Plugin_Readme_Check.php
+++ b/includes/Checker/Checks/Plugin_Repo/Plugin_Readme_Check.php
@@ -338,20 +338,12 @@ class Plugin_Readme_Check extends Abstract_File_Check {
 			);
 		}
 
+		$plugin_license = '';
+
 		$pattern     = preg_quote( 'License', '/' );
 		$has_license = self::file_preg_match( "/(*ANYCRLF)^.*$pattern\s*:\s*(.*)$/im", array( $plugin_main_file ), $matches_license );
-		if ( ! $has_license ) {
-			$this->add_result_error_for_file(
-				$result,
-				__( '<strong>Your plugin has no license declared in Plugin Header.</strong><br>Please update your plugin header with a GPLv2 (or later) compatible license. It is necessary to declare the license of this plugin. You can do this by using the fields available both in the plugin readme and in the plugin headers.', 'plugin-check' ),
-				'no_license',
-				$plugin_main_file,
-				0,
-				0,
-				'https://developer.wordpress.org/plugins/wordpress-org/common-issues/#no-gpl-compatible-license-declared',
-				9
-			);
-		} else {
+
+		if ( $has_license ) {
 			$plugin_license = $this->get_normalized_license( $matches_license[1] );
 		}
 

--- a/includes/Checker/Checks/Plugin_Repo/Plugin_Readme_Check.php
+++ b/includes/Checker/Checks/Plugin_Repo/Plugin_Readme_Check.php
@@ -347,20 +347,6 @@ class Plugin_Readme_Check extends Abstract_File_Check {
 			$plugin_license = $this->get_normalized_license( $matches_license[1] );
 		}
 
-		// Checks for a valid license in Plugin Header.
-		if ( ! empty( $plugin_license ) && ! $this->is_license_gpl_compatible( $plugin_license ) ) {
-			$this->add_result_error_for_file(
-				$result,
-				__( '<strong>Your plugin has an invalid license declared in Plugin Header.</strong><br>Please update your readme with a valid GPL license identifier. It is necessary to declare the license of this plugin. You can do this by using the fields available both in the plugin readme and in the plugin headers.', 'plugin-check' ),
-				'invalid_license',
-				$plugin_main_file,
-				0,
-				0,
-				'https://developer.wordpress.org/plugins/wordpress-org/common-issues/#no-gpl-compatible-license-declared',
-				9
-			);
-		}
-
 		// Check different license types.
 		if ( ! empty( $plugin_license ) && ! empty( $license ) && $license !== $plugin_license ) {
 			$this->add_result_error_for_file(

--- a/tests/phpunit/testdata/plugins/test-plugin-header-fields-with-errors/load.php
+++ b/tests/phpunit/testdata/plugins/test-plugin-header-fields-with-errors/load.php
@@ -8,8 +8,6 @@
  * Version: 1.0.0
  * Author: WordPress Performance Team
  * Author URI: This is not a valid URL
- * License: GPLv2 or later
- * License URI: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
  * Text Domain: test-mismathed-textdomain-here
  * Domain Path: /nonexistent-folder
  * Network: random-value

--- a/tests/phpunit/tests/Checker/Checks/Plugin_Header_Fields_Check_Tests.php
+++ b/tests/phpunit/tests/Checker/Checks/Plugin_Header_Fields_Check_Tests.php
@@ -27,6 +27,7 @@ class Plugin_Header_Fields_Check_Tests extends WP_UnitTestCase {
 		$this->assertCount( 0, wp_list_filter( $errors['load.php'][0][0], array( 'code' => 'plugin_header_restricted_fields' ) ) );
 		$this->assertCount( 1, wp_list_filter( $errors['load.php'][0][0], array( 'code' => 'plugin_header_invalid_requires_wp' ) ) );
 		$this->assertCount( 1, wp_list_filter( $errors['load.php'][0][0], array( 'code' => 'plugin_header_invalid_requires_php' ) ) );
+		$this->assertCount( 1, wp_list_filter( $errors['load.php'][0][0], array( 'code' => 'plugin_header_no_license' ) ) );
 		$this->assertCount( 1, wp_list_filter( $warnings['load.php'][0][0], array( 'code' => 'plugin_header_invalid_plugin_uri_domain' ) ) );
 		$this->assertCount( 1, wp_list_filter( $warnings['load.php'][0][0], array( 'code' => 'plugin_header_invalid_plugin_description' ) ) );
 		$this->assertCount( 1, wp_list_filter( $warnings['load.php'][0][0], array( 'code' => 'plugin_header_invalid_author_uri' ) ) );

--- a/tests/phpunit/tests/Checker/Checks/Plugin_Header_Fields_Check_Tests.php
+++ b/tests/phpunit/tests/Checker/Checks/Plugin_Header_Fields_Check_Tests.php
@@ -58,4 +58,18 @@ class Plugin_Header_Fields_Check_Tests extends WP_UnitTestCase {
 			$this->assertCount( 0, wp_list_filter( $warnings['load.php'][0][0], array( 'code' => 'plugin_header_invalid_requires_plugins' ) ) );
 		}
 	}
+
+	public function test_run_with_invalid_license() {
+		$check         = new Plugin_Header_Fields_Check();
+		$check_context = new Check_Context( UNIT_TESTS_PLUGIN_DIR . 'test-plugin-plugin-readme-mpl1-license-with-errors/load.php' );
+		$check_result  = new Check_Result( $check_context );
+
+		$check->run( $check_result );
+
+		$errors = $check_result->get_errors();
+
+		$this->assertNotEmpty( $errors );
+
+		$this->assertCount( 1, wp_list_filter( $errors['load.php'][0][0], array( 'code' => 'plugin_header_invalid_license' ) ) );
+	}
 }

--- a/tests/phpunit/tests/Checker/Checks/Plugin_Header_Fields_Check_Tests.php
+++ b/tests/phpunit/tests/Checker/Checks/Plugin_Header_Fields_Check_Tests.php
@@ -59,7 +59,7 @@ class Plugin_Header_Fields_Check_Tests extends WP_UnitTestCase {
 		}
 	}
 
-	public function test_run_with_invalid_license() {
+	public function test_run_with_invalid_mpl1_license() {
 		$check         = new Plugin_Header_Fields_Check();
 		$check_context = new Check_Context( UNIT_TESTS_PLUGIN_DIR . 'test-plugin-plugin-readme-mpl1-license-with-errors/load.php' );
 		$check_result  = new Check_Result( $check_context );
@@ -70,6 +70,7 @@ class Plugin_Header_Fields_Check_Tests extends WP_UnitTestCase {
 
 		$this->assertNotEmpty( $errors );
 
+		// Check for invalid license.
 		$this->assertCount( 1, wp_list_filter( $errors['load.php'][0][0], array( 'code' => 'plugin_header_invalid_license' ) ) );
 	}
 }

--- a/tests/phpunit/tests/Checker/Checks/Plugin_Readme_Check_Tests.php
+++ b/tests/phpunit/tests/Checker/Checks/Plugin_Readme_Check_Tests.php
@@ -192,24 +192,6 @@ class Plugin_Readme_Check_Tests extends WP_UnitTestCase {
 		$this->assertEmpty( $errors );
 	}
 
-	public function test_run_with_errors_mpl1_license() {
-		$readme_check  = new Plugin_Readme_Check();
-		$check_context = new Check_Context( UNIT_TESTS_PLUGIN_DIR . 'test-plugin-plugin-readme-mpl1-license-with-errors/load.php' );
-		$check_result  = new Check_Result( $check_context );
-
-		$readme_check->run( $check_result );
-
-		$errors = $check_result->get_errors();
-
-		$this->assertNotEmpty( $errors );
-		$this->assertArrayHasKey( 'load.php', $errors );
-
-		// Check for invalid license.
-		$this->assertArrayHasKey( 0, $errors['load.php'] );
-		$this->assertArrayHasKey( 0, $errors['load.php'][0] );
-		$this->assertCount( 1, wp_list_filter( $errors['load.php'][0][0], array( 'code' => 'invalid_license' ) ) );
-	}
-
 	public function test_run_with_errors_tested_upto() {
 		$readme_check  = new Plugin_Readme_Check();
 		$check_context = new Check_Context( UNIT_TESTS_PLUGIN_DIR . 'test-plugin-plugin-readme-errors-tested-upto/load.php' );


### PR DESCRIPTION
This PR implements second part of https://github.com/WordPress/plugin-check/issues/762

Add two error codes:

- plugin_header_no_license
- plugin_header_invalid_license

Now, error codes `no_license` and `invalid_license` refers only to the license check in readme. 