### PR TITLE
Disallow unsupported characters for `Text Domain` plugin header

### DIFF
--- a/includes/Checker/Checks/Plugin_Repo/Plugin_Header_Fields_Check.php
+++ b/includes/Checker/Checks/Plugin_Repo/Plugin_Header_Fields_Check.php
@@ -411,25 +411,43 @@ class Plugin_Header_Fields_Check implements Static_Check {
 
 		if ( ! $result->plugin()->is_single_file_plugin() ) {
 			if ( ! empty( $plugin_header['TextDomain'] ) ) {
-				$plugin_slug = $result->plugin()->slug();
-
-				if ( $plugin_slug !== $plugin_header['TextDomain'] ) {
-					$this->add_result_warning_for_file(
+				if ( ! preg_match( '/^[a-z0-9]+(?:-[a-z0-9]+)*$/', $plugin_header['TextDomain'] ) ) {
+					$this->add_result_error_for_file(
 						$result,
 						sprintf(
-							/* translators: 1: plugin header field, 2: plugin header text domain, 3: plugin slug */
-							__( 'The "%1$s" header in the plugin file does not match the slug. Found "%2$s", expected "%3$s".', 'plugin-check' ),
+							/* translators: 1: plugin header field, 2: text domain */
+							__( 'The "%1$s" header in the plugin file should only contain lowercase letters, numbers, and hyphens. Found "%2$s".', 'plugin-check' ),
 							esc_html( $labels['TextDomain'] ),
-							esc_html( $plugin_header['TextDomain'] ),
-							esc_html( $plugin_slug )
+							esc_html( $plugin_header['TextDomain'] )
 						),
-						'textdomain_mismatch',
+						'textdomain_invalid_format',
 						$plugin_main_file,
 						0,
 						0,
-						'https://developer.wordpress.org/plugins/internationalization/how-to-internationalize-your-plugin/',
-						6
+						'https://developer.wordpress.org/plugins/internationalization/how-to-internationalize-your-plugin/#text-domains',
+						7
 					);
+				} else {
+					$plugin_slug = $result->plugin()->slug();
+
+					if ( $plugin_slug !== $plugin_header['TextDomain'] ) {
+						$this->add_result_warning_for_file(
+							$result,
+							sprintf(
+								/* translators: 1: plugin header field, 2: plugin header text domain, 3: plugin slug */
+								__( 'The "%1$s" header in the plugin file does not match the slug. Found "%2$s", expected "%3$s".', 'plugin-check' ),
+								esc_html( $labels['TextDomain'] ),
+								esc_html( $plugin_header['TextDomain'] ),
+								esc_html( $plugin_slug )
+							),
+							'textdomain_mismatch',
+							$plugin_main_file,
+							0,
+							0,
+							'https://developer.wordpress.org/plugins/internationalization/how-to-internationalize-your-plugin/',
+							6
+						);
+					}
 				}
 			}
 

--- a/tests/phpunit/testdata/plugins/test-plugin-late-escaping-errors/load.php
+++ b/tests/phpunit/testdata/plugins/test-plugin-late-escaping-errors/load.php
@@ -9,7 +9,7 @@
  * Author URI: https://make.wordpress.org/performance/
  * License: GPLv2 or later
  * License URI: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
- * Text Domain: test-plugin-check-errors
+ * Text Domain: Test-plugin-check_errors
  * Domain Path: /languages
  *
  * @package test-plugin-check-errors

--- a/tests/phpunit/tests/Checker/Checks/Plugin_Header_Fields_Check_Tests.php
+++ b/tests/phpunit/tests/Checker/Checks/Plugin_Header_Fields_Check_Tests.php
@@ -109,6 +109,7 @@ class Plugin_Header_Fields_Check_Tests extends WP_UnitTestCase {
 
 		$this->assertCount( 1, wp_list_filter( $errors['load.php'][0][0], array( 'code' => 'plugin_header_missing_plugin_description' ) ) );
 		$this->assertCount( 1, wp_list_filter( $errors['load.php'][0][0], array( 'code' => 'plugin_header_invalid_plugin_version' ) ) );
+		$this->assertCount( 1, wp_list_filter( $errors['load.php'][0][0], array( 'code' => 'textdomain_invalid_format' ) ) );
 	}
 
 	public function test_run_with_errors_requires_at_least_latest_plus_two_version() {


### PR DESCRIPTION
Fixes https://github.com/WordPress/plugin-check/issues/953