### PR TITLE
Update readme parser to latest master version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
   "require": {
     "php": ">=7.4",
     "ext-json": "*",
-    "afragen/wordpress-plugin-readme-parser": "dev-master#67fba498d0b112acf84386b95e4905c539a33f0b",
+    "afragen/wordpress-plugin-readme-parser": "dev-master#c3758599348148be684b3c4ad1105d09b6230d51",
     "automattic/vipwpcs": "^3.0.0",
     "composer/installers": "^2.2",
     "dealerdirect/phpcodesniffer-composer-installer": "^1.0.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3aab6089bbe13e7a4c81438da8f72ad6",
+    "content-hash": "0cc8b18edc9a06529bbdc89fc0354bba",
     "packages": [
         {
             "name": "afragen/wordpress-plugin-readme-parser",
@@ -12,12 +12,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/afragen/wordpress-plugin-readme-parser.git",
-                "reference": "67fba498d0b112acf84386b95e4905c539a33f0b"
+                "reference": "c3758599348148be684b3c4ad1105d09b6230d51"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/afragen/wordpress-plugin-readme-parser/zipball/67fba498d0b112acf84386b95e4905c539a33f0b",
-                "reference": "67fba498d0b112acf84386b95e4905c539a33f0b",
+                "url": "https://api.github.com/repos/afragen/wordpress-plugin-readme-parser/zipball/c3758599348148be684b3c4ad1105d09b6230d51",
+                "reference": "c3758599348148be684b3c4ad1105d09b6230d51",
                 "shasum": ""
             },
             "require": {

--- a/includes/Checker/Checks/Plugin_Repo/Plugin_Readme_Check.php
+++ b/includes/Checker/Checks/Plugin_Repo/Plugin_Readme_Check.php
@@ -482,6 +482,11 @@ class Plugin_Readme_Check extends Abstract_File_Check {
 		// This should be ERROR rather than WARNING. So ignoring here to handle separately.
 		unset( $warnings['invalid_plugin_name_header'] );
 
+		// We handle license check in our own way.
+		unset( $warnings['license_missing'] );
+		unset( $warnings['invalid_license'] );
+		unset( $warnings['unknown_license'] );
+
 		$warning_keys = array_keys( $warnings );
 
 		$latest_wordpress_version = (float) $this->get_wordpress_stable_version();


### PR DESCRIPTION

- Use latest version of `afragen/wordpress-plugin-readme-parser`
- Ignored warnings regarding license as we handle license check in our own way
