### PR TITLE
Remove unused class imports from two sniffs

### DIFF
--- a/phpcs-sniffs/PluginCheck/Sniffs/CodeAnalysis/DiscouragedFunctionsSniff.php
+++ b/phpcs-sniffs/PluginCheck/Sniffs/CodeAnalysis/DiscouragedFunctionsSniff.php
@@ -11,7 +11,6 @@
 namespace PluginCheckCS\PluginCheck\Sniffs\CodeAnalysis;
 
 use PHPCSUtils\Utils\MessageHelper;
-use PHPCSUtils\Utils\PassedParameters;
 use WordPressCS\WordPress\AbstractFunctionRestrictionsSniff;
 use WordPressCS\WordPress\Helpers\MinimumWPVersionTrait;
 

--- a/phpcs-sniffs/PluginCheck/Sniffs/CodeAnalysis/SettingSanitizationSniff.php
+++ b/phpcs-sniffs/PluginCheck/Sniffs/CodeAnalysis/SettingSanitizationSniff.php
@@ -10,7 +10,6 @@
 
 namespace PluginCheckCS\PluginCheck\Sniffs\CodeAnalysis;
 
-use PHP_CodeSniffer\Util\Tokens;
 use PHPCSUtils\Utils\MessageHelper;
 use PHPCSUtils\Utils\PassedParameters;
 use PHPCSUtils\Utils\TextStrings;


### PR DESCRIPTION
This PR just removes two unused class imports from two sniffs.