### PR TITLE
Use a trait to share the list of offloading services between sniffs

### DIFF
--- a/phpcs-sniffs/PluginCheck/Helpers/OffloadingServicesTrait.php
+++ b/phpcs-sniffs/PluginCheck/Helpers/OffloadingServicesTrait.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * OffloadingServicesTrait
+ *
+ * @package PluginCheck
+ */
+
+namespace PluginCheckCS\PluginCheck\Helpers;
+
+/**
+ * Trait for sharing the list of known offloading services between sniffs.
+ *
+ * @since 1.7.0
+ */
+trait OffloadingServicesTrait {
+
+	/**
+	 * List of known offloading services.
+	 *
+	 * @since 1.7.0
+	 *
+	 * @return array Array of regex patterns for known offloading services.
+	 */
+	protected function get_known_offloading_services() {
+		return array(
+			'code\.jquery\.com',
+			'(?<!api\.)cloudflare\.com',
+			'cdn\.jsdelivr\.net',
+			'cdn\.rawgit\.com',
+			'code\.getmdl\.io',
+			'bootstrapcdn',
+			'cl\.ly',
+			'cdn\.datatables\.net',
+			'aspnetcdn\.com',
+			'ajax\.googleapis\.com',
+			'webfonts\.zoho\.com',
+			'raw\.githubusercontent\.com',
+			'github\.com\/.*\/raw',
+			'unpkg\.com',
+			'imgur\.com',
+			'rawgit\.com',
+			'amazonaws\.com',
+			'cdn\.tiny\.cloud',
+			'tiny\.cloud',
+			'tailwindcss\.com',
+			'herokuapp\.com',
+			'(?<!fonts\.)gstatic\.com',
+			'kit\.fontawesome',
+			'use\.fontawesome',
+			'googleusercontent\.com',
+			'placeholder\.com',
+			's\.w\.org',
+		);
+	}
+
+	/**
+	 * Get the regex pattern for matching known offloading services.
+	 *
+	 * @since 1.7.0
+	 *
+	 * @return string Regex pattern for matching known offloading services.
+	 */
+	protected function get_offloading_services_pattern() {
+		return '/(' . implode( '|', $this->get_known_offloading_services() ) . ')/i';
+	}
+}

--- a/phpcs-sniffs/PluginCheck/Sniffs/CodeAnalysis/EnqueuedResourceOffloadingSniff.php
+++ b/phpcs-sniffs/PluginCheck/Sniffs/CodeAnalysis/EnqueuedResourceOffloadingSniff.php
@@ -12,6 +12,7 @@ namespace PluginCheckCS\PluginCheck\Sniffs\CodeAnalysis;
 
 use PHP_CodeSniffer\Util\Tokens;
 use PHPCSUtils\Utils\PassedParameters;
+use PluginCheckCS\PluginCheck\Helpers\OffloadingServicesTrait;
 use WordPressCS\WordPress\AbstractFunctionParameterSniff;
 
 /**
@@ -26,6 +27,7 @@ use WordPressCS\WordPress\AbstractFunctionParameterSniff;
  * @since 1.1.0
  */
 final class EnqueuedResourceOffloadingSniff extends AbstractFunctionParameterSniff {
+	use OffloadingServicesTrait;
 
 	/**
 	 * The group name for this group of functions.
@@ -70,39 +72,6 @@ final class EnqueuedResourceOffloadingSniff extends AbstractFunctionParameterSni
 			return;
 		}
 
-		// Known offloading services.
-		$look_known_offloading_services = array(
-			'code\.jquery\.com',
-			'(?<!api\.)cloudflare\.com',
-			'cdn\.jsdelivr\.net',
-			'cdn\.rawgit\.com',
-			'code\.getmdl\.io',
-			'bootstrapcdn',
-			'cl\.ly',
-			'cdn\.datatables\.net',
-			'aspnetcdn\.com',
-			'ajax\.googleapis\.com',
-			'webfonts\.zoho\.com',
-			'raw\.githubusercontent\.com',
-			'github\.com\/.*\/raw',
-			'unpkg\.com',
-			'imgur\.com',
-			'rawgit\.com',
-			'amazonaws\.com',
-			'cdn\.tiny\.cloud',
-			'tiny\.cloud',
-			'tailwindcss\.com',
-			'herokuapp\.com',
-			'(?<!fonts\.)gstatic\.com',
-			'kit\.fontawesome',
-			'use\.fontawesome',
-			'googleusercontent\.com',
-			'placeholder\.com',
-			's\.w\.org',
-		);
-
-		$pattern = '/(' . implode( '|', $look_known_offloading_services ) . ')/i';
-
 		$error_ptr = $this->phpcsFile->findNext( Tokens::$emptyTokens, $src_param['start'], ( $src_param['end'] + 1 ), true );
 		if ( false === $error_ptr ) {
 			$error_ptr = $src_param['start'];
@@ -114,6 +83,8 @@ final class EnqueuedResourceOffloadingSniff extends AbstractFunctionParameterSni
 		}
 
 		$src_string = $src_param['clean'];
+
+		$pattern = $this->get_offloading_services_pattern();
 
 		if ( preg_match( $pattern, $src_string ) > 0 ) {
 			$this->phpcsFile->addError(

--- a/phpcs-sniffs/PluginCheck/Sniffs/CodeAnalysis/OffloadingSniff.php
+++ b/phpcs-sniffs/PluginCheck/Sniffs/CodeAnalysis/OffloadingSniff.php
@@ -14,6 +14,7 @@ use PHP_CodeSniffer\Exceptions\RuntimeException;
 use PHP_CodeSniffer\Util\Tokens;
 use PHPCSUtils\Tokens\Collections;
 use PHPCSUtils\Utils\TextStrings;
+use PluginCheckCS\PluginCheck\Helpers\OffloadingServicesTrait;
 use WordPressCS\WordPress\Sniff;
 
 /**
@@ -24,6 +25,7 @@ use WordPressCS\WordPress\Sniff;
  * @since 1.1.0
  */
 final class OffloadingSniff extends Sniff {
+	use OffloadingServicesTrait;
 
 	/**
 	 * Returns an array of tokens this test wants to listen for.
@@ -76,38 +78,7 @@ final class OffloadingSniff extends Sniff {
 			return;
 		}
 
-		// Known offloading services.
-		$look_known_offloading_services = array(
-			'code\.jquery\.com',
-			'(?<!api\.)cloudflare\.com',
-			'cdn\.jsdelivr\.net',
-			'cdn\.rawgit\.com',
-			'code\.getmdl\.io',
-			'bootstrapcdn',
-			'cl\.ly',
-			'cdn\.datatables\.net',
-			'aspnetcdn\.com',
-			'ajax\.googleapis\.com',
-			'webfonts\.zoho\.com',
-			'raw\.githubusercontent\.com',
-			'github\.com\/.*\/raw',
-			'unpkg\.com',
-			'imgur\.com',
-			'rawgit\.com',
-			'amazonaws\.com',
-			'cdn\.tiny\.cloud',
-			'tiny\.cloud',
-			'tailwindcss\.com',
-			'herokuapp\.com',
-			'(?<!fonts\.)gstatic\.com',
-			'kit\.fontawesome',
-			'use\.fontawesome',
-			'googleusercontent\.com',
-			'placeholder\.com',
-			's\.w\.org',
-		);
-
-		$pattern = '/(' . implode( '|', $look_known_offloading_services ) . ')/i';
+		$pattern = $this->get_offloading_services_pattern();
 
 		$matches = array();
 		if ( preg_match_all( $pattern, $content, $matches, PREG_OFFSET_CAPTURE ) > 0 ) {


### PR DESCRIPTION
In this PR, I'm suggesting the creation of the `OffloadingServicesTrait` to hold the pattern to match a list of offloading services. I'm making this suggestion as a way to avoid duplicating this list in the `EnqueuedResourceOffloading` and `Offloading` sniffs.

I opted to place the trait in a new `Helpers` directory. I'm not sure if this is the best approach as I'm not very familiar with this repository.