### PR TITLE
Preferred error type to be singular

### DIFF
--- a/includes/CLI/Plugin_Check_Command.php
+++ b/includes/CLI/Plugin_Check_Command.php
@@ -653,10 +653,10 @@ final class Plugin_Check_Command {
 			if ( 'ERROR' === $item['type'] && $item['severity'] >= $error_severity ) {
 				$errors[] = $item;
 			} elseif ( $include_low_severity_errors && 'ERROR' === $item['type'] && $item['severity'] < $error_severity ) {
-				$item['type'] = 'ERRORS_LOW_SEVERITY';
+				$item['type'] = 'ERROR_LOW_SEVERITY';
 				$errors[]     = $item;
 			} elseif ( $include_low_severity_warnings && 'WARNING' === $item['type'] && $item['severity'] < $warning_severity ) {
-				$item['type'] = 'WARNINGS_LOW_SEVERITY';
+				$item['type'] = 'WARNING_LOW_SEVERITY';
 				$warnings[]   = $item;
 			} elseif ( 'WARNING' === $item['type'] && $item['severity'] >= $warning_severity ) {
 				$warnings[] = $item;

--- a/tests/behat/features/plugin-check-severity.feature
+++ b/tests/behat/features/plugin-check-severity.feature
@@ -199,11 +199,11 @@ Feature: Test that the severity level in plugin check works.
       """
     And STDOUT should contain:
       """
-      WordPress.WP.AlternativeFunctions.rand_mt_rand,ERRORS_LOW_SEVERITY,5
+      WordPress.WP.AlternativeFunctions.rand_mt_rand,ERROR_LOW_SEVERITY,5
       """
     And STDOUT should contain:
       """
-      WordPress.Security.EscapeOutput.OutputNotEscaped,ERRORS_LOW_SEVERITY,5
+      WordPress.Security.EscapeOutput.OutputNotEscaped,ERROR_LOW_SEVERITY,5
       """
 
     When I run the WP-CLI command `plugin check foo-bar-wp --format=csv --fields=code,type,severity --warning-severity=7 --include-low-severity-warnings`
@@ -213,7 +213,7 @@ Feature: Test that the severity level in plugin check works.
       """
     And STDOUT should contain:
       """
-      upgrade_notice_limit,WARNINGS_LOW_SEVERITY,5
+      upgrade_notice_limit,WARNING_LOW_SEVERITY,5
       """
     And STDOUT should contain:
       """


### PR DESCRIPTION
Followup https://github.com/WordPress/plugin-check/pull/696

Renamed error type to `ERROR_LOW_SEVERITY` and `WARNING_LOW_SEVERITY`.