### PR TITLE
Remove CallTimePassByReference check

### DIFF
--- a/phpcs-rulesets/plugin-review.xml
+++ b/phpcs-rulesets/plugin-review.xml
@@ -163,11 +163,6 @@
 		<severity>7</severity>
 	</rule>
 
-	<!-- Call-time pass-by-reference has been deprecated since PHP 5.3 and should not be used. -->
-	<rule ref="Generic.Functions.CallTimePassByReference">
-		<severity>7</severity>
-	</rule>
-
 	<!-- Check for missing required function parameters. -->
 	<rule ref="PluginCheck.CodeAnalysis.RequiredFunctionParameters">
 		<severity>7</severity>

--- a/tests/phpunit/testdata/plugins/test-plugin-review-phpcs-errors/load.php
+++ b/tests/phpunit/testdata/plugins/test-plugin-review-phpcs-errors/load.php
@@ -35,8 +35,6 @@ parse_str( 'first=value&arr[]=foo+bar&arr[]=baz' );
 
 $encoded_value = json_encode( array( 'key' => 'value' ) );
 
-custom_function(&$myvar);
-
 file_get_contents( $url );
 file_put_contents();
 

--- a/tests/phpunit/tests/Checker/Checks/Plugin_Review_PHPCS_Check_Tests.php
+++ b/tests/phpunit/tests/Checker/Checks/Plugin_Review_PHPCS_Check_Tests.php
@@ -45,23 +45,20 @@ class Plugin_Review_PHPCS_Check_Tests extends WP_UnitTestCase {
 		// Check for PluginCheck.CodeAnalysis.RequiredFunctionParameters.parse_str_resultMissing error on Line no 34 and column no at 1.
 		$this->assertSame( 'PluginCheck.CodeAnalysis.RequiredFunctionParameters.parse_str_resultMissing', $errors['load.php'][34][1][0]['code'] );
 
-		// Check for Generic.Functions.CallTimePassByReference.NotAllowed error on Line no 38 and column no 16.
-		$this->assertSame( 'Generic.Functions.CallTimePassByReference.NotAllowed', $errors['load.php'][38][16][0]['code'] );
-
 		// Check for Generic.Files.ByteOrderMark.Found error on Line no 1 and column no 1.
 		$this->assertSame( 'Generic.Files.ByteOrderMark.Found', $errors['file-with-bom.php'][1][1][0]['code'] );
 
 		// There should not be WordPress.WP.AlternativeFunctions.json_encode_json_encode error on Line no 36 and column no at 18.
 		$this->assertCount( 0, wp_list_filter( $errors['load.php'][36][18], array( 'code' => 'WordPress.WP.AlternativeFunctions.json_encode_json_encode' ) ) );
 
-		// There should not be WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents error on Line no 40 and column no 1.
-		$this->assertCount( 0, wp_list_filter( $errors['load.php'][40][1], array( 'code' => 'WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents' ) ) );
+		// There should not be WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents error on Line no 38 and column no 1.
+		$this->assertCount( 0, wp_list_filter( $errors['load.php'][38][1], array( 'code' => 'WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents' ) ) );
 
-		// There should not be WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents error on Line no 41 and column no 1.
-		$this->assertCount( 0, wp_list_filter( $errors['load.php'][41][1], array( 'code' => 'WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents' ) ) );
+		// There should not be WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents error on Line no 39 and column no 1.
+		$this->assertCount( 0, wp_list_filter( $errors['load.php'][39][1], array( 'code' => 'WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents' ) ) );
 
-		// Check for PluginCheck.CodeAnalysis.DiscouragedFunctions.load_plugin_textdomainFound error on Line no 43 and column no at 1.
-		$this->assertSame( 'PluginCheck.CodeAnalysis.DiscouragedFunctions.load_plugin_textdomainFound', $errors['load.php'][43][1][0]['code'] );
+		// Check for PluginCheck.CodeAnalysis.DiscouragedFunctions.load_plugin_textdomainFound error on Line no 41 and column no at 1.
+		$this->assertSame( 'PluginCheck.CodeAnalysis.DiscouragedFunctions.load_plugin_textdomainFound', $errors['load.php'][41][1][0]['code'] );
 
 		// Check for WordPress.Security.ValidatedSanitizedInput warnings on Line no 15 and column no at 27.
 		$this->assertCount( 1, wp_list_filter( $warnings['load.php'][15][27], array( 'code' => 'WordPress.Security.ValidatedSanitizedInput.InputNotValidated' ) ) );


### PR DESCRIPTION
In this PR the deprecated rule "CallTimePassByReference" has been removed.