### PR TITLE
Change error type of NonEnqueuedImage in `ImageFunctions` sniff

### DIFF
--- a/phpcs-sniffs/PluginCheck/Sniffs/CodeAnalysis/ImageFunctionsSniff.php
+++ b/phpcs-sniffs/PluginCheck/Sniffs/CodeAnalysis/ImageFunctionsSniff.php
@@ -59,7 +59,7 @@ final class ImageFunctionsSniff extends Sniff {
 
 		if ( preg_match_all( '#<img[^>]*(?<=src=)#', $content, $matches, \PREG_OFFSET_CAPTURE ) > 0 ) {
 			foreach ( $matches[0] as $match ) {
-				$this->phpcsFile->addError(
+				$this->phpcsFile->addWarning(
 					'Images should be added using wp_get_attachment_image() or similar functions',
 					$this->find_token_in_multiline_string( $stackPtr, $content, $match[1] ),
 					'NonEnqueuedImage'

--- a/phpcs-sniffs/PluginCheck/Tests/CodeAnalysis/ImageFunctionsUnitTest.php
+++ b/phpcs-sniffs/PluginCheck/Tests/CodeAnalysis/ImageFunctionsUnitTest.php
@@ -20,6 +20,15 @@ final class ImageFunctionsUnitTest extends AbstractSniffUnitTest {
 	 * @return array <int line number> => <int number of errors>
 	 */
 	public function getErrorList() {
+		return array();
+	}
+
+	/**
+	 * Returns the lines where warnings should occur.
+	 *
+	 * @return array <int line number> => <int number of warnings>
+	 */
+	public function getWarningList() {
 		return array(
 			1  => 1,
 			7  => 1,
@@ -31,14 +40,5 @@ final class ImageFunctionsUnitTest extends AbstractSniffUnitTest {
 			24 => 1,
 			25 => 1,
 		);
-	}
-
-	/**
-	 * Returns the lines where warnings should occur.
-	 *
-	 * @return array <int line number> => <int number of warnings>
-	 */
-	public function getWarningList() {
-		return array();
 	}
 }

--- a/tests/phpunit/tests/Checker/Checks/Image_Functions_Check_Tests.php
+++ b/tests/phpunit/tests/Checker/Checks/Image_Functions_Check_Tests.php
@@ -18,11 +18,11 @@ class Image_Functions_Check_Tests extends WP_UnitTestCase {
 
 		$check->run( $check_result );
 
-		$errors = $check_result->get_errors();
+		$warnings = $check_result->get_warnings();
 
-		$this->assertNotEmpty( $errors );
-		$this->assertArrayHasKey( 'load.php', $errors );
-		$this->assertEquals( 2, $check_result->get_error_count() );
+		$this->assertNotEmpty( $warnings );
+		$this->assertArrayHasKey( 'load.php', $warnings );
+		$this->assertEquals( 2, $check_result->get_warning_count() );
 	}
 
 	public function test_run_without_errors() {
@@ -32,9 +32,9 @@ class Image_Functions_Check_Tests extends WP_UnitTestCase {
 
 		$check->run( $check_result );
 
-		$errors = $check_result->get_errors();
+		$warnings = $check_result->get_warnings();
 
-		$this->assertEmpty( $errors );
-		$this->assertEquals( 0, $check_result->get_error_count() );
+		$this->assertEmpty( $warnings );
+		$this->assertEquals( 0, $check_result->get_warning_count() );
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/WordPress/plugin-check/issues/757

- `PluginCheck.CodeAnalysis.ImageFunctions.NonEnqueuedImage` is now Warning instead of Error.