### PR TITLE
Add The Unlicense to GPL-compatible license check

### DIFF
--- a/includes/Traits/License_Utils.php
+++ b/includes/Traits/License_Utils.php
@@ -55,6 +55,7 @@ trait License_Utils {
 		$license = str_replace( ' version ', 'v', $license );
 		$license = preg_replace( '/GPL\s*[-|\.]*\s*[v]?([0-9])(\.[0])?/i', 'GPL$1', $license, 1 );
 		$license = preg_replace( '/Apache.*?([0-9])(\.[0])?/i', 'Apache$1', $license );
+		$license = preg_replace( '/(The\s+)?Unlicense/i', 'Unlicense', $license );
 		$license = str_replace( '.', '', $license );
 
 		return $license;

--- a/includes/Traits/License_Utils.php
+++ b/includes/Traits/License_Utils.php
@@ -83,7 +83,7 @@ trait License_Utils {
 	 * @return bool true if the license is GPL compatible, otherwise false.
 	 */
 	protected function is_license_gpl_compatible( $license ) {
-		$match = preg_match( '/GPL|GNU|MIT|FreeBSD|New BSD|BSD-3-Clause|BSD 3 Clause|OpenLDAP|Expat|Apache2|MPL20|ISC|CC0/im', $license );
+		$match = preg_match( '/GPL|GNU|MIT|FreeBSD|New BSD|BSD-3-Clause|BSD 3 Clause|OpenLDAP|Expat|Apache2|MPL20|ISC|CC0|Unlicense/im', $license );
 
 		return ( false === $match || 0 === $match ) ? false : true;
 	}

--- a/tests/phpunit/tests/Traits/License_Utils_Tests.php
+++ b/tests/phpunit/tests/Traits/License_Utils_Tests.php
@@ -115,6 +115,8 @@ class License_Utils_Tests extends WP_UnitTestCase {
 			array( 'CC0', true ),
 			array( 'CC0-1.0', true ),
 			array( 'CC0 1.0 Universal', true ),
+			array( 'The Unlicense', true ),
+			array( 'Unlicense', true ),
 
 			array( 'EPL', false ),
 			array( 'EUPL', false ),

--- a/tests/phpunit/tests/Traits/License_Utils_Tests.php
+++ b/tests/phpunit/tests/Traits/License_Utils_Tests.php
@@ -75,6 +75,9 @@ class License_Utils_Tests extends WP_UnitTestCase {
 
 			array( 'MPL-1.0', 'MPL10' ),
 			array( 'MPL-2.0', 'MPL20' ),
+
+			array( 'The Unlicense', 'Unlicense' ),
+			array( 'Unlicense', 'Unlicense' ),
 		);
 	}
 


### PR DESCRIPTION
The Unlicense is a GPL-Compatible free software
license, but is not recognized by the is_license_gpl_compatible check.
See https://www.gnu.org/licenses/license-list.html#Unlicense.

- Add The Unlicense to the regex in is_license_gpl_compatible() so the plugin will correctly recognize it as GPL-compatible.
- Add tests for recognition of The Unlicense