### PR TITLE
Handle possible empty element in scanner

### DIFF
--- a/includes/Scanner/PHP_Parser.php
+++ b/includes/Scanner/PHP_Parser.php
@@ -1023,6 +1023,14 @@ abstract class PHP_Parser {
 	 *                     or an empty string for non-accurate processing when no string is found.
 	 */
 	public function get_possible_string_for_element( $element, &$found_in_same_line = true, $accurate = true, $file = '' ) {
+		if ( ! is_object( $element ) ) {
+			if ( $accurate ) {
+				return false;
+			} else {
+				return '';
+			}
+		}
+
 		$class = get_class( $element );
 
 		switch ( $class ) {


### PR DESCRIPTION
PHP_Parser: get_possible_string_for_element() - Strangely $element is sometime empty. This PR handle this edge case.