### PR TITLE
Improve license check for Apache

### DIFF
--- a/includes/Traits/License_Utils.php
+++ b/includes/Traits/License_Utils.php
@@ -54,6 +54,7 @@ trait License_Utils {
 		$license = str_replace( 'GNU General Public License', 'GPL', $license );
 		$license = str_replace( ' version ', 'v', $license );
 		$license = preg_replace( '/GPL\s*[-|\.]*\s*[v]?([0-9])(\.[0])?/i', 'GPL$1', $license, 1 );
+		$license = preg_replace( '/Apache.*?([0-9])(\.[0])?/i', 'Apache$1', $license );
 		$license = str_replace( '.', '', $license );
 
 		return $license;
@@ -82,7 +83,7 @@ trait License_Utils {
 	 * @return bool true if the license is GPL compatible, otherwise false.
 	 */
 	protected function is_license_gpl_compatible( $license ) {
-		$match = preg_match( '/GPL|GNU|MIT|FreeBSD|New BSD|BSD-3-Clause|BSD 3 Clause|OpenLDAP|Expat|Apache|MPL20|ISC/im', $license );
+		$match = preg_match( '/GPL|GNU|MIT|FreeBSD|New BSD|BSD-3-Clause|BSD 3 Clause|OpenLDAP|Expat|Apache2|MPL20|ISC/im', $license );
 
 		return ( false === $match || 0 === $match ) ? false : true;
 	}

--- a/tests/phpunit/tests/Traits/License_Utils_Tests.php
+++ b/tests/phpunit/tests/Traits/License_Utils_Tests.php
@@ -66,6 +66,13 @@ class License_Utils_Tests extends WP_UnitTestCase {
 			array( 'GPL version 3', 'GPL3' ),
 			array( 'GPL version 3 or later', 'GPL3' ),
 
+			array( 'Apache License, Version 2.0', 'Apache2' ),
+			array( 'Apache License 2.0', 'Apache2' ),
+			array( 'Apache License 2', 'Apache2' ),
+			array( 'Apache 2.0', 'Apache2' ),
+			array( 'Apache-2.0', 'Apache2' ),
+			array( 'Apache 2', 'Apache2' ),
+
 			array( 'MPL-1.0', 'MPL10' ),
 			array( 'MPL-2.0', 'MPL20' ),
 		);
@@ -97,7 +104,7 @@ class License_Utils_Tests extends WP_UnitTestCase {
 			array( 'GPL3', true ),
 			array( 'MPL20', true ),
 			array( 'MIT', true ),
-			array( 'Apache', true ),
+			array( 'Apache2', true ),
 			array( 'FreeBSD', true ),
 			array( 'New BSD', true ),
 			array( 'BSD-3-Clause', true ),


### PR DESCRIPTION
License:

License "Apache 2.0" is allowed as it is GPL compatible. This PR improves the license check and accepts few variations of the license text which as found in the directory.

Eg:
- Apache License, Version 2.0
- Apache License 2.0
- Apache 2.0
- Apache-2.0
- Apache 2
- Apache License 2

When normalizing, 2 is also kept as if somehow we encounter Apache 1.0, it should be blocked. So, I have kept normalized license like "Apache2".
