### PR TITLE
Add check for restricted contributors

### DIFF
--- a/includes/Checker/Checks/Plugin_Repo/Plugin_Readme_Check.php
+++ b/includes/Checker/Checks/Plugin_Repo/Plugin_Readme_Check.php
@@ -840,9 +840,12 @@ class Plugin_Readme_Check extends Abstract_File_Check {
 	private function get_restricted_contributors() {
 		$restricted_contributors = array(
 			'username'                => 'error',
+			'your-name'               => 'error',
 			'your-username'           => 'error',
+			'your-wordpress-username' => 'error',
 			'your_wordpress_username' => 'error',
 			'yourusername'            => 'error',
+			'yourwordpressusername'   => 'error',
 			'wordpressdotorg'         => 'warning',
 		);
 

--- a/includes/Checker/Checks/Plugin_Repo/Plugin_Readme_Check.php
+++ b/includes/Checker/Checks/Plugin_Repo/Plugin_Readme_Check.php
@@ -651,6 +651,8 @@ class Plugin_Readme_Check extends Abstract_File_Check {
 	 *
 	 * @param Check_Result $result      The Check Result to amend.
 	 * @param string       $readme_file Readme file.
+	 *
+	 * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
 	 */
 	private function check_for_contributors( Check_Result $result, string $readme_file ) {
 		$regex = '/Contributors\s?:(?:\*\*|\s)?(.*?)\R/';
@@ -696,31 +698,68 @@ class Plugin_Readme_Check extends Abstract_File_Check {
 			return;
 		}
 
-		$restricted_contributors = array(
-			'username',
-			'your-username',
-			'your_wordpress_username',
-			'yourusername',
+		$restricted_contributors = $this->get_restricted_contributors();
+
+		$disallowed_contributors = array_keys(
+			array_filter(
+				$restricted_contributors,
+				function ( $value ) {
+					return true === $value;
+				}
+			)
 		);
 
-		$restricted_usernames = array_intersect( $usernames, $restricted_contributors );
+		if ( ! empty( $disallowed_contributors ) ) {
+			$disallowed_usernames = array_intersect( $usernames, $disallowed_contributors );
 
-		if ( ! empty( $restricted_usernames ) ) {
-			$this->add_result_error_for_file(
-				$result,
-				sprintf(
-					/* translators: 1: plugin header field, 2: usernames */
-					__( 'The "%1$s" header in the readme file contains restricted username(s). Found: %2$s', 'plugin-check' ),
-					'Contributors',
-					'"' . implode( '", "', $restricted_usernames ) . '"'
-				),
-				'readme_restricted_contributors',
-				$readme_file,
-				0,
-				0,
-				'https://developer.wordpress.org/plugins/wordpress-org/how-your-readme-txt-works/#readme-header-information',
-				7
-			);
+			if ( ! empty( $disallowed_usernames ) ) {
+				$this->add_result_error_for_file(
+					$result,
+					sprintf(
+						/* translators: 1: plugin header field, 2: usernames */
+						__( 'The "%1$s" header in the readme file contains restricted username(s). Found: %2$s', 'plugin-check' ),
+						'Contributors',
+						'"' . implode( '", "', $disallowed_usernames ) . '"'
+					),
+					'readme_restricted_contributors',
+					$readme_file,
+					0,
+					0,
+					'https://developer.wordpress.org/plugins/wordpress-org/how-your-readme-txt-works/#readme-header-information',
+					7
+				);
+			}
+		}
+
+		$reserved_contributors = array_keys(
+			array_filter(
+				$restricted_contributors,
+				function ( $value ) {
+					return false === $value;
+				}
+			)
+		);
+
+		if ( ! empty( $reserved_contributors ) ) {
+			$reserved_usernames = array_intersect( $usernames, $reserved_contributors );
+
+			if ( ! empty( $reserved_usernames ) ) {
+				$this->add_result_warning_for_file(
+					$result,
+					sprintf(
+						/* translators: 1: plugin header field, 2: usernames */
+						__( 'The "%1$s" header in the readme file contains reserved username(s). Found: %2$s', 'plugin-check' ),
+						'Contributors',
+						'"' . implode( '", "', $reserved_usernames ) . '"'
+					),
+					'readme_reserved_contributors',
+					$readme_file,
+					0,
+					0,
+					'https://developer.wordpress.org/plugins/wordpress-org/how-your-readme-txt-works/#readme-header-information',
+					6
+				);
+			}
 		}
 	}
 
@@ -789,6 +828,34 @@ class Plugin_Readme_Check extends Abstract_File_Check {
 		$ignored_warnings = (array) apply_filters( 'wp_plugin_check_ignored_readme_warnings', $ignored_warnings, $parser );
 
 		return $ignored_warnings;
+	}
+
+	/**
+	 * Returns restricted contributors.
+	 *
+	 * @since 1.4.0
+	 *
+	 * @return array Restricted contributors.
+	 */
+	private function get_restricted_contributors() {
+		$restricted_contributors = array(
+			'username'                => true,
+			'your-username'           => true,
+			'your_wordpress_username' => true,
+			'yourusername'            => true,
+			'wordpressdotorg'         => false,
+		);
+
+		/**
+		 * Filter the list of restricted contributors.
+		 *
+		 * @since 1.4.0
+		 *
+		 * @param array $restricted_contributors Array of restricted contributors with boolean value to indicate whether username should be error or warning. Value 'true' for error and 'false' for warning.
+		 */
+		$restricted_contributors = (array) apply_filters( 'wp_plugin_check_restricted_contributors', $restricted_contributors );
+
+		return $restricted_contributors;
 	}
 
 	/**

--- a/includes/Checker/Checks/Plugin_Repo/Plugin_Readme_Check.php
+++ b/includes/Checker/Checks/Plugin_Repo/Plugin_Readme_Check.php
@@ -704,7 +704,7 @@ class Plugin_Readme_Check extends Abstract_File_Check {
 			array_filter(
 				$restricted_contributors,
 				function ( $value ) {
-					return true === $value;
+					return 'error' === strtolower( $value );
 				}
 			)
 		);
@@ -735,7 +735,7 @@ class Plugin_Readme_Check extends Abstract_File_Check {
 			array_filter(
 				$restricted_contributors,
 				function ( $value ) {
-					return false === $value;
+					return 'warning' === strtolower( $value );
 				}
 			)
 		);
@@ -839,11 +839,11 @@ class Plugin_Readme_Check extends Abstract_File_Check {
 	 */
 	private function get_restricted_contributors() {
 		$restricted_contributors = array(
-			'username'                => true,
-			'your-username'           => true,
-			'your_wordpress_username' => true,
-			'yourusername'            => true,
-			'wordpressdotorg'         => false,
+			'username'                => 'error',
+			'your-username'           => 'error',
+			'your_wordpress_username' => 'error',
+			'yourusername'            => 'error',
+			'wordpressdotorg'         => 'warning',
 		);
 
 		/**
@@ -851,7 +851,7 @@ class Plugin_Readme_Check extends Abstract_File_Check {
 		 *
 		 * @since 1.4.0
 		 *
-		 * @param array $restricted_contributors Array of restricted contributors with boolean value to indicate whether username should be error or warning. Value 'true' for error and 'false' for warning.
+		 * @param array $restricted_contributors Array of restricted contributors with error type.
 		 */
 		$restricted_contributors = (array) apply_filters( 'wp_plugin_check_restricted_contributors', $restricted_contributors );
 

--- a/includes/Checker/Checks/Plugin_Repo/Plugin_Readme_Check.php
+++ b/includes/Checker/Checks/Plugin_Repo/Plugin_Readme_Check.php
@@ -668,7 +668,7 @@ class Plugin_Readme_Check extends Abstract_File_Check {
 
 		$usernames = explode( ',', $matches[1] );
 
-		$usernames = array_map( 'trim', $usernames );
+		$usernames = array_unique( array_map( 'trim', $usernames ) );
 
 		$valid = true;
 

--- a/includes/Checker/Checks/Plugin_Repo/Plugin_Readme_Check.php
+++ b/includes/Checker/Checks/Plugin_Repo/Plugin_Readme_Check.php
@@ -692,6 +692,35 @@ class Plugin_Readme_Check extends Abstract_File_Check {
 				'',
 				6
 			);
+
+			return;
+		}
+
+		$restricted_contributors = array(
+			'username',
+			'your-username',
+			'your_wordpress_username',
+			'yourusername',
+		);
+
+		$restricted_usernames = array_intersect( $usernames, $restricted_contributors );
+
+		if ( ! empty( $restricted_usernames ) ) {
+			$this->add_result_error_for_file(
+				$result,
+				sprintf(
+					/* translators: 1: plugin header field, 2: usernames */
+					__( 'The "%1$s" header in the readme file contains restricted username(s). Found: %2$s', 'plugin-check' ),
+					'Contributors',
+					'"' . implode( '", "', $restricted_usernames ) . '"'
+				),
+				'readme_restricted_contributors',
+				$readme_file,
+				0,
+				0,
+				'https://developer.wordpress.org/plugins/wordpress-org/how-your-readme-txt-works/#readme-header-information',
+				7
+			);
 		}
 	}
 

--- a/tests/phpunit/testdata/plugins/test-plugin-plugin-readme-errors-invalid-name/readme.txt
+++ b/tests/phpunit/testdata/plugins/test-plugin-plugin-readme-errors-invalid-name/readme.txt
@@ -1,6 +1,6 @@
 === Plugin Name ===
 
-Contributors:      plugin-check
+Contributors:      plugin-check, username
 Requires at least: 6.0
 Tested up to:      6.1
 Requires PHP:      5.6

--- a/tests/phpunit/testdata/plugins/test-plugin-plugin-readme-errors-invalid-name/readme.txt
+++ b/tests/phpunit/testdata/plugins/test-plugin-plugin-readme-errors-invalid-name/readme.txt
@@ -1,6 +1,6 @@
 === Plugin Name ===
 
-Contributors:      plugin-check, username
+Contributors:      plugin-check, username, wordpressdotorg
 Requires at least: 6.0
 Tested up to:      6.1
 Requires PHP:      5.6

--- a/tests/phpunit/testdata/plugins/test-plugin-plugin-readme-parser-warnings/readme.txt
+++ b/tests/phpunit/testdata/plugins/test-plugin-plugin-readme-parser-warnings/readme.txt
@@ -1,7 +1,7 @@
 
 === Test Plugin Readme Errors Parser Warnings ===
 
-Contributors:      plugin check, wordpressdotorg
+Contributors:      plugin check, johndoe
 Requires at least: 6.0
 Tested up to:      Latest
 Requires PHP:      5.6

--- a/tests/phpunit/tests/Checker/Checks/Plugin_Readme_Check_Tests.php
+++ b/tests/phpunit/tests/Checker/Checks/Plugin_Readme_Check_Tests.php
@@ -68,6 +68,22 @@ class Plugin_Readme_Check_Tests extends WP_UnitTestCase {
 		$this->assertCount( 1, wp_list_filter( $errors['readme.txt'][0][0], array( 'code' => 'invalid_plugin_name' ) ) );
 	}
 
+	public function test_run_with_errors_restricted_contributors() {
+		$readme_check  = new Plugin_Readme_Check();
+		$check_context = new Check_Context( UNIT_TESTS_PLUGIN_DIR . 'test-plugin-plugin-readme-errors-invalid-name/load.php' );
+		$check_result  = new Check_Result( $check_context );
+
+		$readme_check->run( $check_result );
+
+		$errors = $check_result->get_errors();
+
+		$this->assertNotEmpty( $errors );
+		$this->assertArrayHasKey( 'readme.txt', $errors );
+
+		// Check for restricted contributors error.
+		$this->assertCount( 1, wp_list_filter( $errors['readme.txt'][0][0], array( 'code' => 'readme_restricted_contributors' ) ) );
+	}
+
 	public function test_run_with_errors_empty_name() {
 		$readme_check  = new Plugin_Readme_Check();
 		$check_context = new Check_Context( UNIT_TESTS_PLUGIN_DIR . 'test-plugin-plugin-readme-errors-empty-name/load.php' );

--- a/tests/phpunit/tests/Checker/Checks/Plugin_Readme_Check_Tests.php
+++ b/tests/phpunit/tests/Checker/Checks/Plugin_Readme_Check_Tests.php
@@ -75,13 +75,19 @@ class Plugin_Readme_Check_Tests extends WP_UnitTestCase {
 
 		$readme_check->run( $check_result );
 
-		$errors = $check_result->get_errors();
+		$errors   = $check_result->get_errors();
+		$warnings = $check_result->get_warnings();
 
 		$this->assertNotEmpty( $errors );
+		$this->assertNotEmpty( $warnings );
 		$this->assertArrayHasKey( 'readme.txt', $errors );
+		$this->assertArrayHasKey( 'readme.txt', $warnings );
 
 		// Check for restricted contributors error.
 		$this->assertCount( 1, wp_list_filter( $errors['readme.txt'][0][0], array( 'code' => 'readme_restricted_contributors' ) ) );
+
+		// Check for reserved contributors warning.
+		$this->assertCount( 1, wp_list_filter( $warnings['readme.txt'][0][0], array( 'code' => 'readme_reserved_contributors' ) ) );
 	}
 
 	public function test_run_with_errors_empty_name() {


### PR DESCRIPTION
Add check for restricted contributors.

These are few frequent encounters where readme is generated from some third party readme generator and plugin author forget to update the Contributors value in readme:

```
$restricted_contributors = array(
	'username',
	'your-username',
	'your_wordpress_username',
	'yourusername',
);

```

Edit: Add sample output

![Screen Shot 2024-12-09 at 1 16 29 PM](https://github.com/user-attachments/assets/c4319487-310a-4460-98df-9ee831aac182)
