### PR TITLE
Improve check for donate link in readme

### DIFF
--- a/includes/Checker/Checks/Plugin_Repo/Plugin_Readme_Check.php
+++ b/includes/Checker/Checks/Plugin_Repo/Plugin_Readme_Check.php
@@ -681,10 +681,10 @@ class Plugin_Readme_Check extends Abstract_File_Check {
 		}
 
 		if ( ! $this->is_valid_url( $donate_link ) ) {
-			$this->add_result_warning_for_file(
+			$this->add_result_error_for_file(
 				$result,
 				sprintf(
-					/* translators: %s: plugin header field */
+					/* translators: %s: readme header field */
 					__( 'The "%s" header in the readme file must be a valid URL.', 'plugin-check' ),
 					'Donate link'
 				),
@@ -693,7 +693,30 @@ class Plugin_Readme_Check extends Abstract_File_Check {
 				0,
 				0,
 				'https://developer.wordpress.org/plugins/wordpress-org/how-your-readme-txt-works/#readme-header-information',
-				6
+				7
+			);
+
+			return;
+		}
+
+		// Check for discouraged domain.
+		$matched_domain = $this->find_discouraged_domain( $donate_link );
+
+		if ( $matched_domain ) {
+			$this->add_result_error_for_file(
+				$result,
+				sprintf(
+					/* translators: 1: readme header field, 2: domain */
+					__( 'The "%1$s" header in the readme file is not valid. Discouraged domain "%2$s" found. This is the URL for users to support plugin author financially.', 'plugin-check' ),
+					'Donate link',
+					esc_html( $matched_domain )
+				),
+				'readme_invalid_donate_link_domain',
+				$readme_file,
+				0,
+				0,
+				'https://developer.wordpress.org/plugins/wordpress-org/how-your-readme-txt-works/#readme-header-information',
+				7
 			);
 		}
 	}

--- a/includes/Checker/Checks/Plugin_Repo/Plugin_Readme_Check.php
+++ b/includes/Checker/Checks/Plugin_Repo/Plugin_Readme_Check.php
@@ -312,12 +312,10 @@ class Plugin_Readme_Check extends Abstract_File_Check {
 	private function check_default_text( Check_Result $result, string $readme_file, $parser ) {
 		$short_description = $parser->short_description;
 		$tags              = $parser->tags;
-		$donate_link       = $parser->donate_link;
 
 		if (
 			in_array( 'tag1', $tags, true )
 			|| str_contains( $short_description, 'Here is a short description of the plugin.' )
-			|| str_contains( $donate_link, '//example.com/' )
 		) {
 			$this->add_result_error_for_file(
 				$result,

--- a/tests/phpunit/testdata/plugins/test-plugin-plugin-readme-errors-default-text/readme.txt
+++ b/tests/phpunit/testdata/plugins/test-plugin-plugin-readme-errors-default-text/readme.txt
@@ -8,7 +8,7 @@ Requires PHP:      5.6
 Stable tag:        1.0.0
 License:           GPLv2 or later
 License URI:       https://www.gnu.org/licenses/gpl-2.0.html
-Donate URL:        https://example.com
+Donate Link:       https://example.com
 Tags:              tag1, testing, security
 
 Here is a short description of the plugin.

--- a/tests/phpunit/tests/Checker/Checks/Plugin_Readme_Check_Tests.php
+++ b/tests/phpunit/tests/Checker/Checks/Plugin_Readme_Check_Tests.php
@@ -607,4 +607,19 @@ class Plugin_Readme_Check_Tests extends WP_UnitTestCase {
 		$this->assertCount( 1, wp_list_filter( $errors['readme.txt'][0][0], array( 'code' => 'readme_mismatched_header_requires' ) ) );
 		$this->assertCount( 1, wp_list_filter( $errors['readme.txt'][0][0], array( 'code' => 'readme_mismatched_header_requires_php' ) ) );
 	}
+
+	public function test_run_with_discouraged_donate_link() {
+		$check         = new Plugin_Readme_Check();
+		$check_context = new Check_Context( UNIT_TESTS_PLUGIN_DIR . 'test-plugin-plugin-readme-errors-default-text/load.php' );
+		$check_result  = new Check_Result( $check_context );
+
+		$check->run( $check_result );
+
+		$errors = $check_result->get_errors();
+
+		$this->assertNotEmpty( $errors );
+		$this->assertArrayHasKey( 'readme.txt', $errors );
+
+		$this->assertCount( 1, wp_list_filter( $errors['readme.txt'][0][0], array( 'code' => 'readme_invalid_donate_link_domain' ) ) );
+	}
 }

--- a/tests/phpunit/tests/Checker/Checks/Plugin_Readme_Check_Tests.php
+++ b/tests/phpunit/tests/Checker/Checks/Plugin_Readme_Check_Tests.php
@@ -316,13 +316,13 @@ class Plugin_Readme_Check_Tests extends WP_UnitTestCase {
 		$this->assertCount( 1, wp_list_filter( $errors['readme.md'][0][0], array( 'code' => 'default_readme_text' ) ) );
 		$this->assertCount( 1, wp_list_filter( $errors['readme.md'][0][0], array( 'code' => 'invalid_license' ) ) );
 		$this->assertCount( 1, wp_list_filter( $errors['readme.md'][0][0], array( 'code' => 'license_mismatch' ) ) );
+		$this->assertCount( 1, wp_list_filter( $errors['readme.md'][0][0], array( 'code' => 'readme_invalid_donate_link' ) ) );
 
 		$this->assertNotEmpty( $warnings );
 		$this->assertArrayHasKey( 'readme.md', $warnings );
 
 		$this->assertCount( 1, wp_list_filter( $warnings['readme.md'][0][0], array( 'code' => 'mismatched_plugin_name' ) ) );
 		$this->assertCount( 1, wp_list_filter( $warnings['readme.md'][0][0], array( 'code' => 'readme_invalid_contributors' ) ) );
-		$this->assertCount( 1, wp_list_filter( $warnings['readme.md'][0][0], array( 'code' => 'readme_invalid_donate_link' ) ) );
 	}
 
 	public function test_single_file_plugin_without_error_for_trademarks() {


### PR DESCRIPTION
Brief:

- Update check for discouraged domain other than existing "example.com".
- Instead of warning now it is treated as error.
- We were checking for "example.com" domain in the donate link in the readme file. But the test for that was not asserting as expected. Tests are fixed for this also.
- Updated tests for the changes.
