### PR TITLE
Fix PHPCS checks on unwritable filesystems.

### DIFF
--- a/includes/Checker/Checks/Abstract_PHP_CodeSniffer_Check.php
+++ b/includes/Checker/Checks/Abstract_PHP_CodeSniffer_Check.php
@@ -100,7 +100,7 @@ abstract class Abstract_PHP_CodeSniffer_Check implements Static_Check {
 
 		// Override installed_paths to load custom sniffs.
 		if ( isset( $args['installed_paths'] ) && is_array( $args['installed_paths'] ) ) {
-			Config::setConfigData( 'installed_paths', implode( ',', $args['installed_paths'] ) );
+			Config::setConfigData( 'installed_paths', implode( ',', $args['installed_paths'] ), true );
 		}
 
 		// Create the default arguments for PHPCS.
@@ -121,7 +121,7 @@ abstract class Abstract_PHP_CodeSniffer_Check implements Static_Check {
 		}
 
 		// Reset installed_paths.
-		Config::setConfigData( 'installed_paths', $installed_paths );
+		Config::setConfigData( 'installed_paths', $installed_paths, true );
 
 		// Restore original arguments.
 		$_SERVER['argv'] = $orig_cmd_args;


### PR DESCRIPTION
In #744 a call to setConfigData() was added which has the `$temp` parameter set to the default, which is `true`.

This causes PHPCS to attempt to write the given config to disk.
The default config location is.. `wp-content/plugins/plugin-check/vendor/squizlabs/php_codesniffer/CodeSniffer.conf`

If WordPress is installed on an immutable filesystem (Such as WordPress.org) this causes the entire plugin check to abort.