### PR TITLE
Update i18n error codes severity

### DIFF
--- a/includes/Checker/Checks/General/I18n_Usage_Check.php
+++ b/includes/Checker/Checks/General/I18n_Usage_Check.php
@@ -97,6 +97,7 @@ class I18n_Usage_Check extends Abstract_PHP_CodeSniffer_Check {
 	 * @param string       $docs     URL for further information about the message.
 	 * @param int          $severity Severity level. Default is 5.
 	 *
+	 * @SuppressWarnings(PHPMD.CyclomaticComplexity)
 	 * @SuppressWarnings(PHPMD.NPathComplexity)
 	 */
 	protected function add_result_message_for_file( Check_Result $result, $error, $message, $code, $file, $line = 0, $column = 0, string $docs = '', $severity = 5 ) {
@@ -132,17 +133,19 @@ class I18n_Usage_Check extends Abstract_PHP_CodeSniffer_Check {
 
 		// Update severity.
 		switch ( $code ) {
-			case 'WordPress.WP.I18n.InterpolatedVariableDomain':
 			case 'WordPress.WP.I18n.MissingArgText':
 			case 'WordPress.WP.I18n.NoEmptyStrings':
-			case 'WordPress.WP.I18n.NonSingularStringLiteralContext':
-			case 'WordPress.WP.I18n.NonSingularStringLiteralDomain':
 			case 'WordPress.WP.I18n.TooManyFunctionArgs':
 				$severity = 7;
 				break;
 
 			default:
 				break;
+		}
+
+		// Update severity for error code variations. Eg: WordPress.WP.I18n.NonSingularStringLiteralXXX.
+		if ( str_starts_with( $code, 'WordPress.WP.I18n.InterpolatedVariable' ) || str_starts_with( $code, 'WordPress.WP.I18n.NonSingularStringLiteral' ) ) {
+			$severity = 7;
 		}
 
 		if ( 'WordPress.WP.I18n.TextDomainMismatch' === $code ) {

--- a/tests/phpunit/testdata/plugins/test-plugin-i18n-usage-errors/load.php
+++ b/tests/phpunit/testdata/plugins/test-plugin-i18n-usage-errors/load.php
@@ -34,3 +34,15 @@ esc_html__( 'Hello World!', $text_domain );
 
 esc_html__( 'Hello World!', 'textdomain' ); // Restricted textdomain. Severity should be 7.
 esc_html__( 'Hello World!', 'woocommerce' ); // Severity should be default 5.
+
+// Non singular string literals.
+echo esc_html__( $test, 'test-plugin-i18n-usage-errors' );
+echo _n( $single, $plural, $number, 'test-plugin-i18n-usage-errors' );
+echo _n_noop( $single, $plural, 'test-plugin-i18n-usage-errors' );
+echo _x( $text, $context, 'test-plugin-i18n-usage-errors' );
+
+// Interpolated variables.
+echo esc_html__( "${text}", 'test-plugin-i18n-usage-errors' );
+echo _n( "${single}", "${plural}", $number, 'test-plugin-i18n-usage-errors' );
+echo _n_noop( "${single}", "${plural}", 'test-plugin-i18n-usage-errors' );
+echo _x( "${text}", "${context}", 'test-plugin-i18n-usage-errors' );

--- a/tests/phpunit/tests/Checker/Checks/I18n_Usage_Check_Tests.php
+++ b/tests/phpunit/tests/Checker/Checks/I18n_Usage_Check_Tests.php
@@ -39,6 +39,36 @@ class I18n_Usage_Check_Tests extends WP_UnitTestCase {
 		// Mismatched textdomain but not restricted and with severity 5.
 		$this->assertCount( 1, wp_list_filter( $errors['load.php'][36][29], array( 'code' => 'WordPress.WP.I18n.TextDomainMismatch' ) ) );
 		$this->assertSame( 5, $errors['load.php'][36][29][0]['severity'] );
+
+		// Non singular string literal errors.
+		$this->assertCount( 1, wp_list_filter( $errors['load.php'][40][10], array( 'code' => 'WordPress.WP.I18n.NonSingularStringLiteralSingle' ) ) );
+		$this->assertSame( 7, $errors['load.php'][40][10][0]['severity'] );
+		$this->assertCount( 1, wp_list_filter( $errors['load.php'][40][19], array( 'code' => 'WordPress.WP.I18n.NonSingularStringLiteralPlural' ) ) );
+		$this->assertSame( 7, $errors['load.php'][40][19][0]['severity'] );
+		$this->assertCount( 1, wp_list_filter( $errors['load.php'][41][15], array( 'code' => 'WordPress.WP.I18n.NonSingularStringLiteralSingular' ) ) );
+		$this->assertSame( 7, $errors['load.php'][41][15][0]['severity'] );
+		$this->assertCount( 1, wp_list_filter( $errors['load.php'][41][24], array( 'code' => 'WordPress.WP.I18n.NonSingularStringLiteralPlural' ) ) );
+		$this->assertSame( 7, $errors['load.php'][41][24][0]['severity'] );
+		$this->assertCount( 1, wp_list_filter( $errors['load.php'][42][10], array( 'code' => 'WordPress.WP.I18n.NonSingularStringLiteralText' ) ) );
+		$this->assertSame( 7, $errors['load.php'][42][10][0]['severity'] );
+		$this->assertCount( 1, wp_list_filter( $errors['load.php'][42][17], array( 'code' => 'WordPress.WP.I18n.NonSingularStringLiteralContext' ) ) );
+		$this->assertSame( 7, $errors['load.php'][42][17][0]['severity'] );
+
+		// Interpolated variable errors.
+		$this->assertCount( 1, wp_list_filter( $errors['load.php'][45][18], array( 'code' => 'WordPress.WP.I18n.InterpolatedVariableText' ) ) );
+		$this->assertSame( 7, $errors['load.php'][45][18][0]['severity'] );
+		$this->assertCount( 1, wp_list_filter( $errors['load.php'][46][10], array( 'code' => 'WordPress.WP.I18n.InterpolatedVariableSingle' ) ) );
+		$this->assertSame( 7, $errors['load.php'][46][10][0]['severity'] );
+		$this->assertCount( 1, wp_list_filter( $errors['load.php'][46][23], array( 'code' => 'WordPress.WP.I18n.InterpolatedVariablePlural' ) ) );
+		$this->assertSame( 7, $errors['load.php'][46][23][0]['severity'] );
+		$this->assertCount( 1, wp_list_filter( $errors['load.php'][47][15], array( 'code' => 'WordPress.WP.I18n.InterpolatedVariableSingular' ) ) );
+		$this->assertSame( 7, $errors['load.php'][47][15][0]['severity'] );
+		$this->assertCount( 1, wp_list_filter( $errors['load.php'][47][28], array( 'code' => 'WordPress.WP.I18n.InterpolatedVariablePlural' ) ) );
+		$this->assertSame( 7, $errors['load.php'][47][28][0]['severity'] );
+		$this->assertCount( 1, wp_list_filter( $errors['load.php'][48][10], array( 'code' => 'WordPress.WP.I18n.InterpolatedVariableText' ) ) );
+		$this->assertSame( 7, $errors['load.php'][48][10][0]['severity'] );
+		$this->assertCount( 1, wp_list_filter( $errors['load.php'][48][21], array( 'code' => 'WordPress.WP.I18n.InterpolatedVariableContext' ) ) );
+		$this->assertSame( 7, $errors['load.php'][48][21][0]['severity'] );
 	}
 
 	public function test_run_without_errors() {


### PR DESCRIPTION
PRT team has decided to increase severity for several i18n error codes which are frequently hit in plugin submissions.

This PR:

- Raises the severity for i18n error codes for `WordPress.WP.I18n.InterpolatedVariableXXX` and `WordPress.WP.I18n.NonSingularStringLiteralXXX`. Earlier only selective errors codes were assigned severity 7.
- Unit tests have been added.