### PR TITLE
Disallow runtime checks when any of the custom user table constants are defined

### DIFF
--- a/includes/Checker/Runtime_Environment_Setup.php
+++ b/includes/Checker/Runtime_Environment_Setup.php
@@ -180,6 +180,11 @@ final class Runtime_Environment_Setup {
 	public function can_set_up() {
 		global $wp_filesystem;
 
+		if ( defined( 'CUSTOM_USER_TABLE' ) || defined( 'CUSTOM_USER_META_TABLE' ) ) {
+			// When these constants are defined, we cannot duplicate the user tables for testing.
+			return false;
+		}
+
 		require_once ABSPATH . '/wp-admin/includes/upgrade.php';
 
 		if ( ! is_object( $wp_filesystem ) && ! WP_Filesystem() ) {


### PR DESCRIPTION
This is directly related to #1028: While that PR prevents the more critical bug, it's a problem in itself that we do runtime checks with these tables present, as they cannot be reasonably duplicated, because WordPress will always use the constants.