### PR TITLE
Unique error code for each missing readme headers

### DIFF
--- a/includes/Checker/Checks/Plugin_Repo/Plugin_Readme_Check.php
+++ b/includes/Checker/Checks/Plugin_Repo/Plugin_Readme_Check.php
@@ -248,14 +248,14 @@ class Plugin_Readme_Check extends Abstract_File_Check {
 							$result,
 							sprintf(
 								/* translators: %s: readme header field */
-								__( '<strong>Missing "%s".</strong><br>Your readme has to have headers as well as a proper description and documentation as to how it works and how one can use it.', 'plugin-check' ),
+								__( 'The "%s" header is missing in the readme file.', 'plugin-check' ),
 								$field['label']
 							),
-							'missing_readme_header',
+							'missing_readme_header_' . $field_key,
 							$readme_file,
 							0,
 							0,
-							'https://developer.wordpress.org/plugins/wordpress-org/common-issues/#incomplete-readme'
+							'https://developer.wordpress.org/plugins/wordpress-org/how-your-readme-txt-works/#readme-header-information'
 						);
 					}
 				}

--- a/tests/phpunit/testdata/plugins/test-plugin-plugin-readme-errors-upgrade-notice/readme.txt
+++ b/tests/phpunit/testdata/plugins/test-plugin-plugin-readme-errors-upgrade-notice/readme.txt
@@ -2,7 +2,6 @@
 
 Contributors:      plugin-check
 Requires at least: 6.0
-Tested up to:      6.1
 Requires PHP:      5.6
 Stable tag:        1.0.0
 License:           GPLv2 or later

--- a/tests/phpunit/tests/Checker/Checks/Plugin_Readme_Check_Tests.php
+++ b/tests/phpunit/tests/Checker/Checks/Plugin_Readme_Check_Tests.php
@@ -232,6 +232,22 @@ class Plugin_Readme_Check_Tests extends WP_UnitTestCase {
 		$this->assertCount( 1, wp_list_filter( $errors['readme.txt'][0][0], array( 'code' => 'outdated_tested_upto_header' ) ) );
 	}
 
+	public function test_run_with_errors_missing_readme_headers() {
+		$readme_check  = new Plugin_Readme_Check();
+		$check_context = new Check_Context( UNIT_TESTS_PLUGIN_DIR . 'test-plugin-plugin-readme-errors-upgrade-notice/load.php' );
+		$check_result  = new Check_Result( $check_context );
+
+		$readme_check->run( $check_result );
+
+		$errors = $check_result->get_errors();
+
+		$this->assertNotEmpty( $errors );
+		$this->assertArrayHasKey( 'readme.txt', $errors );
+
+		// Check for missing tested upto header.
+		$this->assertCount( 1, wp_list_filter( $errors['readme.txt'][0][0], array( 'code' => 'missing_readme_header_tested' ) ) );
+	}
+
 	public function test_run_md_with_errors() {
 		$readme_check  = new Plugin_Readme_Check();
 		$check_context = new Check_Context( UNIT_TESTS_PLUGIN_DIR . 'test-plugin-plugin-readme-md-with-errors/load.php' );


### PR DESCRIPTION
For missing readme header, same error code `missing_readme_header` was used for all missing header items. Now error codes will be like:

- missing_readme_header_tested
- missing_readme_header_contributors

Unit test was missing for this error. Unit test has been added.