### PR TITLE
Update severity for incorrect textdomains

### DIFF
--- a/includes/Checker/Checks/General/I18n_Usage_Check.php
+++ b/includes/Checker/Checks/General/I18n_Usage_Check.php
@@ -96,6 +96,8 @@ class I18n_Usage_Check extends Abstract_PHP_CodeSniffer_Check {
 	 * @param int          $column   The column on which the message occurred. Default is 0 (unknown column).
 	 * @param string       $docs     URL for further information about the message.
 	 * @param int          $severity Severity level. Default is 5.
+	 *
+	 * @SuppressWarnings(PHPMD.NPathComplexity)
 	 */
 	protected function add_result_message_for_file( Check_Result $result, $error, $message, $code, $file, $line = 0, $column = 0, string $docs = '', $severity = 5 ) {
 		// Downgrade errors about usage of the 'default' text domain from WordPress Core to warnings.
@@ -143,6 +145,42 @@ class I18n_Usage_Check extends Abstract_PHP_CodeSniffer_Check {
 				break;
 		}
 
+		if ( 'WordPress.WP.I18n.TextDomainMismatch' === $code ) {
+			$restricted_textdomains = $this->get_restricted_textdomains();
+
+			$pattern = '/but\sgot\s&#039;(' . implode( '|', array_map( 'preg_quote', $restricted_textdomains ) ) . ')&#039;\.$/';
+
+			if ( preg_match( $pattern, $message ) ) {
+				$severity = 7;
+			}
+		}
+
 		parent::add_result_message_for_file( $result, $error, $message, $code, $file, $line, $column, $docs, $severity );
+	}
+
+	/**
+	 * Returns restricted textdomains.
+	 *
+	 * @since 1.5.0
+	 *
+	 * @return array Restricted textdomains.
+	 */
+	private function get_restricted_textdomains() {
+		$restricted_textdomains = array(
+			'textdomain',
+			'text-domain',
+			'text_domain',
+		);
+
+		/**
+		 * Filter the list of restricted textdomains.
+		 *
+		 * @since 1.5.0
+		 *
+		 * @param array $restricted_textdomains Array of restricted textdomains.
+		 */
+		$restricted_textdomains = (array) apply_filters( 'wp_plugin_check_restricted_textdomains', $restricted_textdomains );
+
+		return $restricted_textdomains;
 	}
 }

--- a/includes/Checker/Checks/General/I18n_Usage_Check.php
+++ b/includes/Checker/Checks/General/I18n_Usage_Check.php
@@ -170,6 +170,7 @@ class I18n_Usage_Check extends Abstract_PHP_CodeSniffer_Check {
 			'textdomain',
 			'text-domain',
 			'text_domain',
+			'your-text-domain',
 		);
 
 		/**

--- a/tests/phpunit/testdata/plugins/test-plugin-i18n-usage-errors/load.php
+++ b/tests/phpunit/testdata/plugins/test-plugin-i18n-usage-errors/load.php
@@ -31,3 +31,6 @@ $text_domain = 'test-plugin-check-errors';
 
 // This will cause a WordPress.WP.I18n.NonSingularStringLiteralDomain error as a variable is used for the text-domain.
 esc_html__( 'Hello World!', $text_domain );
+
+esc_html__( 'Hello World!', 'textdomain' ); // Restricted textdomain. Severity should be 7.
+esc_html__( 'Hello World!', 'woocommerce' ); // Severity should be default 5.

--- a/tests/phpunit/tests/Checker/Checks/I18n_Usage_Check_Tests.php
+++ b/tests/phpunit/tests/Checker/Checks/I18n_Usage_Check_Tests.php
@@ -31,6 +31,14 @@ class I18n_Usage_Check_Tests extends WP_UnitTestCase {
 
 		// Check for WordPress.WP.I18n.NonSingularStringLiteralDomain error on Line no 33 and column no at 29.
 		$this->assertCount( 1, wp_list_filter( $errors['load.php'][33][29], array( 'code' => 'WordPress.WP.I18n.NonSingularStringLiteralDomain' ) ) );
+
+		// Restricted textdomain with severity 7.
+		$this->assertCount( 1, wp_list_filter( $errors['load.php'][35][29], array( 'code' => 'WordPress.WP.I18n.TextDomainMismatch' ) ) );
+		$this->assertSame( 7, $errors['load.php'][35][29][0]['severity'] );
+
+		// Mismatched textdomain but not restricted and with severity 5.
+		$this->assertCount( 1, wp_list_filter( $errors['load.php'][36][29], array( 'code' => 'WordPress.WP.I18n.TextDomainMismatch' ) ) );
+		$this->assertSame( 5, $errors['load.php'][36][29][0]['severity'] );
 	}
 
 	public function test_run_without_errors() {


### PR DESCRIPTION
Fixes https://github.com/WordPress/plugin-check/issues/891

* Now for array of restricted textdomains, severity will be 7
* Unit test has been added for the changes