### PR TITLE
Check valid WP version for `Requires at least` plugin header

### DIFF
--- a/includes/Checker/Checks/Plugin_Repo/Plugin_Header_Fields_Check.php
+++ b/includes/Checker/Checks/Plugin_Repo/Plugin_Header_Fields_Check.php
@@ -265,8 +265,9 @@ class Plugin_Header_Fields_Check implements Static_Check {
 		}
 
 		if ( ! empty( $plugin_header['RequiresWP'] ) ) {
+			$latest_wp_version = $this->get_wordpress_stable_version();
+
 			if ( ! preg_match( '!^\d+\.\d(\.\d+)?$!', $plugin_header['RequiresWP'] ) ) {
-				$latest_wp_version   = $this->get_wordpress_stable_version();
 				$previous_wp_version = $this->get_wordpress_relative_major_version( $latest_wp_version, -1 );
 
 				$this->add_result_error_for_file(
@@ -285,6 +286,26 @@ class Plugin_Header_Fields_Check implements Static_Check {
 					'',
 					7
 				);
+			} else {
+				$acceptable_min_wp_version = $this->get_wordpress_relative_major_version( $latest_wp_version, 1 );
+
+				if ( version_compare( $plugin_header['RequiresWP'], $acceptable_min_wp_version, '>' ) ) {
+					$this->add_result_error_for_file(
+						$result,
+						sprintf(
+							/* translators: 1: plugin header field, 2: currently used version */
+							__( '<strong>%1$s: %2$s.</strong><br>The "%1$s" value in your plugin header is not valid. This version of WordPress does not exist (yet).', 'plugin-check' ),
+							esc_html( $labels['RequiresWP'] ),
+							esc_html( $plugin_header['RequiresWP'] )
+						),
+						'plugin_header_nonexistent_requires_wp',
+						$plugin_main_file,
+						0,
+						0,
+						'https://developer.wordpress.org/plugins/plugin-basics/header-requirements/#header-fields',
+						7
+					);
+				}
 			}
 		}
 		if ( ! empty( $plugin_header['RequiresPHP'] ) ) {

--- a/tests/phpunit/tests/Checker/Checks/Plugin_Header_Fields_Check_Tests.php
+++ b/tests/phpunit/tests/Checker/Checks/Plugin_Header_Fields_Check_Tests.php
@@ -110,4 +110,61 @@ class Plugin_Header_Fields_Check_Tests extends WP_UnitTestCase {
 		$this->assertCount( 1, wp_list_filter( $errors['load.php'][0][0], array( 'code' => 'plugin_header_missing_plugin_description' ) ) );
 		$this->assertCount( 1, wp_list_filter( $errors['load.php'][0][0], array( 'code' => 'plugin_header_invalid_plugin_version' ) ) );
 	}
+
+	public function test_run_with_errors_requires_at_least_latest_plus_two_version() {
+		// Target plugin has "6.0" in plugin header.
+		set_transient( 'wp_plugin_check_latest_version_info', array( 'current' => '5.8.1' ) );
+
+		$readme_check  = new Plugin_Header_Fields_Check();
+		$check_context = new Check_Context( UNIT_TESTS_PLUGIN_DIR . 'test-plugin-localhost-with-errors/load.php' );
+		$check_result  = new Check_Result( $check_context );
+
+		$readme_check->run( $check_result );
+
+		$errors = $check_result->get_errors();
+
+		$this->assertNotEmpty( $errors );
+
+		$filtered_items = wp_list_filter( $errors['load.php'][0][0], array( 'code' => 'plugin_header_nonexistent_requires_wp' ) );
+
+		$this->assertCount( 1, $filtered_items );
+		$this->assertStringContainsString( 'Requires at least: 6.0', $filtered_items[0]['message'] );
+		$this->assertStringContainsString( 'This version of WordPress does not exist (yet).', $filtered_items[0]['message'] );
+
+		delete_transient( 'wp_plugin_check_latest_version_info' );
+	}
+
+	public function test_run_with_errors_requires_at_least_latest_plus_one_version() {
+		// Target plugin has "6.0" in plugin header.
+		set_transient( 'wp_plugin_check_latest_version_info', array( 'current' => '5.9.1' ) );
+
+		$readme_check  = new Plugin_Header_Fields_Check();
+		$check_context = new Check_Context( UNIT_TESTS_PLUGIN_DIR . 'test-plugin-localhost-with-errors/load.php' );
+		$check_result  = new Check_Result( $check_context );
+
+		$readme_check->run( $check_result );
+
+		$errors = $check_result->get_errors();
+
+		$this->assertEmpty( $errors );
+
+		delete_transient( 'wp_plugin_check_latest_version_info' );
+	}
+
+	public function test_run_with_errors_requires_at_least_latest_version() {
+		// Target plugin has "6.0" in plugin header.
+		set_transient( 'wp_plugin_check_latest_version_info', array( 'current' => '6.0.1' ) );
+
+		$readme_check  = new Plugin_Header_Fields_Check();
+		$check_context = new Check_Context( UNIT_TESTS_PLUGIN_DIR . 'test-plugin-localhost-with-errors/load.php' );
+		$check_result  = new Check_Result( $check_context );
+
+		$readme_check->run( $check_result );
+
+		$errors = $check_result->get_errors();
+
+		$this->assertEmpty( $errors );
+
+		delete_transient( 'wp_plugin_check_latest_version_info' );
+	}
 }

--- a/tests/phpunit/tests/Checker/Checks/Plugin_Header_Fields_Check_Tests.php
+++ b/tests/phpunit/tests/Checker/Checks/Plugin_Header_Fields_Check_Tests.php
@@ -123,6 +123,8 @@ class Plugin_Header_Fields_Check_Tests extends WP_UnitTestCase {
 
 		$errors = $check_result->get_errors();
 
+		delete_transient( 'wp_plugin_check_latest_version_info' );
+
 		$this->assertNotEmpty( $errors );
 
 		$filtered_items = wp_list_filter( $errors['load.php'][0][0], array( 'code' => 'plugin_header_nonexistent_requires_wp' ) );
@@ -130,11 +132,9 @@ class Plugin_Header_Fields_Check_Tests extends WP_UnitTestCase {
 		$this->assertCount( 1, $filtered_items );
 		$this->assertStringContainsString( 'Requires at least: 6.0', $filtered_items[0]['message'] );
 		$this->assertStringContainsString( 'This version of WordPress does not exist (yet).', $filtered_items[0]['message'] );
-
-		delete_transient( 'wp_plugin_check_latest_version_info' );
 	}
 
-	public function test_run_with_errors_requires_at_least_latest_plus_one_version() {
+	public function test_run_without_errors_requires_at_least_latest_plus_one_version() {
 		// Target plugin has "6.0" in plugin header.
 		set_transient( 'wp_plugin_check_latest_version_info', array( 'current' => '5.9.1' ) );
 
@@ -146,12 +146,12 @@ class Plugin_Header_Fields_Check_Tests extends WP_UnitTestCase {
 
 		$errors = $check_result->get_errors();
 
-		$this->assertEmpty( $errors );
-
 		delete_transient( 'wp_plugin_check_latest_version_info' );
+
+		$this->assertEmpty( $errors );
 	}
 
-	public function test_run_with_errors_requires_at_least_latest_version() {
+	public function test_run_without_errors_requires_at_least_latest_version() {
 		// Target plugin has "6.0" in plugin header.
 		set_transient( 'wp_plugin_check_latest_version_info', array( 'current' => '6.0.1' ) );
 
@@ -163,8 +163,8 @@ class Plugin_Header_Fields_Check_Tests extends WP_UnitTestCase {
 
 		$errors = $check_result->get_errors();
 
-		$this->assertEmpty( $errors );
-
 		delete_transient( 'wp_plugin_check_latest_version_info' );
+
+		$this->assertEmpty( $errors );
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/WordPress/plugin-check/issues/851


- Check added for `Requires at least` plugin header for validity of WordPress version
- Version check logic is similar to `Tested up to`.
- At `6.7` WP version, error will be generated for more than or equal to WP `6.9`
- Unit tests added for the updated check