### PR TITLE
Add linter for sniffs

### DIFF
--- a/.github/workflows/php-lint.yml
+++ b/.github/workflows/php-lint.yml
@@ -61,3 +61,32 @@ jobs:
 
       - name: PHPMD
         run: composer phpmd
+
+  php-lint-sniffs:
+    name: PHP (Sniffs)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.0'
+
+      - name: Validate Composer configuration
+        working-directory: "phpcs-sniffs"
+        run: composer validate
+
+      - name: Install PHP dependencies
+        uses: ramsey/composer-install@57532f8be5bda426838819c5ee9afb8af389d51a
+        with:
+          composer-options: '--prefer-dist'
+          working-directory: "phpcs-sniffs"
+
+      - name: PHP Lint
+        working-directory: "phpcs-sniffs"
+        run: composer lint
+
+      - name: PHP Lint PHPCS
+        working-directory: "phpcs-sniffs"
+        run: composer check-cs

--- a/phpcs-sniffs/PluginCheck/Sniffs/CodeAnalysis/LocalhostSniff.php
+++ b/phpcs-sniffs/PluginCheck/Sniffs/CodeAnalysis/LocalhostSniff.php
@@ -55,7 +55,7 @@ final class LocalhostSniff extends Sniff {
 					'Do not use Localhost/127.0.0.1 in your code. Found: %s',
 					$this->find_token_in_multiline_string( $stackPtr, $content, $match[1] ),
 					'Found',
-					[ $match[0] ]
+					array( $match[0] )
 				);
 			}
 		}


### PR DESCRIPTION
Check for PHPCS for `phpcs-sniffs` folder was missing in the GitHub action.