### PR TITLE
Add autoloader suffix to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -61,7 +61,7 @@
       "php": "7.4"
     },
     "sort-packages": true,
-    "autoloader-suffix": "Plugin_Check",
+    "autoloader-suffix": "Plugin_Check_Plugin"
   },
   "scripts": {
     "behat": "BEHAT_FEATURES_FOLDER=tests/behat/features run-behat-tests",

--- a/composer.json
+++ b/composer.json
@@ -60,7 +60,8 @@
     "platform": {
       "php": "7.4"
     },
-    "sort-packages": true
+    "sort-packages": true,
+    "autoloader-suffix": "Plugin_Check",
   },
   "scripts": {
     "behat": "BEHAT_FEATURES_FOLDER=tests/behat/features run-behat-tests",


### PR DESCRIPTION
Could we enable the autoloader suffix functionality such that WordPress.org deploys of the plugin are smoother..?

> E_ERROR: Uncaught Error: Class "ComposerAutoloaderInit67b1819118dada190aab66a634657bf4" not found in wp-content/plugins/plugin-check-trunk/vendor/autoload.php:25

WordPress.org's deploys can be a little funky at times, and that's thrown when the plugin is loaded on a site, but the PHP files on disk are only half loaded, half-old, half-new..
This PR might not resolve that, but might stop a fatal when the page load isn't actually going to be touching anything in Plugin Check (ie. a Plugins API request doesn't need PCP)

This would have the effect of changing the Composer autoloader class from `ComposerAutoloaderInit$UUID` to `ComposerAutoloaderInitPlugin_Check_Plugin`  which should be fairly unique still, but the class name won't change every time the plugin is rebuilt :)

(Low-priority, not a blocker, feel free to discuss it, etc)