### PR TITLE
Add CC0 to GPL-compatible license check

### DIFF
--- a/includes/Traits/License_Utils.php
+++ b/includes/Traits/License_Utils.php
@@ -83,7 +83,7 @@ trait License_Utils {
 	 * @return bool true if the license is GPL compatible, otherwise false.
 	 */
 	protected function is_license_gpl_compatible( $license ) {
-		$match = preg_match( '/GPL|GNU|MIT|FreeBSD|New BSD|BSD-3-Clause|BSD 3 Clause|OpenLDAP|Expat|Apache2|MPL20|ISC/im', $license );
+		$match = preg_match( '/GPL|GNU|MIT|FreeBSD|New BSD|BSD-3-Clause|BSD 3 Clause|OpenLDAP|Expat|Apache2|MPL20|ISC|CC0/im', $license );
 
 		return ( false === $match || 0 === $match ) ? false : true;
 	}

--- a/tests/phpunit/tests/Traits/License_Utils_Tests.php
+++ b/tests/phpunit/tests/Traits/License_Utils_Tests.php
@@ -112,6 +112,9 @@ class License_Utils_Tests extends WP_UnitTestCase {
 			array( 'OpenLDAP', true ),
 			array( 'Expat', true ),
 			array( 'ISC', true ),
+			array( 'CC0', true ),
+			array( 'CC0-1.0', true ),
+			array( 'CC0 1.0 Universal', true ),
 
 			array( 'EPL', false ),
 			array( 'EUPL', false ),


### PR DESCRIPTION
Foremost, thank you for the awesome plugin—it’s a pleasure to use, and I appreciate all your hard work.

I ran into an issue when creating a plugin under the `CC0 1.0 Universal` license: the license check fails. In my plugin header:

```php
/**
 * License:         CC0-1.0
 * License URI:     https://creativecommons.org/publicdomain/zero/1.0/
 */
```

And in `readme.txt`:
```text
License: CC0-1.0
```

However, this triggers the following error:
```txt
0 	0 	ERROR 	plugin_header_invalid_license 	Invalid License: CC0-1.0. 
Please update your Plugin Header with a valid GPLv2 (or later) compatible license.
```

Per the [GNU license list](https://www.gnu.org/licenses/license-list.html#CC0), CC0 1.0 Universal is indeed GPL-compatible. I’ve updated the [is_license_gpl_compatible()](https://github.com/WordPress/plugin-check/blob/trunk/includes/Traits/License_Utils.php#L85) method to include CC0 in the regex (see code below).

This small, first commit ensures that CC0-licensed works are correctly recognized as GPL-compatible.