### PR TITLE
EnqueuedResourceOffloading: make some small improvements to the sniff code

### DIFF
--- a/phpcs-sniffs/PluginCheck/Sniffs/CodeAnalysis/EnqueuedResourceOffloadingSniff.php
+++ b/phpcs-sniffs/PluginCheck/Sniffs/CodeAnalysis/EnqueuedResourceOffloadingSniff.php
@@ -51,59 +51,6 @@ final class EnqueuedResourceOffloadingSniff extends AbstractFunctionParameterSni
 	);
 
 	/**
-	 * False + the empty tokens array.
-	 *
-	 * This array is enriched with the $emptyTokens array in the register() method.
-	 *
-	 * @var array<int|string, int|string>
-	 */
-	private $false_tokens = array(
-		\T_FALSE => \T_FALSE,
-	);
-
-	/**
-	 * Token codes which are "safe" to accept to determine whether a version would evaluate to `false`.
-	 *
-	 * This array is enriched with the several of the PHPCS token arrays in the register() method.
-	 *
-	 * @var array<int|string, int|string>
-	 */
-	private $safe_tokens = array(
-		\T_NULL                     => \T_NULL,
-		\T_FALSE                    => \T_FALSE,
-		\T_TRUE                     => \T_TRUE,
-		\T_LNUMBER                  => \T_LNUMBER,
-		\T_DNUMBER                  => \T_DNUMBER,
-		\T_CONSTANT_ENCAPSED_STRING => \T_CONSTANT_ENCAPSED_STRING,
-		\T_START_NOWDOC             => \T_START_NOWDOC,
-		\T_NOWDOC                   => \T_NOWDOC,
-		\T_END_NOWDOC               => \T_END_NOWDOC,
-		\T_OPEN_PARENTHESIS         => \T_OPEN_PARENTHESIS,
-		\T_CLOSE_PARENTHESIS        => \T_CLOSE_PARENTHESIS,
-		\T_STRING_CONCAT            => \T_STRING_CONCAT,
-	);
-
-	/**
-	 * Returns an array of tokens this test wants to listen for.
-	 *
-	 * Overloads and calls the parent method to allow for adding additional tokens to the $safe_tokens property.
-	 *
-	 * @return array
-	 */
-	public function register() {
-		$this->false_tokens += Tokens::$emptyTokens;
-
-		$this->safe_tokens += Tokens::$emptyTokens;
-		$this->safe_tokens += Tokens::$assignmentTokens;
-		$this->safe_tokens += Tokens::$comparisonTokens;
-		$this->safe_tokens += Tokens::$operators;
-		$this->safe_tokens += Tokens::$booleanOperators;
-		$this->safe_tokens += Tokens::$castTokens;
-
-		return parent::register();
-	}
-
-	/**
 	 * Process the parameters of a matched function.
 	 *
 	 * @since 1.1.0

--- a/phpcs-sniffs/PluginCheck/Sniffs/CodeAnalysis/EnqueuedResourceOffloadingSniff.php
+++ b/phpcs-sniffs/PluginCheck/Sniffs/CodeAnalysis/EnqueuedResourceOffloadingSniff.php
@@ -37,7 +37,7 @@ final class EnqueuedResourceOffloadingSniff extends AbstractFunctionParameterSni
 	protected $group_name = 'Enqueued';
 
 	/**
-	 * List of enqueued functions that need to be checked for use of the in_footer and version arguments.
+	 * List of functions to check.
 	 *
 	 * @since 1.1.0
 	 *

--- a/phpcs-sniffs/PluginCheck/Sniffs/CodeAnalysis/EnqueuedResourceOffloadingSniff.php
+++ b/phpcs-sniffs/PluginCheck/Sniffs/CodeAnalysis/EnqueuedResourceOffloadingSniff.php
@@ -115,8 +115,7 @@ final class EnqueuedResourceOffloadingSniff extends AbstractFunctionParameterSni
 
 		$src_string = $src_param['clean'];
 
-		$matches = array();
-		if ( preg_match( $pattern, $src_string, $matches, PREG_OFFSET_CAPTURE ) > 0 ) {
+		if ( preg_match( $pattern, $src_string ) > 0 ) {
 			$this->phpcsFile->addError(
 				'Found call to %s() with external resource. Offloading %ss to your servers or any remote service is disallowed.',
 				$error_ptr,


### PR DESCRIPTION
Today I spent some time checking the code for the `EnqueuedResourceOffloading` sniff. I noticed some opportunities for some small improvements, which I'm combining in this PR. Below is a list of the changes that I'm suggesting. 

As I don't have much context about this repository, it is hard for me to know if such PRs are useful or not. Please let me know if they are not useful. If they are, I plan to take a look at the other sniffs and potentially create similar PRs if I find something.

Before doing that, I also plan to create another PR adding more tests to this sniff.

Also, I'm familiar with how sniffs work, but I'm not familiar with how they are used in this repository. So there is a chance that one of the changes that I'm suggesting here might not make sense for this repository, despite making sense for PHPCS sniffs in general.

### EnqueuedResourceOffloading: remove unused properties

This commit removes the `EnqueuedResourceOffloadingSniff::$false_tokens` and the `EnqueuedResourceOffloadingSniff::$safe_tokens` properties as they are not used by the sniff. I believe they were introduced accidentally due to a copy and paste error when creating the sniff.

Since those properties were removed, it is not necessary anymore to overload the `register()` method to change the value of those properties, so this method was removed as well.

This change should not affect the functionality of the sniff.

### EnqueuedResourceOffloading: fix docblock description

Probably due to a copy and paste error, this docblock description was describing something that does not apply to this sniff.

### EnqueuedResourceOffloading: simplify preg_match() call

As far as I can see, there is no reason to pass the `$matches` parameter and the `PREG_OFFSET_CAPTURE` flag to the `preg_match()` call as `$matches` is not used.