### PR TITLE
Localhost: make some improvements to the sniff code

### DIFF
--- a/phpcs-sniffs/PluginCheck/Sniffs/CodeAnalysis/LocalhostSniff.php
+++ b/phpcs-sniffs/PluginCheck/Sniffs/CodeAnalysis/LocalhostSniff.php
@@ -51,7 +51,7 @@ final class LocalhostSniff extends Sniff {
 		if ( preg_match_all( '#https?:\/\/(localhost|127.0.0.1|(.*\.local(host)?))\/#i', $content, $matches, PREG_OFFSET_CAPTURE ) > 0 ) {
 			foreach ( $matches[0] as $match ) {
 				$this->phpcsFile->addError(
-					'Do not use Localhost/127.0.0.1 in your code. Found: %s',
+					'Do not use Localhost/127.0.0.1/*.local in your code. Found: %s',
 					$this->find_token_in_multiline_string( $stackPtr, $content, $match[1] ),
 					'Found',
 					array( $match[0] )

--- a/phpcs-sniffs/PluginCheck/Sniffs/CodeAnalysis/LocalhostSniff.php
+++ b/phpcs-sniffs/PluginCheck/Sniffs/CodeAnalysis/LocalhostSniff.php
@@ -48,39 +48,15 @@ final class LocalhostSniff extends Sniff {
 			return;
 		}
 
-		if ( preg_match_all( '#https?:\/\/(localhost|127.0.0.1|(.*\.local(host)?))\/#i', $content, $matches, PREG_OFFSET_CAPTURE ) > 0 ) {
+		if ( preg_match_all( '#https?:\/\/(localhost|127.0.0.1|(.*\.local(host)?))\/#i', $content, $matches ) > 0 ) {
 			foreach ( $matches[0] as $match ) {
 				$this->phpcsFile->addError(
 					'Do not use Localhost/127.0.0.1/*.local in your code. Found: %s',
-					$this->find_token_in_multiline_string( $stackPtr, $content, $match[1] ),
+					$stackPtr,
 					'Found',
-					array( $match[0] )
+					array( $match )
 				);
 			}
 		}
-	}
-
-	/**
-	 * Find the exact token on which the error should be reported for multi-line strings.
-	 *
-	 * @since 1.3.0
-	 *
-	 * @param int    $stackPtr     The position of the current token in the stack.
-	 * @param string $content      The complete, potentially multi-line, text string.
-	 * @param int    $match_offset The offset within the content at which the match was found.
-	 * @return int The stack pointer to the token containing the start of the match.
-	 */
-	private function find_token_in_multiline_string( $stackPtr, $content, $match_offset ) {
-		$newline_count = 0;
-		if ( $match_offset > 0 ) {
-			$newline_count = substr_count( $content, "\n", 0, $match_offset );
-		}
-
-		// Account for heredoc/nowdoc text starting at the token *after* the opener.
-		if ( isset( Tokens::$heredocTokens[ $this->tokens[ $stackPtr ]['code'] ] ) === true ) {
-			++$newline_count;
-		}
-
-		return ( $stackPtr + $newline_count );
 	}
 }

--- a/phpcs-sniffs/PluginCheck/Sniffs/CodeAnalysis/LocalhostSniff.php
+++ b/phpcs-sniffs/PluginCheck/Sniffs/CodeAnalysis/LocalhostSniff.php
@@ -42,7 +42,6 @@ final class LocalhostSniff extends Sniff {
 	 * @return int|void Integer stack pointer to skip forward or void to continue normal file processing.
 	 */
 	public function process_token( $stackPtr ) {
-		$end_ptr = $stackPtr;
 		$content = $this->tokens[ $stackPtr ]['content'];
 
 		if ( false === stripos( $content, '//' ) ) {
@@ -59,8 +58,6 @@ final class LocalhostSniff extends Sniff {
 				);
 			}
 		}
-
-		return ( $end_ptr + 1 );
 	}
 
 	/**

--- a/phpcs-sniffs/PluginCheck/Sniffs/CodeAnalysis/LocalhostSniff.php
+++ b/phpcs-sniffs/PluginCheck/Sniffs/CodeAnalysis/LocalhostSniff.php
@@ -49,7 +49,7 @@ final class LocalhostSniff extends Sniff {
 			return;
 		}
 
-		if ( preg_match_all( '#https?:\/\/(localhost|127.0.0.1|(.*\.local(host)?))\/#', $content, $matches, PREG_OFFSET_CAPTURE ) > 0 ) {
+		if ( preg_match_all( '#https?:\/\/(localhost|127.0.0.1|(.*\.local(host)?))\/#i', $content, $matches, PREG_OFFSET_CAPTURE ) > 0 ) {
 			foreach ( $matches[0] as $match ) {
 				$this->phpcsFile->addError(
 					'Do not use Localhost/127.0.0.1 in your code. Found: %s',

--- a/phpcs-sniffs/PluginCheck/Tests/CodeAnalysis/LocalhostUnitTest.inc
+++ b/phpcs-sniffs/PluginCheck/Tests/CodeAnalysis/LocalhostUnitTest.inc
@@ -3,7 +3,7 @@
 $var            = 'This file contains https://127.0.0.1/example url.'; // Error.
 $sample_url     = 'Sample URL is http://docker.local/example here.'; // Error.
 $custom_url     = 'Custom URL https://docker.localhost/example here.'; // Error.
-$custom_content = file_get_contents("http://127.0.0.1/api.php?url=".$url); // Error.
+$custom_content = file_get_contents("http://127.0.0.1/api.php?url=$url"); // Error.
 
 wp_register_script( 'custom-js', 'https://127.0.0.1/dist/custom.js' ); // Error.
 wp_enqueue_script( 'custom-js', 'https://127.0.0.1/dist/custom.js' ); // Error.

--- a/phpcs-sniffs/PluginCheck/Tests/CodeAnalysis/LocalhostUnitTest.inc
+++ b/phpcs-sniffs/PluginCheck/Tests/CodeAnalysis/LocalhostUnitTest.inc
@@ -28,3 +28,15 @@ $multiple_urls = 'Custom URL https://docker.localhost/example and https://localh
 <img src="<?php echo "http://localhost/image.png"; ?>" alt="" /><!-- Error. -->
 
 <p>URL in inline HTML is http://localhost/example2.php bad.</p><!-- Error. -->
+
+<?php
+
+$multiline_string = 'A multi-line string with URLs
+	https://docker.localhost/example and
+	https://localhost/example.php here.'; // Errors.
+
+$multiline_string = <<<'TEXT'
+	Another multi-line string with URLs
+	https://docker.localhost/example and
+	https://localhost/example.php here.
+TEXT; // Errors.

--- a/phpcs-sniffs/PluginCheck/Tests/CodeAnalysis/LocalhostUnitTest.inc
+++ b/phpcs-sniffs/PluginCheck/Tests/CodeAnalysis/LocalhostUnitTest.inc
@@ -8,7 +8,7 @@ $custom_content = file_get_contents("http://127.0.0.1/api.php?url=".$url); // Er
 wp_register_script( 'custom-js', 'https://127.0.0.1/dist/custom.js' ); // Error.
 wp_enqueue_script( 'custom-js', 'https://127.0.0.1/dist/custom.js' ); // Error.
 wp_register_style( 'custom-css', 'http://localhost/dist/custom.css' ); // Error.
-wp_enqueue_style( 'custom-css', 'http://localhost/dist/custom.css' ); // Error.
+wp_enqueue_style( 'custom-css', 'http://LOCALHOST/dist/custom.css' ); // Error.
 
 $important_links = array(
   'view-pro'      => array(

--- a/phpcs-sniffs/PluginCheck/Tests/CodeAnalysis/LocalhostUnitTest.php
+++ b/phpcs-sniffs/PluginCheck/Tests/CodeAnalysis/LocalhostUnitTest.php
@@ -35,6 +35,10 @@ final class LocalhostUnitTest extends AbstractSniffUnitTest {
 			25 => 2,
 			28 => 1,
 			30 => 1,
+			35 => 1,
+			36 => 1,
+			40 => 1,
+			41 => 1,
 		);
 	}
 


### PR DESCRIPTION
Similar to what I did for the `EnqueuedResourceOffloading` sniff (#1018), today I checked the `Localhost` sniff and noticed some opportunities for some improvements, which I'm combining in this PR. Below is a list of the changes that I'm suggesting.

### Localhost: the regex pattern should be case-insensitive

`http://LOCALHOST` is valid, and I imagine it should be forbidden as well.

### Localhost: remove unnecessary code

PHPCS will skip checking tokens if what is returned by `LocalhostSniff::process_token()` is greater than the current stack pointer:

https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/dccc53f0632a453ae8bddb4e065a85125488fca3/src/Files/File.php#L440

Returning `$stackPtr + 1` will not skip any tokens and thus is not necessary, at least as far as I can see. The returned value will be equal to the current stack pointer in the next pass of the foreach loop instead of greater than the current stack pointer.

### Localhost: update the error message to also include "*.local"

Besides forbidding "localhost"  and "127.0.0.1", the sniff also forbids "*.local". This commit changes the error message to mention "*.local" as it was not previously mentioned.

### Localhost: correctly identify error line for heredoc/nowdoc strings

The sniff was incorrectly identifying the error line for URLs inside heredoc/nowdoc. Considering the nowdoc string added as a test in this commit, the sniff was identifying the error lines as 41 and 42 instead of the correct 40 and 41.

This was happening because of an error in the logic of the `find_token_in_multiline_string()` method. As far as I could test, this method is actually not necessary, as just passing `$stackPtr` to `addError()` should be enough for it to correctly identify the error line.

PHPCS tokenizes multi-line strings using one token per line. So `$stackPtr` will correspond to the correct error line (the line that contains the localhost URL).

In a sniff like `Offloading`, it makes sense to use this method as it combines the content of multi-line strings using `TextStrings::getCompleteTextString()`, but that is not the case for `Localhost`.

Removing `find_token_in_multiline_string()` also meant that it was not necessary anymore to pass the `PREG_OFFSET_CAPTURE` flag to `preg_match_all()` as the information about the offset is not used anymore.

### Localhost: update a test to use a T_DOUBLE_QUOTED_STRING

The sniff listens for `T_DOUBLE_QUOTED_STRING`, and before, there were no tests with this type of token.