### PR TITLE
Upgrade severity for missing readme headers

### DIFF
--- a/includes/Checker/Checks/Plugin_Repo/Plugin_Readme_Check.php
+++ b/includes/Checker/Checks/Plugin_Repo/Plugin_Readme_Check.php
@@ -288,7 +288,8 @@ class Plugin_Readme_Check extends Abstract_File_Check {
 							$readme_file,
 							0,
 							0,
-							'https://developer.wordpress.org/plugins/wordpress-org/how-your-readme-txt-works/#readme-header-information'
+							'https://developer.wordpress.org/plugins/wordpress-org/how-your-readme-txt-works/#readme-header-information',
+							7
 						);
 					}
 				}

--- a/tests/phpunit/testdata/plugins/test-plugin-plugin-readme-errors-upgrade-notice/readme.txt
+++ b/tests/phpunit/testdata/plugins/test-plugin-plugin-readme-errors-upgrade-notice/readme.txt
@@ -1,6 +1,5 @@
 === Test Plugin with readme ===
 
-Contributors:      plugin-check
 Requires at least: 6.0
 Requires PHP:      5.6
 Stable tag:        1.0.0

--- a/tests/phpunit/tests/Checker/Checks/Plugin_Readme_Check_Tests.php
+++ b/tests/phpunit/tests/Checker/Checks/Plugin_Readme_Check_Tests.php
@@ -272,6 +272,8 @@ class Plugin_Readme_Check_Tests extends WP_UnitTestCase {
 	}
 
 	public function test_run_with_errors_missing_readme_headers() {
+		add_filter( 'wp_plugin_check_ignored_readme_warnings', '__return_empty_array' );
+
 		$readme_check  = new Plugin_Readme_Check();
 		$check_context = new Check_Context( UNIT_TESTS_PLUGIN_DIR . 'test-plugin-plugin-readme-errors-upgrade-notice/load.php' );
 		$check_result  = new Check_Result( $check_context );
@@ -280,13 +282,20 @@ class Plugin_Readme_Check_Tests extends WP_UnitTestCase {
 
 		$errors = $check_result->get_errors();
 
+		remove_filter( 'wp_plugin_check_ignored_readme_warnings', '__return_empty_array' );
+
 		$this->assertNotEmpty( $errors );
 		$this->assertArrayHasKey( 'readme.txt', $errors );
 
 		// Check for missing tested upto header.
-		$tested_error = wp_list_filter( $errors['readme.txt'][0][0], array( 'code' => 'missing_readme_header_tested' ) );
-		$this->assertCount( 1, $tested_error );
-		$this->assertSame( 7, $tested_error[0]['severity'] );
+		$tested_upto_error = array_values( wp_list_filter( $errors['readme.txt'][0][0], array( 'code' => 'missing_readme_header_tested' ) ) );
+		$this->assertCount( 1, $tested_upto_error );
+		$this->assertSame( 7, $tested_upto_error[0]['severity'] );
+
+		// Check for missing contributors header.
+		$contributors_error = array_values( wp_list_filter( $errors['readme.txt'][0][0], array( 'code' => 'missing_readme_header_contributors' ) ) );
+		$this->assertCount( 1, $contributors_error );
+		$this->assertSame( 7, $contributors_error[0]['severity'] );
 	}
 
 	public function test_run_md_with_errors() {

--- a/tests/phpunit/tests/Checker/Checks/Plugin_Readme_Check_Tests.php
+++ b/tests/phpunit/tests/Checker/Checks/Plugin_Readme_Check_Tests.php
@@ -284,7 +284,9 @@ class Plugin_Readme_Check_Tests extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'readme.txt', $errors );
 
 		// Check for missing tested upto header.
-		$this->assertCount( 1, wp_list_filter( $errors['readme.txt'][0][0], array( 'code' => 'missing_readme_header_tested' ) ) );
+		$tested_error = wp_list_filter( $errors['readme.txt'][0][0], array( 'code' => 'missing_readme_header_tested' ) );
+		$this->assertCount( 1, $tested_error );
+		$this->assertSame( 7, $tested_error[0]['severity'] );
 	}
 
 	public function test_run_md_with_errors() {


### PR DESCRIPTION
Fixes https://github.com/WordPress/plugin-check/issues/930