### PR TITLE
Improve url validation to check duplicate protocol

### DIFF
--- a/includes/Checker/Checks/Plugin_Repo/Plugin_Header_Fields_Check.php
+++ b/includes/Checker/Checks/Plugin_Repo/Plugin_Header_Fields_Check.php
@@ -488,13 +488,13 @@ class Plugin_Header_Fields_Check implements Static_Check {
 		if ( filter_var( $url, FILTER_VALIDATE_URL ) !== $url || ! str_starts_with( $url, 'http' ) ) {
 			return false;
 		}
-	
+
 		// Detect duplicated protocol (e.g., "https://http://example.com/").
 		$parsed_url = wp_parse_url( $url );
 		if ( isset( $parsed_url['scheme'] ) && str_contains( substr( $url, strlen( $parsed_url['scheme'] ) + 3 ), '://' ) ) {
 			return false;
 		}
-	
+
 		return true;
 	}
 

--- a/includes/Checker/Checks/Plugin_Repo/Plugin_Header_Fields_Check.php
+++ b/includes/Checker/Checks/Plugin_Repo/Plugin_Header_Fields_Check.php
@@ -485,7 +485,17 @@ class Plugin_Header_Fields_Check implements Static_Check {
 	 * @return bool true if the URL is valid, otherwise false.
 	 */
 	private function is_valid_url( $url ) {
-		return filter_var( $url, FILTER_VALIDATE_URL ) === $url && str_starts_with( $url, 'http' );
+		if ( filter_var( $url, FILTER_VALIDATE_URL ) !== $url || ! str_starts_with( $url, 'http' ) ) {
+			return false;
+		}
+	
+		// Detect duplicated protocol (e.g., "https://http://example.com/").
+		$parsed_url = wp_parse_url( $url );
+		if ( isset( $parsed_url['scheme'] ) && str_contains( substr( $url, strlen( $parsed_url['scheme'] ) + 3 ), '://' ) ) {
+			return false;
+		}
+	
+		return true;
 	}
 
 	/**

--- a/tests/phpunit/testdata/plugins/test-plugin-header-fields-duplicated-protocol-with-errors/load.php
+++ b/tests/phpunit/testdata/plugins/test-plugin-header-fields-duplicated-protocol-with-errors/load.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * Plugin Name: Test Header fields with errors
+ * Plugin URI: https://example.com/sample-link
+ * Description: Here is a short description of the plugin.
+ * Requires at least: Recent version
+ * Requires PHP: Latest version
+ * Author: WordPress Performance Team
+ * Author URI: https://http://example.com/
+ * Text Domain: test-mismathed-textdomain-here
+ * Domain Path: /nonexistent-folder
+ * Network: random-value
+ * GitHub Plugin URI: johndoe/package
+ * Requires Plugins: Example Plugin, OtherPlugin
+ *
+ * @package test-plugin-header-fields-with-errors
+ */

--- a/tests/phpunit/tests/Checker/Checks/Plugin_Header_Fields_Check_Tests.php
+++ b/tests/phpunit/tests/Checker/Checks/Plugin_Header_Fields_Check_Tests.php
@@ -167,4 +167,20 @@ class Plugin_Header_Fields_Check_Tests extends WP_UnitTestCase {
 
 		$this->assertEmpty( $errors );
 	}
+
+	public function test_run_with_errors_duplicated_protocol_is_valid_url() {
+		$check         = new Plugin_Header_Fields_Check();
+		$check_context = new Check_Context( UNIT_TESTS_PLUGIN_DIR . 'test-plugin-header-fields-duplicated-protocol-with-errors/load.php' );
+		$check_result  = new Check_Result( $check_context );
+
+		$check->run( $check_result );
+
+		$errors = $check_result->get_errors();
+
+		$filtered_items = wp_list_filter( $errors['load.php'][0][0], array( 'code' => 'plugin_header_invalid_author_uri' ) );
+
+		$this->assertCount( 1, $filtered_items );
+		$this->assertStringContainsString( 'Author URI', $filtered_items[1]['message'] );
+		$this->assertStringContainsString( 'is not valid', $filtered_items[1]['message'] );
+	}
 }


### PR DESCRIPTION
Improved `is_valid_url()` to detect duplicated protocol in URLs.

This PR enhances the is_valid_url() function to identify and reject URLs that contain duplicated protocols (e.g., https://http://example.com/).

Fixes #890 