### PR TITLE
Update WPCS to 3.2.0 and work around a conflict between PHPCS 3.13+ and PHP-Parser 5+

### DIFF
--- a/.github/workflows/behat-test.yml
+++ b/.github/workflows/behat-test.yml
@@ -68,7 +68,7 @@ jobs:
         - '8.2'
         wordpress: [ 'latest' ]
         include:
-          - php: '8.3'
+          - php: '8.4'
             wordpress: 'latest'
             coverage: true
           - php: '7.4'

--- a/composer.lock
+++ b/composer.lock
@@ -208,28 +208,28 @@
         },
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",
-            "version": "v1.0.0",
+            "version": "v1.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/composer-installer.git",
-                "reference": "4be43904336affa5c2f70744a348312336afd0da"
+                "reference": "e9cf5e4bbf7eeaf9ef5db34938942602838fc2b1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/composer-installer/zipball/4be43904336affa5c2f70744a348312336afd0da",
-                "reference": "4be43904336affa5c2f70744a348312336afd0da",
+                "url": "https://api.github.com/repos/PHPCSStandards/composer-installer/zipball/e9cf5e4bbf7eeaf9ef5db34938942602838fc2b1",
+                "reference": "e9cf5e4bbf7eeaf9ef5db34938942602838fc2b1",
                 "shasum": ""
             },
             "require": {
-                "composer-plugin-api": "^1.0 || ^2.0",
+                "composer-plugin-api": "^2.2",
                 "php": ">=5.4",
                 "squizlabs/php_codesniffer": "^2.0 || ^3.1.0 || ^4.0"
             },
             "require-dev": {
-                "composer/composer": "*",
+                "composer/composer": "^2.2",
                 "ext-json": "*",
                 "ext-zip": "*",
-                "php-parallel-lint/php-parallel-lint": "^1.3.1",
+                "php-parallel-lint/php-parallel-lint": "^1.4.0",
                 "phpcompatibility/php-compatibility": "^9.0",
                 "yoast/phpunit-polyfills": "^1.0"
             },
@@ -249,9 +249,9 @@
             "authors": [
                 {
                     "name": "Franck Nijhof",
-                    "email": "franck.nijhof@dealerdirect.com",
-                    "homepage": "http://www.frenck.nl",
-                    "role": "Developer / IT Manager"
+                    "email": "opensource@frenck.dev",
+                    "homepage": "https://frenck.dev",
+                    "role": "Open source developer"
                 },
                 {
                     "name": "Contributors",
@@ -259,7 +259,6 @@
                 }
             ],
             "description": "PHP_CodeSniffer Standards Composer Installer Plugin",
-            "homepage": "http://www.dealerdirect.com",
             "keywords": [
                 "PHPCodeSniffer",
                 "PHP_CodeSniffer",
@@ -280,35 +279,54 @@
             ],
             "support": {
                 "issues": "https://github.com/PHPCSStandards/composer-installer/issues",
+                "security": "https://github.com/PHPCSStandards/composer-installer/security/policy",
                 "source": "https://github.com/PHPCSStandards/composer-installer"
             },
-            "time": "2023-01-05T11:28:13+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCSStandards",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/phpcsstandards",
+                    "type": "thanks_dev"
+                }
+            ],
+            "time": "2025-07-17T20:45:56+00:00"
         },
         {
             "name": "phpcsstandards/phpcsextra",
-            "version": "1.2.1",
+            "version": "1.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHPCSExtra.git",
-                "reference": "11d387c6642b6e4acaf0bd9bf5203b8cca1ec489"
+                "reference": "fa4b8d051e278072928e32d817456a7fdb57b6ca"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSExtra/zipball/11d387c6642b6e4acaf0bd9bf5203b8cca1ec489",
-                "reference": "11d387c6642b6e4acaf0bd9bf5203b8cca1ec489",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSExtra/zipball/fa4b8d051e278072928e32d817456a7fdb57b6ca",
+                "reference": "fa4b8d051e278072928e32d817456a7fdb57b6ca",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.4",
-                "phpcsstandards/phpcsutils": "^1.0.9",
-                "squizlabs/php_codesniffer": "^3.8.0"
+                "phpcsstandards/phpcsutils": "^1.1.0",
+                "squizlabs/php_codesniffer": "^3.13.0 || ^4.0"
             },
             "require-dev": {
                 "php-parallel-lint/php-console-highlighter": "^1.0",
-                "php-parallel-lint/php-parallel-lint": "^1.3.2",
+                "php-parallel-lint/php-parallel-lint": "^1.4.0",
                 "phpcsstandards/phpcsdevcs": "^1.1.6",
                 "phpcsstandards/phpcsdevtools": "^1.2.1",
-                "phpunit/phpunit": "^4.5 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.0"
+                "phpunit/phpunit": "^4.5 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.3.4"
             },
             "type": "phpcodesniffer-standard",
             "extra": {
@@ -358,35 +376,39 @@
                 {
                     "url": "https://opencollective.com/php_codesniffer",
                     "type": "open_collective"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/phpcsstandards",
+                    "type": "thanks_dev"
                 }
             ],
-            "time": "2023-12-08T16:49:07+00:00"
+            "time": "2025-06-14T07:40:39+00:00"
         },
         {
             "name": "phpcsstandards/phpcsutils",
-            "version": "1.0.12",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHPCSUtils.git",
-                "reference": "87b233b00daf83fb70f40c9a28692be017ea7c6c"
+                "reference": "65355670ac17c34cd235cf9d3ceae1b9252c4dad"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSUtils/zipball/87b233b00daf83fb70f40c9a28692be017ea7c6c",
-                "reference": "87b233b00daf83fb70f40c9a28692be017ea7c6c",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSUtils/zipball/65355670ac17c34cd235cf9d3ceae1b9252c4dad",
+                "reference": "65355670ac17c34cd235cf9d3ceae1b9252c4dad",
                 "shasum": ""
             },
             "require": {
                 "dealerdirect/phpcodesniffer-composer-installer": "^0.4.1 || ^0.5 || ^0.6.2 || ^0.7 || ^1.0",
                 "php": ">=5.4",
-                "squizlabs/php_codesniffer": "^3.10.0 || 4.0.x-dev@dev"
+                "squizlabs/php_codesniffer": "^3.13.0 || ^4.0"
             },
             "require-dev": {
                 "ext-filter": "*",
                 "php-parallel-lint/php-console-highlighter": "^1.0",
-                "php-parallel-lint/php-parallel-lint": "^1.3.2",
+                "php-parallel-lint/php-parallel-lint": "^1.4.0",
                 "phpcsstandards/phpcsdevcs": "^1.1.6",
-                "yoast/phpunit-polyfills": "^1.1.0 || ^2.0.0"
+                "yoast/phpunit-polyfills": "^1.1.0 || ^2.0.0 || ^3.0.0"
             },
             "type": "phpcodesniffer-standard",
             "extra": {
@@ -423,6 +445,7 @@
                 "phpcodesniffer-standard",
                 "phpcs",
                 "phpcs3",
+                "phpcs4",
                 "standards",
                 "static analysis",
                 "tokens",
@@ -446,9 +469,13 @@
                 {
                     "url": "https://opencollective.com/php_codesniffer",
                     "type": "open_collective"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/phpcsstandards",
+                    "type": "thanks_dev"
                 }
             ],
-            "time": "2024-05-20T13:34:27+00:00"
+            "time": "2025-06-12T04:32:33+00:00"
         },
         {
             "name": "plugin-check/phpcs-sniffs",
@@ -577,16 +604,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.12.2",
+            "version": "3.13.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
-                "reference": "6d4cf6032d4b718f168c90a96e36c7d0eaacb2aa"
+                "reference": "5b5e3821314f947dd040c70f7992a64eac89025c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/6d4cf6032d4b718f168c90a96e36c7d0eaacb2aa",
-                "reference": "6d4cf6032d4b718f168c90a96e36c7d0eaacb2aa",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/5b5e3821314f947dd040c70f7992a64eac89025c",
+                "reference": "5b5e3821314f947dd040c70f7992a64eac89025c",
                 "shasum": ""
             },
             "require": {
@@ -657,20 +684,20 @@
                     "type": "thanks_dev"
                 }
             ],
-            "time": "2025-04-13T04:10:18+00:00"
+            "time": "2025-06-17T22:17:01+00:00"
         },
         {
             "name": "wp-coding-standards/wpcs",
-            "version": "3.1.0",
+            "version": "3.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/WordPress/WordPress-Coding-Standards.git",
-                "reference": "9333efcbff231f10dfd9c56bb7b65818b4733ca7"
+                "reference": "d2421de7cec3274ae622c22c744de9a62c7925af"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/9333efcbff231f10dfd9c56bb7b65818b4733ca7",
-                "reference": "9333efcbff231f10dfd9c56bb7b65818b4733ca7",
+                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/d2421de7cec3274ae622c22c744de9a62c7925af",
+                "reference": "d2421de7cec3274ae622c22c744de9a62c7925af",
                 "shasum": ""
             },
             "require": {
@@ -679,13 +706,13 @@
                 "ext-tokenizer": "*",
                 "ext-xmlreader": "*",
                 "php": ">=5.4",
-                "phpcsstandards/phpcsextra": "^1.2.1",
-                "phpcsstandards/phpcsutils": "^1.0.10",
-                "squizlabs/php_codesniffer": "^3.9.0"
+                "phpcsstandards/phpcsextra": "^1.4.0",
+                "phpcsstandards/phpcsutils": "^1.1.0",
+                "squizlabs/php_codesniffer": "^3.13.0"
             },
             "require-dev": {
                 "php-parallel-lint/php-console-highlighter": "^1.0.0",
-                "php-parallel-lint/php-parallel-lint": "^1.3.2",
+                "php-parallel-lint/php-parallel-lint": "^1.4.0",
                 "phpcompatibility/php-compatibility": "^9.0",
                 "phpcsstandards/phpcsdevtools": "^1.2.0",
                 "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.0"
@@ -723,7 +750,7 @@
                     "type": "custom"
                 }
             ],
-            "time": "2024-03-25T16:39:00+00:00"
+            "time": "2025-07-24T20:08:31+00:00"
         }
     ],
     "packages-dev": [


### PR DESCRIPTION
This PR supersedes #1013. It uses the commit created by `dependabot` to update WPCS to 3.2.0 (and consequently PHPCS to 3.13.2), but before doing that, it works around a conflict introduced between PHPCS 3.13+ and PHP-Parser 5+.

### Run code coverage on PHP 8.4 instead of 8.3

This is necessary to work around a conflict between PHPCS 3.13+ and PHP-Parser 5.x that will start causing the Behat GitHub action to fail with the following error once PHPCS is updated to the latest version:

```
PHP Fatal error:  Uncaught Error: Token T_PUBLIC_SET has ID of type string, should be int. You may be using a library with broken token emulation in vendor/nikic/php-parser/lib/PhpParser/compatibility_tokens.php:38
Stack trace:
#0 vendor/nikic/php-parser/lib/PhpParser/compatibility_tokens.php(70): PhpParser\defineCompatibilityTokens()
#1 vendor/nikic/php-parser/lib/PhpParser/Lexer.php(5): require('...')
#2 vendor/squizlabs/php_codesniffer/autoload.php(173): include('...')
#3 vendor/squizlabs/php_codesniffer/autoload.php(138): PHP_CodeSniffer\Autoload::loadFile()
#4 vendor/nikic/php-parser/lib/PhpParser/ParserFactory.php(16): PHP_CodeSniffer\Autoload::load()
#5 vendor/nikic/php-parser/lib/PhpParser/ParserFactory.php(40): PhpParser\ParserFactory->createForVersion()
#6 vendor/phpunit/php-code-coverage/src/StaticAnalysis/ParsingFileAnalyser.php(144): PhpParser\ParserFactory->createForHostVersion()
#7 vendor/phpunit/php-code-coverage/src/StaticAnalysis/ParsingFileAnalyser.php(116): SebastianBergmann\CodeCoverage\StaticAnalysis\ParsingFileAnalyser->analyse()
#8 vendor/phpunit/php-code-coverage/src/CodeCoverage.php(513): SebastianBergmann\CodeCoverage\StaticAnalysis\ParsingFileAnalyser->executableLinesIn()
#9 vendor/phpunit/php-code-coverage/src/CodeCoverage.php(273): SebastianBergmann\CodeCoverage\CodeCoverage->applyExecutableLinesFilter()
#10 vendor/phpunit/php-code-coverage/src/CodeCoverage.php(241): SebastianBergmann\CodeCoverage\CodeCoverage->append()
#11 tests/behat/utils/maybe-generate-wp-cli-coverage.php(31): SebastianBergmann\CodeCoverage\CodeCoverage->stop()
#12 [internal function]: {closure}()
#13 {main}
  thrown in vendor/nikic/php-parser/lib/PhpParser/compatibility_tokens.php on line 38
```

This happens because PHP-Parser 5+ started enforcing polyfilled token constants to be integers (https://github.com/nikic/PHP-Parser/commit/ff095c3c65c144f32a811685a81195c4df53fb99), which is a breaking change for PHPCS, as it uses strings for those constants.

PHPCS 3.13.0 added support for PHP 8.4+ asymmetric visibility, which includes the token `T_PUBLIC_SET`. When running PHPCS with versions older than 8.4, PHPCS will polyfill this token with a string value, triggering the PHP-Parser error mentioned above.

This error only happens on the code coverage GitHub Action job because PHPUnit only uses PHP-Parser when collecting code coverage.

As a workaround, I believe it is fine to run the code coverage job with PHP 8.4 instead of 8.3. This way, PHPCS will not polyfill the `T_PUBLIC_SET` token (and other tokens related to asymmetric visibility) and won't trigger the PHP-Parser error. Running the code coverage on the latest PHP version makes sense anyway.

Related:
https://github.com/PHPCSStandards/PHP_CodeSniffer/issues/357
https://github.com/nikic/PHP-Parser/issues/981

### Bump wp-coding-standards/wpcs from 3.1.0 to 3.2.0

Bumps [wp-coding-standards/wpcs](https://github.com/WordPress/WordPress-Coding-Standards) from 3.1.0 to 3.2.0.
- [Release notes](https://github.com/WordPress/WordPress-Coding-Standards/releases)
- [Changelog](https://github.com/WordPress/WordPress-Coding-Standards/blob/develop/CHANGELOG.md)
- [Commits](https://github.com/WordPress/WordPress-Coding-Standards/compare/3.1.0...3.2.0)

---
updated-dependencies:
- dependency-name: wp-coding-standards/wpcs
  dependency-version: 3.2.0
  dependency-type: direct:production
  update-type: version-update:semver-minor
...

Signed-off-by: dependabot[bot] <support@github.com>