### PR TITLE
Add version utilities

### DIFF
--- a/includes/Traits/Version_Utils.php
+++ b/includes/Traits/Version_Utils.php
@@ -80,7 +80,7 @@ trait Version_Utils {
 	 *
 	 * @return string Recommended PHP version.
 	 */
-	protected function get_recommended_php_version(): string {
+	protected function get_wordpress_recommended_php_version(): string {
 		$recommended_version = '7.4'; // Default fallback recommended version.
 
 		$version_details = wp_check_php_version();

--- a/includes/Traits/Version_Utils.php
+++ b/includes/Traits/Version_Utils.php
@@ -48,51 +48,6 @@ trait Version_Utils {
 	}
 
 	/**
-	 * Returns required PHP version.
-	 *
-	 * @since 1.4.0
-	 *
-	 * @return string Required PHP version.
-	 */
-	protected function get_php_required_version(): string {
-		$version = $this->get_latest_version_info( 'php_version' );
-
-		return $version ?? $this->get_required_php_version();
-	}
-
-	/**
-	 * Returns required MySQL version.
-	 *
-	 * @since 1.4.0
-	 *
-	 * @return string Required MySQL version.
-	 */
-	protected function get_mysql_required_version(): string {
-		$version = $this->get_latest_version_info( 'mysql_version' );
-
-		return $version ?? $this->get_required_mysql_version();
-	}
-
-	/**
-	 * Returns recommended PHP version.
-	 *
-	 * @since 1.4.0
-	 *
-	 * @return string Recommended PHP version.
-	 */
-	protected function get_php_recommended_version(): string {
-		$recommended_version = '7.4'; // Default fallback recommended version.
-
-		$version_details = wp_check_php_version();
-
-		if ( is_array( $version_details ) && ! empty( $version_details['recommended_version'] ) ) {
-			$recommended_version = $version_details['recommended_version'];
-		}
-
-		return $recommended_version;
-	}
-
-	/**
 	 * Returns relative WordPress major version.
 	 *
 	 * @since 1.4.0
@@ -136,39 +91,5 @@ trait Version_Utils {
 		}
 
 		return array_key_exists( $key, $info ) ? $info[ $key ] : null;
-	}
-
-	/**
-	 * Returns the current WordPress' required PHP version.
-	 *
-	 * @since 1.4.0
-	 *
-	 * @return string The current WordPress' required PHP version.
-	 */
-	private function get_required_php_version(): string {
-		static $required_php_version;
-
-		if ( ! isset( $required_php_version ) ) {
-			require ABSPATH . WPINC . '/version.php';
-		}
-
-		return $required_php_version;
-	}
-
-	/**
-	 * Returns the current WordPress' required MySQL version.
-	 *
-	 * @since 1.4.0
-	 *
-	 * @return string The current WordPress' required MySQL version.
-	 */
-	private function get_required_mysql_version(): string {
-		static $required_mysql_version;
-
-		if ( ! isset( $required_mysql_version ) ) {
-			require ABSPATH . WPINC . '/version.php';
-		}
-
-		return $required_mysql_version;
 	}
 }

--- a/includes/Traits/Version_Utils.php
+++ b/includes/Traits/Version_Utils.php
@@ -54,7 +54,7 @@ trait Version_Utils {
 	 *
 	 * @return string Required PHP version.
 	 */
-	protected function get_wordpress_required_php_version(): string {
+	protected function get_php_required_version(): string {
 		$version = $this->get_latest_version_info( 'php_version' );
 
 		return $version ?? $this->get_required_php_version();
@@ -67,7 +67,7 @@ trait Version_Utils {
 	 *
 	 * @return string Required MySQL version.
 	 */
-	protected function get_wordpress_required_mysql_version(): string {
+	protected function get_mysql_required_version(): string {
 		$version = $this->get_latest_version_info( 'mysql_version' );
 
 		return $version ?? $this->get_required_mysql_version();
@@ -80,7 +80,7 @@ trait Version_Utils {
 	 *
 	 * @return string Recommended PHP version.
 	 */
-	protected function get_wordpress_recommended_php_version(): string {
+	protected function get_php_recommended_version(): string {
 		$recommended_version = '7.4'; // Default fallback recommended version.
 
 		$version_details = wp_check_php_version();

--- a/includes/Traits/Version_Utils.php
+++ b/includes/Traits/Version_Utils.php
@@ -17,7 +17,7 @@ trait Version_Utils {
 	/**
 	 * Returns current major WordPress version.
 	 *
-	 * @since 1.0.0
+	 * @since 1.4.0
 	 *
 	 * @return string Stable WordPress version.
 	 */

--- a/includes/Traits/Version_Utils.php
+++ b/includes/Traits/Version_Utils.php
@@ -93,6 +93,25 @@ trait Version_Utils {
 	}
 
 	/**
+	 * Returns relative WordPress major version.
+	 *
+	 * @since 1.4.0
+	 *
+	 * @param string $version WordPress major version.
+	 * @param int    $steps   Steps to find relative version. Defaults to 1 for next major version.
+	 * @return string Relative WordPress major version.
+	 */
+	protected function get_wordpress_relative_major_version( string $version, int $steps = 1 ): string {
+		if ( 0 === $steps ) {
+			return $version;
+		}
+
+		$new_version = floatval( $version ) + ( 0.1 * $steps );
+
+		return (string) number_format( $new_version, 1 );
+	}
+
+	/**
 	 * Returns specific information.
 	 *
 	 * @since 1.4.0

--- a/includes/Traits/Version_Utils.php
+++ b/includes/Traits/Version_Utils.php
@@ -1,0 +1,155 @@
+<?php
+/**
+ * Trait WordPress\Plugin_Check\Traits\Version_Utils
+ *
+ * @package plugin-check
+ */
+
+namespace WordPress\Plugin_Check\Traits;
+
+/**
+ * Trait for version utilities.
+ *
+ * @since 1.4.0
+ */
+trait Version_Utils {
+
+	/**
+	 * Returns current major WordPress version.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return string Stable WordPress version.
+	 */
+	protected function get_wordpress_stable_version(): string {
+		$version = $this->get_latest_version_info( 'current' );
+
+		// Strip off any -alpha, -RC, -beta suffixes.
+		list( $version, ) = explode( '-', $version );
+
+		if ( preg_match( '#^\d.\d#', $version, $matches ) ) {
+			$version = $matches[0];
+		}
+
+		return $version;
+	}
+
+	/**
+	 * Returns WordPress latest version.
+	 *
+	 * @since 1.4.0
+	 *
+	 * @return string WordPress latest version.
+	 */
+	protected function get_wordpress_latest_version(): string {
+		$version = $this->get_latest_version_info( 'current' );
+
+		return $version ?? get_bloginfo( 'version' );
+	}
+
+	/**
+	 * Returns required PHP version.
+	 *
+	 * @since 1.4.0
+	 *
+	 * @return string Required PHP version.
+	 */
+	protected function get_wordpress_required_php_version(): string {
+		$version = $this->get_latest_version_info( 'php_version' );
+
+		return $version ?? $this->get_required_php_version();
+	}
+
+	/**
+	 * Returns required MySQL version.
+	 *
+	 * @since 1.4.0
+	 *
+	 * @return string Required MySQL version.
+	 */
+	protected function get_wordpress_required_mysql_version(): string {
+		$version = $this->get_latest_version_info( 'mysql_version' );
+
+		return $version ?? $this->get_required_mysql_version();
+	}
+
+	/**
+	 * Returns recommended PHP version.
+	 *
+	 * @since 1.4.0
+	 *
+	 * @return string Recommended PHP version.
+	 */
+	protected function get_recommended_php_version(): string {
+		$recommended_version = '7.4'; // Default fallback recommended version.
+
+		$version_details = wp_check_php_version();
+
+		if ( is_array( $version_details ) && ! empty( $version_details['recommended_version'] ) ) {
+			$recommended_version = $version_details['recommended_version'];
+		}
+
+		return $recommended_version;
+	}
+
+	/**
+	 * Returns specific information.
+	 *
+	 * @since 1.4.0
+	 *
+	 * @param string $key The information key to retrieve.
+	 * @return mixed The requested information.
+	 */
+	private function get_latest_version_info( string $key ) {
+		$info = get_transient( 'wp_plugin_check_latest_version_info' );
+
+		if ( false === $info ) {
+			$response = wp_remote_get( 'https://api.wordpress.org/core/version-check/1.7/' );
+
+			if ( ! is_wp_error( $response ) && 200 === wp_remote_retrieve_response_code( $response ) ) {
+				$body = json_decode( wp_remote_retrieve_body( $response ), true );
+
+				if ( isset( $body['offers'] ) && ! empty( $body['offers'] ) ) {
+					$info = reset( $body['offers'] );
+					set_transient( 'wp_plugin_check_latest_version_info', $info, DAY_IN_SECONDS );
+				}
+			}
+		}
+
+		return array_key_exists( $key, $info ) ? $info[ $key ] : null;
+	}
+
+	/**
+	 * Returns the current WordPress' required PHP version.
+	 *
+	 * @since 1.4.0
+	 *
+	 * @return string The current WordPress' required PHP version.
+	 */
+	private function get_required_php_version(): string {
+		static $required_php_version;
+
+		if ( ! isset( $required_php_version ) ) {
+			require ABSPATH . WPINC . '/version.php';
+		}
+
+		return $required_php_version;
+	}
+
+	/**
+	 * Returns the current WordPress' required MySQL version.
+	 *
+	 * @since 1.4.0
+	 *
+	 * @return string The current WordPress' required MySQL version.
+	 */
+	private function get_required_mysql_version(): string {
+		static $required_mysql_version;
+
+		if ( ! isset( $required_mysql_version ) ) {
+			require ABSPATH . WPINC . '/version.php';
+		}
+
+		return $required_mysql_version;
+	}
+}

--- a/tests/phpstan/bootstrap.php
+++ b/tests/phpstan/bootstrap.php
@@ -1,5 +1,4 @@
 <?php
 
-define( 'WPINC', '' );
 define( 'WP_PLUGIN_CHECK_PLUGIN_DIR_PATH', '' );
 define( 'WP_PLUGIN_CHECK_PLUGIN_DIR_URL', '' );

--- a/tests/phpstan/bootstrap.php
+++ b/tests/phpstan/bootstrap.php
@@ -1,4 +1,5 @@
 <?php
 
+define( 'WPINC', '' );
 define( 'WP_PLUGIN_CHECK_PLUGIN_DIR_PATH', '' );
 define( 'WP_PLUGIN_CHECK_PLUGIN_DIR_URL', '' );

--- a/tests/phpunit/tests/Traits/Version_Utils_Tests.php
+++ b/tests/phpunit/tests/Traits/Version_Utils_Tests.php
@@ -13,22 +13,8 @@ class Version_Utils_Tests extends WP_UnitTestCase {
 
 	protected $info_transient_key = 'wp_plugin_check_latest_version_info';
 
-	protected $php_check_transient_key = '';
-
 	public function set_up() {
 		parent::set_up();
-
-		$this->php_check_transient_key = 'php_check_' . md5( PHP_VERSION );
-
-		$php_check_data = array(
-			'recommended_version' => '7.4',
-			'minimum_version'     => '7.2.24',
-			'is_supported'        => true,
-			'is_secure'           => true,
-			'is_acceptable'       => true,
-		);
-
-		set_site_transient( $this->php_check_transient_key, $php_check_data );
 
 		$info_data = array(
 			'response'        => 'upgrade',
@@ -72,7 +58,6 @@ class Version_Utils_Tests extends WP_UnitTestCase {
 
 	public function tear_down() {
 		delete_transient( $this->info_transient_key );
-		delete_site_transient( $this->php_check_transient_key );
 		parent::tear_down();
 	}
 

--- a/tests/phpunit/tests/Traits/Version_Utils_Tests.php
+++ b/tests/phpunit/tests/Traits/Version_Utils_Tests.php
@@ -62,21 +62,6 @@ class Version_Utils_Tests extends WP_UnitTestCase {
 		$this->assertSame( '6.7', $version );
 	}
 
-	public function test_wordpress_required_php_version() {
-		$version = $this->get_php_required_version();
-		$this->assertSame( '7.2.24', $version );
-	}
-
-	public function test_wordpress_required_mysql_version() {
-		$version = $this->get_mysql_required_version();
-		$this->assertSame( '5.5.5', $version );
-	}
-
-	public function test_wordpress_recommended_php_version() {
-		$version = $this->get_php_recommended_version();
-		$this->assertSame( '7.4', $version );
-	}
-
 	/**
 	 * @dataProvider data_wordpress_version_items
 	 */

--- a/tests/phpunit/tests/Traits/Version_Utils_Tests.php
+++ b/tests/phpunit/tests/Traits/Version_Utils_Tests.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * Tests for the Version_Utils trait.
+ *
+ * @package plugin-check
+ */
+
+use WordPress\Plugin_Check\Traits\Version_Utils;
+
+class Version_Utils_Tests extends WP_UnitTestCase {
+
+	use Version_Utils;
+
+	protected $info_transient_key = 'wp_plugin_check_latest_version_info';
+
+	protected $php_check_transient_key = '';
+
+	public function set_up() {
+		parent::set_up();
+
+		$this->php_check_transient_key = 'php_check_' . md5( PHP_VERSION );
+
+		$php_check_data = array(
+			'recommended_version' => '7.4',
+			'minimum_version'     => '7.2.24',
+			'is_supported'        => true,
+			'is_secure'           => true,
+			'is_acceptable'       => true,
+		);
+
+		set_site_transient( $this->php_check_transient_key, $php_check_data );
+
+		$info_data = array(
+			'response'        => 'upgrade',
+			'download'        => 'https://downloads.wordpress.org/release/wordpress-6.7.1.zip',
+			'locale'          => 'en_US',
+			'packages'        => array(
+				'full'        => 'https://downloads.wordpress.org/release/wordpress-6.7.1.zip',
+				'no_content'  => 'https://downloads.wordpress.org/release/wordpress-6.7.1-no-content.zip',
+				'new_bundled' => 'https://downloads.wordpress.org/release/wordpress-6.7.1-new-bundled.zip',
+				'partial'     => false,
+				'rollback'    => false,
+			),
+			'current'         => '6.7.1',
+			'version'         => '6.7.1',
+			'php_version'     => '7.2.24',
+			'mysql_version'   => '5.5.5',
+			'new_bundled'     => '6.7',
+			'partial_version' => false,
+		);
+
+		set_transient( $this->info_transient_key, $info_data );
+	}
+
+	public function test_wordpress_latest_version() {
+		$version = $this->get_wordpress_latest_version();
+		$this->assertSame( '6.7.1', $version );
+	}
+
+	public function test_wordpress_stable_version() {
+		$version = $this->get_wordpress_stable_version();
+		$this->assertSame( '6.7', $version );
+	}
+
+	public function test_wordpress_required_php_version() {
+		$version = $this->get_wordpress_required_php_version();
+		$this->assertSame( '7.2.24', $version );
+	}
+
+	public function test_wordpress_required_mysql_version() {
+		$version = $this->get_wordpress_required_mysql_version();
+		$this->assertSame( '5.5.5', $version );
+	}
+
+	public function test_recommended_php_version() {
+		$version = $this->get_recommended_php_version();
+		$this->assertSame( '7.4', $version );
+	}
+
+	public function tear_down() {
+		delete_transient( $this->info_transient_key );
+		delete_site_transient( $this->php_check_transient_key );
+		parent::tear_down();
+	}
+}

--- a/tests/phpunit/tests/Traits/Version_Utils_Tests.php
+++ b/tests/phpunit/tests/Traits/Version_Utils_Tests.php
@@ -63,17 +63,17 @@ class Version_Utils_Tests extends WP_UnitTestCase {
 	}
 
 	public function test_wordpress_required_php_version() {
-		$version = $this->get_wordpress_required_php_version();
+		$version = $this->get_php_required_version();
 		$this->assertSame( '7.2.24', $version );
 	}
 
 	public function test_wordpress_required_mysql_version() {
-		$version = $this->get_wordpress_required_mysql_version();
+		$version = $this->get_mysql_required_version();
 		$this->assertSame( '5.5.5', $version );
 	}
 
 	public function test_wordpress_recommended_php_version() {
-		$version = $this->get_wordpress_recommended_php_version();
+		$version = $this->get_php_recommended_version();
 		$this->assertSame( '7.4', $version );
 	}
 

--- a/tests/phpunit/tests/Traits/Version_Utils_Tests.php
+++ b/tests/phpunit/tests/Traits/Version_Utils_Tests.php
@@ -77,9 +77,32 @@ class Version_Utils_Tests extends WP_UnitTestCase {
 		$this->assertSame( '7.4', $version );
 	}
 
+	/**
+	 * @dataProvider data_wordpress_version_items
+	 */
+	public function test_wordpress_relative_major_version( $version, $steps, $new_version ) {
+		$result = $this->get_wordpress_relative_major_version( $version, $steps );
+		$this->assertSame( $new_version, $result );
+	}
+
 	public function tear_down() {
 		delete_transient( $this->info_transient_key );
 		delete_site_transient( $this->php_check_transient_key );
 		parent::tear_down();
+	}
+
+	public function data_wordpress_version_items() {
+		return array(
+			array( '6.7', 1, '6.8' ),
+			array( '6.7', -1, '6.6' ),
+			array( '6.7', 2, '6.9' ),
+			array( '6.7', -2, '6.5' ),
+			array( '5.9', 1, '6.0' ),
+			array( '6.0', -1, '5.9' ),
+			array( '5.9', 2, '6.1' ),
+			array( '6.0', -2, '5.8' ),
+			array( '5.8', 2, '6.0' ),
+			array( '6.1', -2, '5.9' ),
+		);
 	}
 }

--- a/tests/phpunit/tests/Traits/Version_Utils_Tests.php
+++ b/tests/phpunit/tests/Traits/Version_Utils_Tests.php
@@ -72,8 +72,8 @@ class Version_Utils_Tests extends WP_UnitTestCase {
 		$this->assertSame( '5.5.5', $version );
 	}
 
-	public function test_recommended_php_version() {
-		$version = $this->get_recommended_php_version();
+	public function test_wordpress_recommended_php_version() {
+		$version = $this->get_wordpress_recommended_php_version();
 		$this->assertSame( '7.4', $version );
 	}
 


### PR DESCRIPTION
Add version utilities:

- Add `get_wordpress_stable_version()` similar to that helper method in `Plugin_Readme_Check` class
- New methods to fetch version informations
   * get_wordpress_latest_version()
- Added `Version_Utils_Tests` unit test class
