### PR TITLE
Update error message for `plugin_header_invalid_requires_wp` code 

### DIFF
--- a/includes/Checker/Checks/Plugin_Repo/Plugin_Header_Fields_Check.php
+++ b/includes/Checker/Checks/Plugin_Repo/Plugin_Header_Fields_Check.php
@@ -14,6 +14,7 @@ use WordPress\Plugin_Check\Checker\Static_Check;
 use WordPress\Plugin_Check\Traits\Amend_Check_Result;
 use WordPress\Plugin_Check\Traits\License_Utils;
 use WordPress\Plugin_Check\Traits\Stable_Check;
+use WordPress\Plugin_Check\Traits\Version_Utils;
 
 /**
  * Check for plugin header fields.
@@ -25,6 +26,7 @@ class Plugin_Header_Fields_Check implements Static_Check {
 	use Amend_Check_Result;
 	use License_Utils;
 	use Stable_Check;
+	use Version_Utils;
 
 	/**
 	 * Gets the categories for the check.
@@ -245,14 +247,17 @@ class Plugin_Header_Fields_Check implements Static_Check {
 
 		if ( ! empty( $plugin_header['RequiresWP'] ) ) {
 			if ( ! preg_match( '!^\d+\.\d(\.\d+)?$!', $plugin_header['RequiresWP'] ) ) {
+				$latest_wp_version   = $this->get_wordpress_stable_version();
+				$previous_wp_version = $this->get_wordpress_relative_major_version( $latest_wp_version, -1 );
+
 				$this->add_result_error_for_file(
 					$result,
 					sprintf(
-						/* translators: 1: plugin header field; 2: Example version 6.5.1. 3: Example version 6.6. */
+						/* translators: 1: plugin header field, 2: Example version 6.7, 3: Example version 6.6 */
 						__( 'The "%1$s" header in the plugin file should only contain a WordPress version such as "%2$s" or "%3$s".', 'plugin-check' ),
 						esc_html( $labels['RequiresWP'] ),
-						'6.5.1',
-						'6.6'
+						esc_html( $latest_wp_version ),
+						esc_html( $previous_wp_version )
 					),
 					'plugin_header_invalid_requires_wp',
 					$plugin_main_file,

--- a/tests/phpunit/tests/Checker/Checks/Plugin_Header_Fields_Check_Tests.php
+++ b/tests/phpunit/tests/Checker/Checks/Plugin_Header_Fields_Check_Tests.php
@@ -41,6 +41,27 @@ class Plugin_Header_Fields_Check_Tests extends WP_UnitTestCase {
 		}
 	}
 
+	public function test_run_with_invalid_requires_wp_header() {
+		set_transient( 'wp_plugin_check_latest_version_info', array( 'current' => '6.5.1' ) );
+
+		$check         = new Plugin_Header_Fields_Check();
+		$check_context = new Check_Context( UNIT_TESTS_PLUGIN_DIR . 'test-plugin-header-fields-with-errors/load.php' );
+		$check_result  = new Check_Result( $check_context );
+
+		$check->run( $check_result );
+
+		$errors = $check_result->get_errors();
+
+		$this->assertNotEmpty( $errors );
+
+		$error_items = wp_list_filter( $errors['load.php'][0][0], array( 'code' => 'plugin_header_invalid_requires_wp' ) );
+
+		$this->assertCount( 1, $error_items );
+		$this->assertStringContainsString( 'such as "6.5" or "6.4"', reset( $error_items )['message'] );
+
+		delete_transient( 'wp_plugin_check_latest_version_info' );
+	}
+
 	public function test_run_with_valid_requires_plugins_header() {
 		/*
 		 * Test plugin has following valid header.


### PR DESCRIPTION
Command: `wp plugin check pc-sample --format=csv`

Before

```
FILE: pc-sample.php
code,message
plugin_header_invalid_requires_wp,"The ""Requires at least"" header in the plugin file should only contain a WordPress version such as ""6.5.1"" or ""6.6""."
```


After

```
FILE: pc-sample.php
code,message
plugin_header_invalid_requires_wp,"The ""Requires at least"" header in the plugin file should only contain a WordPress version such as ""6.7"" or ""6.6""."
```

Version here corresponds to the latest WP version and earlier WP version. Earlier those were hardcoded.