### PR TITLE
Update severity for i18n codes

### DIFF
--- a/includes/Checker/Checks/General/I18n_Usage_Check.php
+++ b/includes/Checker/Checks/General/I18n_Usage_Check.php
@@ -128,6 +128,21 @@ class I18n_Usage_Check extends Abstract_PHP_CodeSniffer_Check {
 				break;
 		}
 
+		// Update severity.
+		switch ( $code ) {
+			case 'WordPress.WP.I18n.InterpolatedVariableDomain':
+			case 'WordPress.WP.I18n.MissingArgText':
+			case 'WordPress.WP.I18n.NoEmptyStrings':
+			case 'WordPress.WP.I18n.NonSingularStringLiteralContext':
+			case 'WordPress.WP.I18n.NonSingularStringLiteralDomain':
+			case 'WordPress.WP.I18n.TooManyFunctionArgs':
+				$severity = 7;
+				break;
+
+			default:
+				break;
+		}
+
 		parent::add_result_message_for_file( $result, $error, $message, $code, $file, $line, $column, $docs, $severity );
 	}
 }

--- a/tests/behat/features/plugin-check.feature
+++ b/tests/behat/features/plugin-check.feature
@@ -750,3 +750,53 @@ Feature: Test that the WP-CLI command works.
 	    """
 	    application_detected
 	    """
+
+  Scenario: Check for i18n severity
+    Given a WP install with the Plugin Check plugin
+    And a wp-content/plugins/foo-sample/foo-sample.php file:
+      """
+      <?php
+      /**
+       * Plugin Name: Foo Sample
+       * Plugin URI: https://foo-sample.com
+       * Description: Custom plugin.
+       * Version: 0.1.0
+       * Author: WordPress Performance Team
+       * Author URI: https://make.wordpress.org/performance/
+       * License: GPL-2.0+
+       * License URI: http://www.gnu.org/licenses/gpl-2.0.txt
+       */
+
+      esc_html_e( 'Hello world', "${var}" );
+      esc_html_e( domain: 'foo-sample' );
+      esc_html_e( '%s', 'foo-sample' );
+      echo esc_html_x( 'Hello world', $var, 'foo-sample' );
+      esc_html_e( 'Hello world', $var );
+      esc_html_e( 'Hello world', 'foo-sample', 'too-many-args' );
+      """
+
+    When I run the WP-CLI command `plugin check foo-sample --checks=i18n_usage --fields=line,type,code,severity --format=csv`
+    Then STDOUT should contain:
+	    """
+	    13,ERROR,WordPress.WP.I18n.InterpolatedVariableDomain,7
+	    """
+    And STDOUT should contain:
+	    """
+	    14,ERROR,WordPress.WP.I18n.MissingArgText,7
+	    """
+    And STDOUT should contain:
+	    """
+	    15,ERROR,WordPress.WP.I18n.NoEmptyStrings,7
+	    """
+    And STDOUT should contain:
+	    """
+	    16,ERROR,WordPress.WP.I18n.NonSingularStringLiteralContext,7
+	    """
+    And STDOUT should contain:
+	    """
+	    17,ERROR,WordPress.WP.I18n.NonSingularStringLiteralDomain,7
+	    """
+    And STDOUT should contain:
+	    """
+	    18,ERROR,WordPress.WP.I18n.TooManyFunctionArgs,7
+	    """


### PR DESCRIPTION
Regarding i18n improvement for the plugins, PRT team has decided to raise some `WordPress.WP.I18n` error codes to severity 7 making those blockers in the WP.org. As first step, following codes are made severity 7. These are pretty robust checks and irrespective of plugin text domain.

- WordPress.WP.I18n.InterpolatedVariableDomain
- WordPress.WP.I18n.MissingArgText
- WordPress.WP.I18n.NoEmptyStrings
- WordPress.WP.I18n.NonSingularStringLiteralContext
- WordPress.WP.I18n.NonSingularStringLiteralDomain
- WordPress.WP.I18n.TooManyFunctionArgs

Feature test scenario has also been added for new severity level.

Example errors which will be triggered as blockers:
```
      esc_html_e( 'Hello world', "${var}" );
      esc_html_e( domain: 'foo-sample' );
      esc_html_e( '%s', 'foo-sample' );
      echo esc_html_x( 'Hello world', $var, 'foo-sample' );
      esc_html_e( 'Hello world', $var );
      esc_html_e( 'Hello world', 'foo-sample', 'too-many-args' );

```