### PR TITLE
Fix order of cleanup actions in PHP unit tests

### DIFF
--- a/tests/phpunit/tests/Checker/Checks/Plugin_Header_Fields_Check_Tests.php
+++ b/tests/phpunit/tests/Checker/Checks/Plugin_Header_Fields_Check_Tests.php
@@ -52,14 +52,14 @@ class Plugin_Header_Fields_Check_Tests extends WP_UnitTestCase {
 
 		$errors = $check_result->get_errors();
 
+		delete_transient( 'wp_plugin_check_latest_version_info' );
+
 		$this->assertNotEmpty( $errors );
 
 		$error_items = wp_list_filter( $errors['load.php'][0][0], array( 'code' => 'plugin_header_invalid_requires_wp' ) );
 
 		$this->assertCount( 1, $error_items );
 		$this->assertStringContainsString( 'such as "6.5" or "6.4"', reset( $error_items )['message'] );
-
-		delete_transient( 'wp_plugin_check_latest_version_info' );
 	}
 
 	public function test_run_with_valid_requires_plugins_header() {

--- a/tests/phpunit/tests/Checker/Checks/Plugin_Readme_Check_Tests.php
+++ b/tests/phpunit/tests/Checker/Checks/Plugin_Readme_Check_Tests.php
@@ -349,6 +349,8 @@ class Plugin_Readme_Check_Tests extends WP_UnitTestCase {
 
 		$warnings = $check_result->get_warnings();
 
+		delete_transient( 'wp_plugin_check_latest_wp_version' );
+
 		$this->assertNotEmpty( $warnings );
 		$this->assertArrayHasKey( 'readme.txt', $warnings );
 
@@ -359,8 +361,6 @@ class Plugin_Readme_Check_Tests extends WP_UnitTestCase {
 		$filtered_items = array_values( $filtered_items );
 
 		$this->assertStringContainsString( 'The "Tested up to" field was ignored. This field should only contain a valid WordPress version such as "' . $version . '"', $filtered_items[0]['message'] );
-
-		delete_transient( 'wp_plugin_check_latest_wp_version' );
 	}
 
 	public function test_run_with_errors_multiple_parser_warnings_and_empty_ignored_array() {
@@ -375,6 +375,8 @@ class Plugin_Readme_Check_Tests extends WP_UnitTestCase {
 		$errors   = $check_result->get_errors();
 		$warnings = $check_result->get_warnings();
 
+		remove_filter( 'wp_plugin_check_ignored_readme_warnings', '__return_empty_array' );
+
 		$this->assertNotEmpty( $warnings );
 		$this->assertArrayHasKey( 'readme.txt', $warnings );
 
@@ -385,8 +387,6 @@ class Plugin_Readme_Check_Tests extends WP_UnitTestCase {
 		$this->assertEquals( 8, $check_result->get_warning_count() );
 		$this->assertEmpty( $errors );
 		$this->assertEquals( 0, $check_result->get_error_count() );
-
-		remove_filter( 'wp_plugin_check_ignored_readme_warnings', '__return_empty_array' );
 	}
 
 	public function test_filter_readme_warnings_ignored() {
@@ -406,8 +406,6 @@ class Plugin_Readme_Check_Tests extends WP_UnitTestCase {
 
 		$result = apply_filters( $filter_name, array() );
 
-		$this->assertEquals( $custom_ignores, $result );
-
 		// Remove the filter to avoid interfering with other tests.
 		remove_filter(
 			$filter_name,
@@ -415,6 +413,8 @@ class Plugin_Readme_Check_Tests extends WP_UnitTestCase {
 				return $custom_ignores;
 			}
 		);
+
+		$this->assertEquals( $custom_ignores, $result );
 	}
 
 	public function test_filter_wp_plugin_check_ignored_readme_warnings_will_return_no_error() {
@@ -442,11 +442,6 @@ class Plugin_Readme_Check_Tests extends WP_UnitTestCase {
 		$errors   = $check_result->get_errors();
 		$warnings = $check_result->get_warnings();
 
-		$this->assertEmpty( $errors );
-		$this->assertEmpty( $warnings );
-		$this->assertSame( 0, $check_result->get_error_count() );
-		$this->assertSame( 0, $check_result->get_warning_count() );
-
 		// Remove the filter to avoid interfering with other tests.
 		remove_filter(
 			$filter_name,
@@ -454,6 +449,11 @@ class Plugin_Readme_Check_Tests extends WP_UnitTestCase {
 				return $custom_ignores;
 			}
 		);
+
+		$this->assertEmpty( $errors );
+		$this->assertEmpty( $warnings );
+		$this->assertSame( 0, $check_result->get_error_count() );
+		$this->assertSame( 0, $check_result->get_warning_count() );
 	}
 
 	public function test_run_with_errors_upgrade_notice() {
@@ -485,6 +485,8 @@ class Plugin_Readme_Check_Tests extends WP_UnitTestCase {
 
 		$errors = $check_result->get_errors();
 
+		delete_transient( 'wp_plugin_check_latest_wp_version' );
+
 		$this->assertNotEmpty( $errors );
 
 		$filtered_items = wp_list_filter( $errors['readme.md'][0][0], array( 'code' => 'nonexistent_tested_upto_header' ) );
@@ -492,11 +494,9 @@ class Plugin_Readme_Check_Tests extends WP_UnitTestCase {
 		$this->assertCount( 1, $filtered_items );
 		$this->assertStringContainsString( 'Tested up to: 6.1', $filtered_items[0]['message'] );
 		$this->assertStringContainsString( 'This version of WordPress does not exist (yet).', $filtered_items[0]['message'] );
-
-		delete_transient( 'wp_plugin_check_latest_wp_version' );
 	}
 
-	public function test_run_with_errors_tested_up_to_latest_plus_one_version() {
+	public function test_run_without_errors_tested_up_to_latest_plus_one_version() {
 		$version = '6.0'; // Target plugin has "6.1" is readme.
 
 		set_transient( 'wp_plugin_check_latest_wp_version', $version );
@@ -509,12 +509,12 @@ class Plugin_Readme_Check_Tests extends WP_UnitTestCase {
 
 		$errors = $check_result->get_errors();
 
-		$this->assertCount( 0, wp_list_filter( $errors['readme.md'][0][0], array( 'code' => 'nonexistent_tested_upto_header' ) ) );
-
 		delete_transient( 'wp_plugin_check_latest_wp_version' );
+
+		$this->assertCount( 0, wp_list_filter( $errors['readme.md'][0][0], array( 'code' => 'nonexistent_tested_upto_header' ) ) );
 	}
 
-	public function test_run_with_errors_tested_up_to_latest_stable_version() {
+	public function test_run_without_errors_tested_up_to_latest_stable_version() {
 		$version = '6.1'; // Target plugin has "6.1" is readme.
 
 		set_transient( 'wp_plugin_check_latest_wp_version', $version );
@@ -527,9 +527,9 @@ class Plugin_Readme_Check_Tests extends WP_UnitTestCase {
 
 		$errors = $check_result->get_errors();
 
-		$this->assertCount( 0, wp_list_filter( $errors['readme.md'][0][0], array( 'code' => 'nonexistent_tested_upto_header' ) ) );
-
 		delete_transient( 'wp_plugin_check_latest_wp_version' );
+
+		$this->assertCount( 0, wp_list_filter( $errors['readme.md'][0][0], array( 'code' => 'nonexistent_tested_upto_header' ) ) );
 	}
 
 	public function test_run_without_errors_readme_contributors_warning() {

--- a/tests/phpunit/tests/Utilities/Plugin_Request_Utility_Tests.php
+++ b/tests/phpunit/tests/Utilities/Plugin_Request_Utility_Tests.php
@@ -260,8 +260,6 @@ class Plugin_Request_Utility_Tests extends WP_UnitTestCase {
 
 		$result = Plugin_Request_Utility::get_directories_to_ignore();
 
-		$this->assertEquals( $custom_ignore_directories, $result );
-
 		// Remove the filter to avoid interfering with other tests.
 		remove_filter(
 			$filter_name,
@@ -269,6 +267,8 @@ class Plugin_Request_Utility_Tests extends WP_UnitTestCase {
 				return $custom_ignore_directories;
 			}
 		);
+
+		$this->assertEquals( $custom_ignore_directories, $result );
 	}
 
 	public function test_filter_ignore_files() {
@@ -289,8 +289,6 @@ class Plugin_Request_Utility_Tests extends WP_UnitTestCase {
 
 		$result = Plugin_Request_Utility::get_files_to_ignore();
 
-		$this->assertEquals( $custom_ignore_files, $result );
-
 		// Remove the filter to avoid interfering with other tests.
 		remove_filter(
 			$filter_name,
@@ -298,6 +296,8 @@ class Plugin_Request_Utility_Tests extends WP_UnitTestCase {
 				return $custom_ignore_files;
 			}
 		);
+
+		$this->assertEquals( $custom_ignore_files, $result );
 	}
 
 	public function test_plugin_without_error_for_ignore_directories() {
@@ -331,10 +331,6 @@ class Plugin_Request_Utility_Tests extends WP_UnitTestCase {
 
 		$results = $checks->run_checks( $check_context, $checks_to_run );
 
-		$this->assertInstanceOf( Check_Result::class, $results );
-		$this->assertEmpty( $results->get_warnings() );
-		$this->assertEmpty( $results->get_errors() );
-
 		// Remove the filter to avoid interfering with other tests.
 		remove_filter(
 			$filter_name,
@@ -342,6 +338,10 @@ class Plugin_Request_Utility_Tests extends WP_UnitTestCase {
 				return $custom_ignore_directories;
 			}
 		);
+
+		$this->assertInstanceOf( Check_Result::class, $results );
+		$this->assertEmpty( $results->get_warnings() );
+		$this->assertEmpty( $results->get_errors() );
 	}
 
 	public function test_plugin_with_error_for_ignore_directories() {
@@ -464,6 +464,14 @@ class Plugin_Request_Utility_Tests extends WP_UnitTestCase {
 
 		$results = $checks->run_checks( $check_context, $checks_to_run );
 
+		// Remove the filter to avoid interfering with other tests.
+		remove_filter(
+			$filter_name,
+			static function () use ( $custom_ignore_files ) {
+				return $custom_ignore_files;
+			}
+		);
+
 		$this->assertInstanceOf( Check_Result::class, $results );
 
 		$errors   = $results->get_errors();
@@ -473,13 +481,5 @@ class Plugin_Request_Utility_Tests extends WP_UnitTestCase {
 		$this->assertEmpty( $warnings );
 		$this->assertEquals( 2, $results->get_error_count() );
 		$this->assertEquals( 0, $results->get_warning_count() );
-
-		// Remove the filter to avoid interfering with other tests.
-		remove_filter(
-			$filter_name,
-			static function () use ( $custom_ignore_files ) {
-				return $custom_ignore_files;
-			}
-		);
 	}
 }


### PR DESCRIPTION
Based on feedback from PR - https://github.com/WordPress/plugin-check/pull/852

- Moved `delete_transient()` and `remove_filter()` calls in unit tests before the assertion to avoid potential issues in the future