### PR TITLE
Duplicated message for file type check

### DIFF
--- a/includes/Checker/Checks/Plugin_Repo/File_Type_Check.php
+++ b/includes/Checker/Checks/Plugin_Repo/File_Type_Check.php
@@ -235,7 +235,7 @@ class File_Type_Check extends Abstract_File_Check {
 	protected function look_for_application_files( Check_Result $result, array $files ) {
 		$application_files = self::filter_files_by_extensions(
 			$files,
-			array( 'a', 'bin', 'bpk', 'deploy', 'dist', 'distz', 'dmg', 'dms', 'DS_Store', 'dump', 'elc', 'exe', 'iso', 'lha', 'lrf', 'lzh', 'o', 'obj', 'phar', 'pkg', 'sh', 'so' )
+			array( 'a', 'bin', 'bpk', 'deploy', 'dist', 'distz', 'dmg', 'dms', 'dump', 'elc', 'exe', 'iso', 'lha', 'lrf', 'lzh', 'o', 'obj', 'phar', 'pkg', 'sh', 'so' )
 		);
 		if ( $application_files ) {
 			foreach ( $application_files as $file ) {

--- a/tests/behat/features/plugin-check.feature
+++ b/tests/behat/features/plugin-check.feature
@@ -719,3 +719,34 @@ Feature: Test that the WP-CLI command works.
 	    """
 	    readme_invalid_contributors
 	    """
+
+  Scenario: Check duplicated error messages for hidden files and application files
+    Given a WP install with the Plugin Check plugin
+    And a wp-content/plugins/foo-sample/foo-sample.php file:
+      """
+      <?php
+      /**
+       * Plugin Name: Foo Sample
+       * Plugin URI: https://foo-sample.com
+       * Description: Custom plugin.
+       * Version: 0.1.0
+       * Author: WordPress Performance Team
+       * Author URI: https://make.wordpress.org/performance/
+       * License: GPL-2.0+
+       * License URI: http://www.gnu.org/licenses/gpl-2.0.txt
+       */
+
+      """
+    And a wp-content/plugins/foo-sample/.DS_Store file:
+      """
+      """
+
+    When I run the WP-CLI command `plugin check foo-sample --checks=file_type`
+    Then STDOUT should contain:
+	    """
+	    hidden_files
+	    """
+    And STDOUT should not contain:
+	    """
+	    application_detected
+	    """


### PR DESCRIPTION
For file `.DS_Store`, two errors are triggered: `hidden_files` and `application_detected`

In this PR, I have removed `DS_Store` extension from the list of application extensions.

For `.DS_Store` file, `hidden_files` error is already triggered. So, I believe application check should not test for `DS_Store`.

This will fix duplicated message for the same file.

PR also includes scenario in the feature test for the related change.
