### PR TITLE
Implement Version Utils in readme check

### DIFF
--- a/includes/Checker/Checks/Plugin_Repo/Plugin_Readme_Check.php
+++ b/includes/Checker/Checks/Plugin_Repo/Plugin_Readme_Check.php
@@ -14,6 +14,7 @@ use WordPress\Plugin_Check\Traits\Amend_Check_Result;
 use WordPress\Plugin_Check\Traits\Find_Readme;
 use WordPress\Plugin_Check\Traits\License_Utils;
 use WordPress\Plugin_Check\Traits\Stable_Check;
+use WordPress\Plugin_Check\Traits\Version_Utils;
 use WordPressdotorg\Plugin_Directory\Readme\Parser;
 
 /**
@@ -29,6 +30,7 @@ class Plugin_Readme_Check extends Abstract_File_Check {
 	use Find_Readme;
 	use Stable_Check;
 	use License_Utils;
+	use Version_Utils;
 
 	/**
 	 * Gets the categories for the check.
@@ -784,47 +786,6 @@ class Plugin_Readme_Check extends Abstract_File_Check {
 				);
 			}
 		}
-	}
-
-	/**
-	 * Returns current major WordPress version.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @return string Stable WordPress version.
-	 */
-	private function get_wordpress_stable_version() {
-		$version = get_transient( 'wp_plugin_check_latest_wp_version' );
-
-		if ( false === $version ) {
-			$response = wp_remote_get( 'https://api.wordpress.org/core/version-check/1.7/' );
-
-			if ( ! is_wp_error( $response ) && 200 === wp_remote_retrieve_response_code( $response ) ) {
-				$body = json_decode( wp_remote_retrieve_body( $response ), true );
-
-				if ( isset( $body['offers'] ) && ! empty( $body['offers'] ) ) {
-					$latest_release = reset( $body['offers'] );
-
-					$version = $latest_release['current'];
-
-					set_transient( 'wp_plugin_check_latest_wp_version', $version, DAY_IN_SECONDS );
-				}
-			}
-		}
-
-		// If $version is still false at this point, use current installed WordPress version.
-		if ( false === $version ) {
-			$version = get_bloginfo( 'version' );
-
-			// Strip off any -alpha, -RC, -beta suffixes.
-			list( $version, ) = explode( '-', $version );
-		}
-
-		if ( preg_match( '#^\d.\d#', $version, $matches ) ) {
-			$version = $matches[0];
-		}
-
-		return $version;
 	}
 
 	/**

--- a/tests/phpunit/tests/Checker/Checks/Plugin_Readme_Check_Tests.php
+++ b/tests/phpunit/tests/Checker/Checks/Plugin_Readme_Check_Tests.php
@@ -339,7 +339,7 @@ class Plugin_Readme_Check_Tests extends WP_UnitTestCase {
 	public function test_run_with_errors_parser_warnings_with_custom_set_transient_version() {
 		$version = '5.0';
 
-		set_transient( 'wp_plugin_check_latest_wp_version', $version );
+		set_transient( 'wp_plugin_check_latest_version_info', array( 'current' => '5.0.1' ) );
 
 		$readme_check  = new Plugin_Readme_Check();
 		$check_context = new Check_Context( UNIT_TESTS_PLUGIN_DIR . 'test-plugin-plugin-readme-parser-warnings/load.php' );
@@ -349,7 +349,7 @@ class Plugin_Readme_Check_Tests extends WP_UnitTestCase {
 
 		$warnings = $check_result->get_warnings();
 
-		delete_transient( 'wp_plugin_check_latest_wp_version' );
+		delete_transient( 'wp_plugin_check_latest_version_info' );
 
 		$this->assertNotEmpty( $warnings );
 		$this->assertArrayHasKey( 'readme.txt', $warnings );
@@ -473,9 +473,8 @@ class Plugin_Readme_Check_Tests extends WP_UnitTestCase {
 	}
 
 	public function test_run_with_errors_tested_up_to_latest_plus_two_version() {
-		$version = '5.9'; // Target plugin has "6.1" is readme.
-
-		set_transient( 'wp_plugin_check_latest_wp_version', $version );
+		// Target plugin has "6.1" is readme.
+		set_transient( 'wp_plugin_check_latest_version_info', array( 'current' => '5.9.1' ) );
 
 		$readme_check  = new Plugin_Readme_Check();
 		$check_context = new Check_Context( UNIT_TESTS_PLUGIN_DIR . 'test-plugin-plugin-readme-md-with-errors/load.php' );
@@ -485,7 +484,7 @@ class Plugin_Readme_Check_Tests extends WP_UnitTestCase {
 
 		$errors = $check_result->get_errors();
 
-		delete_transient( 'wp_plugin_check_latest_wp_version' );
+		delete_transient( 'wp_plugin_check_latest_version_info' );
 
 		$this->assertNotEmpty( $errors );
 
@@ -497,9 +496,8 @@ class Plugin_Readme_Check_Tests extends WP_UnitTestCase {
 	}
 
 	public function test_run_without_errors_tested_up_to_latest_plus_one_version() {
-		$version = '6.0'; // Target plugin has "6.1" is readme.
-
-		set_transient( 'wp_plugin_check_latest_wp_version', $version );
+		// Target plugin has "6.1" is readme.
+		set_transient( 'wp_plugin_check_latest_version_info', array( 'current' => '6.0.1' ) );
 
 		$readme_check  = new Plugin_Readme_Check();
 		$check_context = new Check_Context( UNIT_TESTS_PLUGIN_DIR . 'test-plugin-plugin-readme-md-with-errors/load.php' );
@@ -509,15 +507,14 @@ class Plugin_Readme_Check_Tests extends WP_UnitTestCase {
 
 		$errors = $check_result->get_errors();
 
-		delete_transient( 'wp_plugin_check_latest_wp_version' );
+		delete_transient( 'wp_plugin_check_latest_version_info' );
 
 		$this->assertCount( 0, wp_list_filter( $errors['readme.md'][0][0], array( 'code' => 'nonexistent_tested_upto_header' ) ) );
 	}
 
 	public function test_run_without_errors_tested_up_to_latest_stable_version() {
-		$version = '6.1'; // Target plugin has "6.1" is readme.
-
-		set_transient( 'wp_plugin_check_latest_wp_version', $version );
+		// Target plugin has "6.1" is readme.
+		set_transient( 'wp_plugin_check_latest_version_info', array( 'current' => '6.1.1' ) );
 
 		$readme_check  = new Plugin_Readme_Check();
 		$check_context = new Check_Context( UNIT_TESTS_PLUGIN_DIR . 'test-plugin-plugin-readme-md-with-errors/load.php' );
@@ -527,7 +524,7 @@ class Plugin_Readme_Check_Tests extends WP_UnitTestCase {
 
 		$errors = $check_result->get_errors();
 
-		delete_transient( 'wp_plugin_check_latest_wp_version' );
+		delete_transient( 'wp_plugin_check_latest_version_info' );
 
 		$this->assertCount( 0, wp_list_filter( $errors['readme.md'][0][0], array( 'code' => 'nonexistent_tested_upto_header' ) ) );
 	}


### PR DESCRIPTION

- Removed `get_wordpress_stable_version()` private helper method from `Plugin_Readme_Check` in favor of `Version_Utils`.
- Version helpers are now consolidated and `Version_Utils` trait will be responsible for fetching necessary version info details.
- Updated PHP unit test for the changes
