### PR TITLE
Make sure headers are not empty in the requires header check

### DIFF
--- a/includes/Checker/Checks/Plugin_Repo/Plugin_Readme_Check.php
+++ b/includes/Checker/Checks/Plugin_Repo/Plugin_Readme_Check.php
@@ -834,7 +834,7 @@ class Plugin_Readme_Check extends Abstract_File_Check {
 			$readme_value = $parser->{$requires[ $require ]['key']};
 			$plugin_value = $plugin_data[ $requires[ $require ]['header_field'] ];
 
-			if ( $readme_value !== $plugin_value ) {
+			if ( ! empty( $readme_value ) && ! empty( $plugin_value ) && $readme_value !== $plugin_value ) {
 				$this->add_result_error_for_file(
 					$result,
 					sprintf(


### PR DESCRIPTION

When there is `Requires at least` is plugin header but not in readme, this check should not have been triggered. It generated message like this.

```
Mismatched Requires at least:  != 4.9. "Requires at least" needs to be exactly the same with that in your main plugin file's header.
```

So I believe it makes sense to check for not empty for header value before actually checking the comparison.