### PR TITLE
Update disallowed domains for Plugin URI check

### DIFF
--- a/includes/Checker/Checks/Plugin_Repo/Plugin_Header_Fields_Check.php
+++ b/includes/Checker/Checks/Plugin_Repo/Plugin_Header_Fields_Check.php
@@ -114,19 +114,20 @@ class Plugin_Header_Fields_Check implements Static_Check {
 					'',
 					6
 				);
-			} elseif ( str_contains( $plugin_header['PluginURI'], '//wordpress.org/' ) || str_contains( $plugin_header['PluginURI'], '//example.com/' ) ) {
+			} elseif ( preg_match( '/\/\/(WordPress\.org|example\.com)\//', $plugin_header['PluginURI'], $matches ) ) {
 				$this->add_result_warning_for_file(
 					$result,
 					sprintf(
-						/* translators: %s: plugin header field */
-						__( 'The "%s" header in the plugin file is not valid.', 'plugin-check' ),
-						esc_html( $labels['PluginURI'] )
+						/* translators: 1: plugin header field, 2: domain */
+						__( 'The "%1$s" header in the plugin file is not valid. Discouraged domain "%2$s" found. This is the home page of the plugin, which should be a unique URL, preferably on your own website. ', 'plugin-check' ),
+						esc_html( $labels['PluginURI'] ),
+						esc_html( $matches[1] ),
 					),
 					'plugin_header_invalid_plugin_uri_domain',
 					$plugin_main_file,
 					0,
 					0,
-					'',
+					'https://developer.wordpress.org/plugins/plugin-basics/header-requirements/#header-fields',
 					6
 				);
 			}

--- a/includes/Checker/Checks/Plugin_Repo/Plugin_Header_Fields_Check.php
+++ b/includes/Checker/Checks/Plugin_Repo/Plugin_Header_Fields_Check.php
@@ -119,7 +119,7 @@ class Plugin_Header_Fields_Check implements Static_Check {
 					$result,
 					sprintf(
 						/* translators: 1: plugin header field, 2: domain */
-						__( 'The "%1$s" header in the plugin file is not valid. Discouraged domain "%2$s" found. This is the home page of the plugin, which should be a unique URL, preferably on your own website. ', 'plugin-check' ),
+						__( 'The "%1$s" header in the plugin file is not valid. Discouraged domain "%2$s" found. This is the homepage of the plugin, which should be a unique URL, preferably on your own website. ', 'plugin-check' ),
 						esc_html( $labels['PluginURI'] ),
 						esc_html( $matches[1] ),
 					),

--- a/includes/Checker/Checks/Plugin_Repo/Plugin_Header_Fields_Check.php
+++ b/includes/Checker/Checks/Plugin_Repo/Plugin_Header_Fields_Check.php
@@ -114,7 +114,7 @@ class Plugin_Header_Fields_Check implements Static_Check {
 					'',
 					6
 				);
-			} elseif ( preg_match( '/\/\/(WordPress\.org|example\.com)\//', $plugin_header['PluginURI'], $matches ) ) {
+			} elseif ( preg_match( '/\/\/(example\.com|example\.net|example\.org)\//', $plugin_header['PluginURI'], $matches ) ) {
 				$this->add_result_warning_for_file(
 					$result,
 					sprintf(


### PR DESCRIPTION
Fixes https://github.com/WordPress/plugin-check/issues/771

- Update message for plugin_header_invalid_plugin_uri_domain check

Example output:

The "Plugin URI" header in the plugin file is not valid. Discouraged domain "example.com" found. This is the home page of the plugin, which should be a unique URL, preferably on your own website.