### PR TITLE
Add check for unsupported plugin name in plugin header field

### DIFF
--- a/includes/Checker/Checks/Plugin_Repo/Plugin_Header_Fields_Check.php
+++ b/includes/Checker/Checks/Plugin_Repo/Plugin_Header_Fields_Check.php
@@ -97,6 +97,25 @@ class Plugin_Header_Fields_Check implements Static_Check {
 					'',
 					6
 				);
+			} else {
+				$potential_slug = sanitize_title_with_dashes( str_replace( '_', '-', preg_replace( '/[^a-z0-9 _.-]/i', '', remove_accents( $plugin_header['Name'] ) ) ) );
+
+				if ( empty( $potential_slug ) ) {
+					$this->add_result_error_for_file(
+						$result,
+						sprintf(
+							/* translators: %s: plugin header field */
+							__( 'The "%s" header in the plugin file is not valid. It may only contain latin letters (A-z), numbers, spaces, and hyphens.', 'plugin-check' ),
+							esc_html( $labels['Name'] )
+						),
+						'plugin_header_unsupported_plugin_name',
+						$plugin_main_file,
+						0,
+						0,
+						'https://developer.wordpress.org/plugins/plugin-basics/header-requirements/#header-fields',
+						7
+					);
+				}
 			}
 		}
 

--- a/includes/Checker/Checks/Plugin_Repo/Plugin_Header_Fields_Check.php
+++ b/includes/Checker/Checks/Plugin_Repo/Plugin_Header_Fields_Check.php
@@ -98,9 +98,9 @@ class Plugin_Header_Fields_Check implements Static_Check {
 					6
 				);
 			} else {
-				$potential_slug = sanitize_title_with_dashes( str_replace( '_', '-', preg_replace( '/[^a-z0-9 _.-]/i', '', remove_accents( $plugin_header['Name'] ) ) ) );
+				$valid_chars_count = preg_match_all( '/[a-z0-9-]/i', $plugin_header['Name'] );
 
-				if ( empty( $potential_slug ) ) {
+				if ( intval( $valid_chars_count ) < 5 ) {
 					$this->add_result_error_for_file(
 						$result,
 						sprintf(

--- a/includes/Checker/Checks/Plugin_Repo/Plugin_Header_Fields_Check.php
+++ b/includes/Checker/Checks/Plugin_Repo/Plugin_Header_Fields_Check.php
@@ -98,14 +98,14 @@ class Plugin_Header_Fields_Check implements Static_Check {
 					6
 				);
 			} else {
-				$valid_chars_count = preg_match_all( '/[a-z0-9-]/i', $plugin_header['Name'] );
+				$valid_chars_count = preg_match_all( '/[a-z0-9]/i', $plugin_header['Name'] );
 
 				if ( intval( $valid_chars_count ) < 5 ) {
 					$this->add_result_error_for_file(
 						$result,
 						sprintf(
 							/* translators: %s: plugin header field */
-							__( 'The "%s" header in the plugin file is not valid. It may only contain latin letters (A-z), numbers, spaces, and hyphens.', 'plugin-check' ),
+							__( 'The "%s" header in the plugin file is not valid. It needs to contain at least 5 latin letters (a-Z) and/or numbers. This is necessary because the initial plugin slug is generated from the name.', 'plugin-check' ),
 							esc_html( $labels['Name'] )
 						),
 						'plugin_header_unsupported_plugin_name',

--- a/tests/behat/features/plugin-check.feature
+++ b/tests/behat/features/plugin-check.feature
@@ -800,3 +800,27 @@ Feature: Test that the WP-CLI command works.
 	    """
 	    18,ERROR,WordPress.WP.I18n.TooManyFunctionArgs,7
 	    """
+
+  Scenario: Check unsupported plugin name in plugin header field
+    Given a WP install with the Plugin Check plugin
+    And a wp-content/plugins/foo-sample/foo-sample.php file:
+      """
+      <?php
+      /**
+       * Plugin Name: अद्भुत प्लगिन
+       * Plugin URI: https://foo-sample.com
+       * Description: Custom plugin.
+       * Version: 0.1.0
+       * Author: WordPress Performance Team
+       * Author URI: https://make.wordpress.org/performance/
+       * License: GPL-2.0+
+       * License URI: http://www.gnu.org/licenses/gpl-2.0.txt
+       */
+
+      """
+
+    When I run the WP-CLI command `plugin check foo-sample`
+    Then STDOUT should contain:
+	    """
+	    plugin_header_unsupported_plugin_name
+	    """


### PR DESCRIPTION
Fixes https://github.com/WordPress/plugin-check/issues/805