### PR TITLE
Support strict output format

### DIFF
--- a/includes/CLI/Plugin_Check_Command.php
+++ b/includes/CLI/Plugin_Check_Command.php
@@ -302,7 +302,7 @@ final class Plugin_Check_Command {
 			}
 		}
 
-		if ( ! empty( $assoc_args['strict-format'] ) ) {
+		if ( true === $options['strict-format'] ) {
 			$formatter->display_items( $all_results );
 			return;
 		}

--- a/includes/CLI/Plugin_Check_Command.php
+++ b/includes/CLI/Plugin_Check_Command.php
@@ -83,6 +83,9 @@ final class Plugin_Check_Command {
 	 *   - json
 	 * ---
 	 *
+	 * [--strict-format]
+	 * : Output a single flat list of all results.
+	 *
 	 * [--categories]
 	 * : Limit displayed results to include only specific categories Checks.
 	 *
@@ -159,6 +162,7 @@ final class Plugin_Check_Command {
 				'include-low-severity-warnings' => false,
 				'slug'                          => '',
 				'ignore-codes'                  => '',
+				'strict-format'                 => false,
 			)
 		);
 
@@ -255,8 +259,9 @@ final class Plugin_Check_Command {
 		$include_low_severity_errors   = ! empty( $options['include-low-severity-errors'] ) ? true : false;
 		$include_low_severity_warnings = ! empty( $options['include-low-severity-warnings'] ) ? true : false;
 
-		// Print the formatted results.
-		// Go over all files with errors first and print them, combined with any warnings in the same file.
+		$all_results = array();
+
+		// Collect all errors.
 		foreach ( $errors as $file_name => $file_errors ) {
 			$file_warnings = array();
 			if ( isset( $warnings[ $file_name ] ) ) {
@@ -273,12 +278,13 @@ final class Plugin_Check_Command {
 				$file_results = $this->get_filtered_results_by_severity( $file_results, intval( $error_severity ), intval( $warning_severity ), $include_low_severity_errors, $include_low_severity_warnings );
 			}
 
-			if ( ! empty( $file_results ) ) {
-				$this->display_results( $formatter, $file_name, $file_results );
+			foreach ( $file_results as $item ) {
+				$item['file']  = $file_name;
+				$all_results[] = $item;
 			}
 		}
 
-		// If there are any files left with only warnings, print those next.
+		// Collect remaining warnings.
 		foreach ( $warnings as $file_name => $file_warnings ) {
 			$file_results = $this->flatten_file_results( array(), $file_warnings );
 
@@ -290,9 +296,28 @@ final class Plugin_Check_Command {
 				$file_results = $this->get_filtered_results_by_severity( $file_results, intval( $error_severity ), intval( $warning_severity ), $include_low_severity_errors, $include_low_severity_warnings );
 			}
 
-			if ( ! empty( $file_results ) ) {
-				$this->display_results( $formatter, $file_name, $file_results );
+			foreach ( $file_results as $item ) {
+				$item['file']  = $file_name;
+				$all_results[] = $item;
 			}
+		}
+
+		if ( ! empty( $assoc_args['strict-format'] ) ) {
+			$formatter->display_items( $all_results );
+			return;
+		}
+
+		// Group results by file.
+		$results_by_file = array();
+
+		foreach ( $all_results as $item ) {
+			$file = $item['file'];
+			unset( $item['file'] );
+			$results_by_file[ $file ][] = $item;
+		}
+
+		foreach ( $results_by_file as $file_name => $file_results ) {
+			$this->display_results( $formatter, $file_name, $file_results );
 		}
 	}
 

--- a/includes/CLI/Plugin_Check_Command.php
+++ b/includes/CLI/Plugin_Check_Command.php
@@ -42,6 +42,9 @@ final class Plugin_Check_Command {
 		'table',
 		'csv',
 		'json',
+		'strict-table',
+		'strict-csv',
+		'strict-json',
 	);
 
 	/**
@@ -74,17 +77,17 @@ final class Plugin_Check_Command {
 	 * : Ignore error codes provided as an argument in comma-separated values.
 	 *
 	 * [--format=<format>]
-	 * : Format to display the results. Options are table, csv, and json. The default will be a table.
+	 * : Format to display the results. Options are table, csv, json, strict-table, strict-csv, and strict-json. The default will be a table.
 	 * ---
 	 * default: table
 	 * options:
 	 *   - table
 	 *   - csv
 	 *   - json
+	 *   - strict-table
+	 *   - strict-csv
+	 *   - strict-json
 	 * ---
-	 *
-	 * [--strict-format]
-	 * : Output a single flat list of all results.
 	 *
 	 * [--categories]
 	 * : Limit displayed results to include only specific categories Checks.
@@ -162,7 +165,6 @@ final class Plugin_Check_Command {
 				'include-low-severity-warnings' => false,
 				'slug'                          => '',
 				'ignore-codes'                  => '',
-				'strict-format'                 => false,
 			)
 		);
 
@@ -302,7 +304,14 @@ final class Plugin_Check_Command {
 			}
 		}
 
-		if ( true === $options['strict-format'] ) {
+		// Handle strict-* formats.
+		if ( str_starts_with( $options['format'], 'strict-' ) ) {
+			$base_format = substr( $options['format'], 7 );
+
+			$formatter_args           = $assoc_args;
+			$formatter_args['format'] = $base_format;
+
+			$formatter = $this->get_formatter( $formatter_args, $default_fields );
 			$formatter->display_items( $all_results );
 			return;
 		}
@@ -311,9 +320,7 @@ final class Plugin_Check_Command {
 		$results_by_file = array();
 
 		foreach ( $all_results as $item ) {
-			$file = $item['file'];
-			unset( $item['file'] );
-			$results_by_file[ $file ][] = $item;
+			$results_by_file[ $item['file'] ][] = $item;
 		}
 
 		foreach ( $results_by_file as $file_name => $file_results ) {

--- a/tests/behat/features/plugin-check.feature
+++ b/tests/behat/features/plugin-check.feature
@@ -149,6 +149,19 @@ Feature: Test that the WP-CLI command works.
       WordPress.WP.AlternativeFunctions.rand_mt_rand
       """
 
+    When I run the WP-CLI command `plugin check foo-single.php --format=json --fields=line,column,type,code`
+    Then STDOUT should contain:
+      """
+      FILE:
+      """
+
+    When I run the WP-CLI command `plugin check foo-single.php --format=json --fields=line,column,type,code --strict-format`
+    Then STDOUT should be valid JSON
+    And STDOUT should not contain:
+      """
+      FILE:
+      """
+
   Scenario: Check plugin with special chars in plugin name
     Given a WP install with the Plugin Check plugin
     And a wp-content/plugins/johns-post-counter/johns-post-counter.php file:

--- a/tests/behat/features/plugin-check.feature
+++ b/tests/behat/features/plugin-check.feature
@@ -155,7 +155,7 @@ Feature: Test that the WP-CLI command works.
       FILE:
       """
 
-    When I run the WP-CLI command `plugin check foo-single.php --format=json --fields=line,column,type,code --strict-format`
+    When I run the WP-CLI command `plugin check foo-single.php --format=strict-json --fields=line,column,type,code`
     Then STDOUT should be valid JSON
     And STDOUT should not contain:
       """

--- a/tests/behat/includes/FeatureContext.php
+++ b/tests/behat/includes/FeatureContext.php
@@ -124,6 +124,19 @@ final class FeatureContext extends WP_CLI_FeatureContext {
 	}
 
 	/**
+	 * @Then /^STDOUT should be valid JSON$/
+	 */
+	public function stdout_should_be_valid_json() {
+		$output = $this->result->stdout;
+
+		json_decode( $output );
+
+		if ( JSON_ERROR_NONE !== json_last_error() ) {
+			throw new Exception( 'STDOUT is not valid JSON: ' . json_last_error_msg() );
+		}
+	}
+
+	/**
 	 * Ensure that a requested directory exists and create it recursively as needed.
 	 *
 	 * @param string $directory Directory to ensure the existence of.


### PR DESCRIPTION
Fixes https://github.com/WordPress/plugin-check/issues/748

- Introduce more options for `--format` 
    * strict-table
    * strict-csv
    * strict-json
- With above new formats, **FILE:** part in the output will be omitted.
- Added feature test for the changes