### PR TITLE
refactored: trademark validation methods to unify trademark checks for names and slugs

### DIFF
--- a/includes/Checker/Checks/Plugin_Repo/Trademarks_Check.php
+++ b/includes/Checker/Checks/Plugin_Repo/Trademarks_Check.php
@@ -346,7 +346,7 @@ class Trademarks_Check extends Abstract_File_Check {
 	 * @throws Exception Thrown if we found trademarked term in plugin name.
 	 */
 	private function validate_name_has_no_trademarks( $plugin_name ) {
-		$check = $this->has_trademarked_slug( sanitize_title_with_dashes( $plugin_name ) );
+		$check = $this->has_trademark( $plugin_name, true );
 		if ( ! $check ) {
 			return;
 		}
@@ -404,7 +404,7 @@ class Trademarks_Check extends Abstract_File_Check {
 	 * @throws Exception Thrown if we found trademarked term in plugin slug.
 	 */
 	private function validate_slug_has_no_trademarks( $plugin_slug ) {
-		$check = $this->has_trademarked_slug( $plugin_slug );
+		$check = $this->has_trademark( $plugin_slug, false );
 		if ( ! $check ) {
 			return;
 		}
@@ -453,53 +453,88 @@ class Trademarks_Check extends Abstract_File_Check {
 	}
 
 	/**
-	 * Whether the plugin uses a trademark in the slug.
+	 * Whether the text contains a trademark term.
 	 *
-	 * @since 1.0.0
+	 * @since 1.7.0
 	 *
-	 * @param string $slug The plugin slug.
-	 * @return string|false The trademark slug if found, false otherwise.
+	 * @param string $text             The text to check for trademarks.
+	 * @param bool   $use_word_boundary Whether to use word boundaries for checking (true for names, false for slugs).
+	 * @return string|false The trademark term if found, false otherwise.
 	 */
-	private function has_trademarked_slug( $slug ) {
-		// Bail early if the plugin slug not provided.
-		if ( empty( $slug ) ) {
+	private function has_trademark( $text, $use_word_boundary = false ) {
+		// Bail early if the text is not provided.
+		if ( empty( $text ) ) {
 			return false;
 		}
 
-		$has_trademarked_slug = false;
+		$has_trademark = false;
 
 		foreach ( self::TRADEMARK_SLUGS as $trademark ) {
 			if ( str_ends_with( $trademark, '-' ) ) {
-				// Trademarks ending in "-" indicate slug cannot begin with that term.
-				if ( 0 === strpos( $slug, $trademark ) ) {
-					$has_trademarked_slug = $trademark;
+				// Trademarks ending in "-" indicate text cannot begin with that term.
+				if ( 0 === strpos( $text, $trademark ) ) {
+					$has_trademark = $trademark;
 					break;
 				}
-			} elseif ( false !== strpos( $slug, $trademark ) ) {
-				// Otherwise, the term cannot appear anywhere in slug.
-
+			} elseif ( $use_word_boundary ) {
+				// For plugin names, use word boundaries to avoid false positives (like "wc" in "wcag")
+				$pattern = '/\b' . preg_quote( $trademark, '/' ) . '\b/i';
+				if ( preg_match( $pattern, $text ) ) {
+					// check for 'for-TRADEMARK' exceptions.
+					if ( $this->is_valid_for_use_exception( $text, $trademark ) ) {
+						// It is a valid for-use exception, try the next trademark.
+						continue;
+					}
+					$has_trademark = $trademark;
+					break;
+				}
+			} elseif ( false !== strpos( $text, $trademark ) ) {
+				// For slugs, the term cannot appear anywhere as a substring
 				// check for 'for-TRADEMARK' exceptions.
-				if ( $this->is_valid_for_use_exception( $slug, $trademark ) ) {
+				if ( $this->is_valid_for_use_exception( $text, $trademark ) ) {
 					// It is a valid for-use exception, try the next trademark.
 					continue;
 				}
-
-				$has_trademarked_slug = $trademark;
+				$has_trademark = $trademark;
 				break;
 			}
 		}
 
 		// Check portmanteaus.
-		if ( ! $has_trademarked_slug ) {
+		if ( ! $has_trademark ) {
 			foreach ( self::PORTMANTEAUS as $portmanteau ) {
-				if ( 0 === stripos( $slug, $portmanteau ) ) {
-					$has_trademarked_slug = $portmanteau;
+				if ( 0 === stripos( $text, $portmanteau ) ) {
+					$has_trademark = $portmanteau;
 					break;
 				}
 			}
 		}
 
-		return $has_trademarked_slug;
+		return $has_trademark;
+	}
+	
+	/**
+	 * Whether the plugin uses a trademark in the slug.
+	 *
+	 * @since 1.7.0
+	 *
+	 * @param string $slug The plugin slug.
+	 * @return string|false The trademark slug if found, false otherwise.
+	 */
+	private function has_trademarked_slug( $slug ) {
+		return $this->has_trademark( $slug, false );
+	}
+	
+	/**
+	 * Whether the plugin name contains a trademarked term.
+	 *
+	 * @since 1.7.0
+	 *
+	 * @param string $name The plugin name.
+	 * @return string|false The trademark term if found, false otherwise.
+	 */
+	private function has_trademarked_name( $name ) {
+		return $this->has_trademark( $name, true );
 	}
 
 	/**

--- a/includes/Checker/Checks/Plugin_Repo/Trademarks_Check.php
+++ b/includes/Checker/Checks/Plugin_Repo/Trademarks_Check.php
@@ -514,30 +514,6 @@ class Trademarks_Check extends Abstract_File_Check {
 	}
 
 	/**
-	 * Whether the plugin uses a trademark in the slug.
-	 *
-	 * @since 1.7.0
-	 *
-	 * @param string $slug The plugin slug.
-	 * @return string|false The trademark slug if found, false otherwise.
-	 */
-	private function has_trademarked_slug( $slug ) {
-		return $this->has_trademark( $slug, false );
-	}
-
-	/**
-	 * Whether the plugin name contains a trademarked term.
-	 *
-	 * @since 1.7.0
-	 *
-	 * @param string $name The plugin name.
-	 * @return string|false The trademark term if found, false otherwise.
-	 */
-	private function has_trademarked_name( $name ) {
-		return $this->has_trademark( $name, true );
-	}
-
-	/**
 	 * Validates whether the trademark is valid with a for-use exception.
 	 *
 	 * @since 1.0.0

--- a/includes/Checker/Checks/Plugin_Repo/Trademarks_Check.php
+++ b/includes/Checker/Checks/Plugin_Repo/Trademarks_Check.php
@@ -477,7 +477,7 @@ class Trademarks_Check extends Abstract_File_Check {
 					break;
 				}
 			} elseif ( $use_word_boundary ) {
-				// For plugin names, use word boundaries to avoid false positives (like "wc" in "wcag")
+				// For plugin names, use word boundaries to avoid false positives (like "wc" in "wcag").
 				$pattern = '/\b' . preg_quote( $trademark, '/' ) . '\b/i';
 				if ( preg_match( $pattern, $text ) ) {
 					// check for 'for-TRADEMARK' exceptions.
@@ -512,7 +512,7 @@ class Trademarks_Check extends Abstract_File_Check {
 
 		return $has_trademark;
 	}
-	
+
 	/**
 	 * Whether the plugin uses a trademark in the slug.
 	 *
@@ -524,7 +524,7 @@ class Trademarks_Check extends Abstract_File_Check {
 	private function has_trademarked_slug( $slug ) {
 		return $this->has_trademark( $slug, false );
 	}
-	
+
 	/**
 	 * Whether the plugin name contains a trademarked term.
 	 *

--- a/includes/Checker/Checks/Plugin_Repo/Trademarks_Check.php
+++ b/includes/Checker/Checks/Plugin_Repo/Trademarks_Check.php
@@ -346,7 +346,7 @@ class Trademarks_Check extends Abstract_File_Check {
 	 * @throws Exception Thrown if we found trademarked term in plugin name.
 	 */
 	private function validate_name_has_no_trademarks( $plugin_name ) {
-		$check = $this->has_trademark( $plugin_name, true );
+		$check = $this->has_trademarked_name( $plugin_name );
 		if ( ! $check ) {
 			return;
 		}
@@ -404,7 +404,7 @@ class Trademarks_Check extends Abstract_File_Check {
 	 * @throws Exception Thrown if we found trademarked term in plugin slug.
 	 */
 	private function validate_slug_has_no_trademarks( $plugin_slug ) {
-		$check = $this->has_trademark( $plugin_slug, false );
+		$check = $this->has_trademarked_slug( $plugin_slug );
 		if ( ! $check ) {
 			return;
 		}
@@ -452,46 +452,86 @@ class Trademarks_Check extends Abstract_File_Check {
 		throw new Exception( $message );
 	}
 
+
+	
 	/**
-	 * Whether the text contains a trademark term.
+	 * Whether the plugin name contains a trademarked term.
 	 *
 	 * @since 1.7.0
 	 *
-	 * @param string $text             The text to check for trademarks.
-	 * @param bool   $use_word_boundary Whether to use word boundaries for checking (true for names, false for slugs).
+	 * @param string $name The plugin name.
 	 * @return string|false The trademark term if found, false otherwise.
 	 */
-	private function has_trademark( $text, $use_word_boundary = false ) {
+	private function has_trademarked_name( $name ) {
 		// Bail early if the text is not provided.
-		if ( empty( $text ) ) {
+		if ( empty( $name ) ) {
 			return false;
 		}
-
+		
 		$has_trademark = false;
 
 		foreach ( self::TRADEMARK_SLUGS as $trademark ) {
 			if ( str_ends_with( $trademark, '-' ) ) {
 				// Trademarks ending in "-" indicate text cannot begin with that term.
-				if ( 0 === strpos( $text, $trademark ) ) {
+				if ( 0 === strpos( $name, $trademark ) ) {
 					$has_trademark = $trademark;
 					break;
 				}
-			} elseif ( $use_word_boundary ) {
+			} else {
 				// For plugin names, use word boundaries to avoid false positives (like "wc" in "wcag").
 				$pattern = '/\b' . preg_quote( $trademark, '/' ) . '\b/i';
-				if ( preg_match( $pattern, $text ) ) {
+				if ( preg_match( $pattern, $name ) ) {
 					// check for 'for-TRADEMARK' exceptions.
-					if ( $this->is_valid_for_use_exception( $text, $trademark ) ) {
+					if ( $this->is_valid_for_use_exception( $name, $trademark ) ) {
 						// It is a valid for-use exception, try the next trademark.
 						continue;
 					}
 					$has_trademark = $trademark;
 					break;
 				}
-			} elseif ( false !== strpos( $text, $trademark ) ) {
+			}
+		}
+		
+		// Check portmanteaus.
+		if ( ! $has_trademark ) {
+			foreach ( self::PORTMANTEAUS as $portmanteau ) {
+				if ( 0 === stripos( $name, $portmanteau ) ) {
+					$has_trademark = $portmanteau;
+					break;
+				}
+			}
+		}
+
+		return $has_trademark;
+	}
+
+	/**
+	 * Whether the plugin uses a trademark in the slug.
+	 *
+	 * @since 1.7.0
+	 *
+	 * @param string $slug The plugin slug.
+	 * @return string|false The trademark slug if found, false otherwise.
+	 */
+	private function has_trademarked_slug( $slug ) {
+		// Bail early if the text is not provided.
+		if ( empty( $slug ) ) {
+			return false;
+		}
+		
+		$has_trademark = false;
+
+		foreach ( self::TRADEMARK_SLUGS as $trademark ) {
+			if ( str_ends_with( $trademark, '-' ) ) {
+				// Trademarks ending in "-" indicate text cannot begin with that term.
+				if ( 0 === strpos( $slug, $trademark ) ) {
+					$has_trademark = $trademark;
+					break;
+				}
+			} elseif ( false !== strpos( $slug, $trademark ) ) {
 				// For slugs, the term cannot appear anywhere as a substring
 				// check for 'for-TRADEMARK' exceptions.
-				if ( $this->is_valid_for_use_exception( $text, $trademark ) ) {
+				if ( $this->is_valid_for_use_exception( $slug, $trademark ) ) {
 					// It is a valid for-use exception, try the next trademark.
 					continue;
 				}
@@ -503,7 +543,7 @@ class Trademarks_Check extends Abstract_File_Check {
 		// Check portmanteaus.
 		if ( ! $has_trademark ) {
 			foreach ( self::PORTMANTEAUS as $portmanteau ) {
-				if ( 0 === stripos( $text, $portmanteau ) ) {
+				if ( 0 === stripos( $slug, $portmanteau ) ) {
 					$has_trademark = $portmanteau;
 					break;
 				}

--- a/includes/Checker/Checks/Plugin_Repo/Trademarks_Check.php
+++ b/includes/Checker/Checks/Plugin_Repo/Trademarks_Check.php
@@ -453,7 +453,6 @@ class Trademarks_Check extends Abstract_File_Check {
 	}
 
 
-	
 	/**
 	 * Whether the plugin name contains a trademarked term.
 	 *
@@ -467,7 +466,7 @@ class Trademarks_Check extends Abstract_File_Check {
 		if ( empty( $name ) ) {
 			return false;
 		}
-		
+
 		$has_trademark = false;
 
 		foreach ( self::TRADEMARK_SLUGS as $trademark ) {
@@ -491,7 +490,7 @@ class Trademarks_Check extends Abstract_File_Check {
 				}
 			}
 		}
-		
+
 		// Check portmanteaus.
 		if ( ! $has_trademark ) {
 			foreach ( self::PORTMANTEAUS as $portmanteau ) {
@@ -518,7 +517,7 @@ class Trademarks_Check extends Abstract_File_Check {
 		if ( empty( $slug ) ) {
 			return false;
 		}
-		
+
 		$has_trademark = false;
 
 		foreach ( self::TRADEMARK_SLUGS as $trademark ) {


### PR DESCRIPTION
This pull request refactors the trademark checking logic for plugin names and slugs to improve accuracy and code maintainability. The main change is the introduction of a generalized `has_trademark` method, which replaces the previous slug-specific logic and adds word boundary checks for plugin names to reduce false positives like. For example the current version of the plugin flags the acronym `WCAG` for the use of `WC`. Helper methods have also been added for clarity and future extensibility.

**Trademark checking logic improvements:**

* Introduced a new `has_trademark` method that checks for trademarked terms in both plugin names and slugs, with an option to use word boundaries for names to avoid false positives.
* Updated `validate_name_has_no_trademarks` and `validate_slug_has_no_trademarks` to use the new `has_trademark` method, passing the appropriate word boundary flag for each case [[1]](diffhunk://#diff-4a2fdfc8003e431887d025fbf5ef3dd6b845a3ec7ea67418fd2a49c414f01eddL349-R349) [[2]](diffhunk://#diff-4a2fdfc8003e431887d025fbf5ef3dd6b845a3ec7ea67418fd2a49c414f01eddL407-R407).

**Code organization and maintainability:**

* Added helper methods `has_trademarked_slug` and `has_trademarked_name` that delegate to `has_trademark` with the correct parameters, improving code readability and future extensibility.
* Updated method and docblock names to reflect the more generalized trademark checking and new versioning.