### PR TITLE
Remove warning for dynamic callback

### DIFF
--- a/phpcs-sniffs/PluginCheck/Sniffs/CodeAnalysis/SettingSanitizationSniff.php
+++ b/phpcs-sniffs/PluginCheck/Sniffs/CodeAnalysis/SettingSanitizationSniff.php
@@ -80,23 +80,6 @@ final class SettingSanitizationSniff extends AbstractFunctionParameterSniff {
 				$error_code . 'Invalid',
 				array( $matched_content )
 			);
-
-			return;
-		}
-
-		$next_token = $this->phpcsFile->findNext( Tokens::$emptyTokens, $third_param['start'], ( $third_param['end'] + 1 ), true );
-
-		if ( false !== $next_token ) {
-			$next_type = $this->tokens[ $next_token ]['type'];
-
-			if ( in_array( $next_type, array( 'T_ARRAY', 'T_OPEN_SHORT_ARRAY', 'T_VARIABLE', 'T_CALLABLE' ), true ) ) {
-				$this->phpcsFile->addWarning(
-					'Dynamic argument passed in third parameter of %s(). Please ensure proper sanitization.',
-					$stackPtr,
-					$error_code . 'Dynamic',
-					array( $matched_content )
-				);
-			}
 		}
 	}
 }

--- a/phpcs-sniffs/PluginCheck/Tests/CodeAnalysis/SettingSanitizationUnitTest.inc
+++ b/phpcs-sniffs/PluginCheck/Tests/CodeAnalysis/SettingSanitizationUnitTest.inc
@@ -4,9 +4,6 @@ register_setting( 'my_options_group', 'my_option_name', 10 ); // Error.
 register_setting( 'my_options_group', 'my_option_name', false ); // Error.
 register_setting( 'my_options_group', 'my_option_name', 'absint' ); // Good.
 register_setting('my_options_group','my_option_name', 'sanitize_text_field' ); // Good.
-register_setting('my_options_group', 'my_option_name', [ 'sanitize_callback' => 'sanitize_text_field']); // Warning.
-$args = array( 'sanitize_callback' => 'absint' );
-register_setting( 'my_options_group', 'my_option_name', $args ); // Warning.
 
 class TestClass {
 	public function register_setting() {
@@ -15,13 +12,3 @@ class TestClass {
 
 $obj = new TestClass();
 $obj->register_setting(); // Good.
-
-register_setting('my_options_group', 'my_option_name',array(&$this,'validate')); // Warning.
-
-register_setting(
-		'my_options_group',
-		$setting_key,
-		array(
-				'sanitize_callback' => $setting['sanitize_callback']
-		)
-); // Warning.

--- a/phpcs-sniffs/PluginCheck/Tests/CodeAnalysis/SettingSanitizationUnitTest.php
+++ b/phpcs-sniffs/PluginCheck/Tests/CodeAnalysis/SettingSanitizationUnitTest.php
@@ -35,12 +35,7 @@ final class SettingSanitizationUnitTest extends AbstractSniffUnitTest {
 	 * @return array <int line number> => <int number of warnings>
 	 */
 	public function getWarningList() {
-		return array(
-			7  => 1,
-			9  => 1,
-			19 => 1,
-			21 => 1,
-		);
+		return array();
 	}
 
 	/**

--- a/tests/phpunit/testdata/plugins/test-plugin-setting-sanitization-check-with-errors/load.php
+++ b/tests/phpunit/testdata/plugins/test-plugin-setting-sanitization-check-with-errors/load.php
@@ -19,5 +19,3 @@
 register_setting( 'my_options_group', 'option_1' ); // Error.
 register_setting( 'my_options_group', 'option_2', false ); // Error.
 register_setting( 'my_options_group', 'option_3', 'absint' ); // Good.
-$args = array( 'sanitize_callback' => 'absint' );
-register_setting( 'my_options_group', 'option_4', $args ); // Warning.

--- a/tests/phpunit/tests/Checker/Checks/Setting_Sanitization_Check_Test.php
+++ b/tests/phpunit/tests/Checker/Checks/Setting_Sanitization_Check_Test.php
@@ -18,16 +18,12 @@ class Setting_Sanitization_Check_Test extends WP_UnitTestCase {
 
 		$check->run( $check_result );
 
-		$errors   = $check_result->get_errors();
-		$warnings = $check_result->get_warnings();
+		$errors = $check_result->get_errors();
 
 		$this->assertNotEmpty( $errors );
-		$this->assertNotEmpty( $warnings );
 		$this->assertArrayHasKey( 'load.php', $errors );
-		$this->assertArrayHasKey( 'load.php', $warnings );
 
 		$this->assertSame( 'PluginCheck.CodeAnalysis.SettingSanitization.register_settingMissing', $errors['load.php'][19][1][0]['code'] );
 		$this->assertSame( 'PluginCheck.CodeAnalysis.SettingSanitization.register_settingInvalid', $errors['load.php'][20][1][0]['code'] );
-		$this->assertSame( 'PluginCheck.CodeAnalysis.SettingSanitization.register_settingDynamic', $warnings['load.php'][23][1][0]['code'] );
 	}
 }


### PR DESCRIPTION
Fixes: https://github.com/WordPress/plugin-check/issues/871

- "Dynamic" warning is removed as it is creating more noise rather than informational