### PR TITLE
Add file related functions in the exclusion list of alternative functions rule

### DIFF
--- a/phpcs-rulesets/plugin-review.xml
+++ b/phpcs-rulesets/plugin-review.xml
@@ -106,6 +106,8 @@
 	<rule ref="WordPress.WP.AlternativeFunctions">
 		<type>error</type>
 		<exclude name="WordPress.WP.AlternativeFunctions.json_encode_json_encode"/>
+		<exclude name="WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents"/>
+		<exclude name="WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents"/>
 	</rule>
 
 	<rule ref="Generic.PHP.ForbiddenFunctions">

--- a/tests/phpunit/testdata/plugins/test-plugin-review-phpcs-errors/load.php
+++ b/tests/phpunit/testdata/plugins/test-plugin-review-phpcs-errors/load.php
@@ -36,3 +36,6 @@ parse_str( 'first=value&arr[]=foo+bar&arr[]=baz' );
 $encoded_value = json_encode( array( 'key' => 'value' ) );
 
 custom_function(&$myvar);
+
+file_get_contents( $url );
+file_put_contents();

--- a/tests/phpunit/tests/Checker/Checks/Plugin_Review_PHPCS_Check_Tests.php
+++ b/tests/phpunit/tests/Checker/Checks/Plugin_Review_PHPCS_Check_Tests.php
@@ -54,6 +54,12 @@ class Plugin_Review_PHPCS_Check_Tests extends WP_UnitTestCase {
 		// There should not be WordPress.WP.AlternativeFunctions.json_encode_json_encode error on Line no 36 and column no at 18.
 		$this->assertCount( 0, wp_list_filter( $errors['load.php'][36][18], array( 'code' => 'WordPress.WP.AlternativeFunctions.json_encode_json_encode' ) ) );
 
+		// There should not be WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents error on Line no 40 and column no 1.
+		$this->assertCount( 0, wp_list_filter( $errors['load.php'][40][1], array( 'code' => 'WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents' ) ) );
+
+		// There should not be WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents error on Line no 41 and column no 1.
+		$this->assertCount( 0, wp_list_filter( $errors['load.php'][41][1], array( 'code' => 'WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents' ) ) );
+
 		// Check for WordPress.Security.ValidatedSanitizedInput warnings on Line no 15 and column no at 27.
 		$this->assertCount( 1, wp_list_filter( $warnings['load.php'][15][27], array( 'code' => 'WordPress.Security.ValidatedSanitizedInput.InputNotValidated' ) ) );
 		$this->assertCount( 1, wp_list_filter( $warnings['load.php'][15][27], array( 'code' => 'WordPress.Security.ValidatedSanitizedInput.MissingUnslash' ) ) );


### PR DESCRIPTION

Following functions are added in the exclusion list for alternative functions rule:

- WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
- WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents

Above function calls are giving almost always false positives. So those should be reviewed manually.