### PR TITLE
Add heredoc sniff

### DIFF
--- a/phpcs-rulesets/plugin-check.ruleset.xml
+++ b/phpcs-rulesets/plugin-check.ruleset.xml
@@ -30,8 +30,8 @@
 		<severity>7</severity>
 	</rule>
 
-	<!-- Prohibit the use of HEREDOC or NOWDOC. -->
-	<rule ref="Squiz.PHP.Heredoc">
+	<!-- Prohibit the use of HEREDOC. -->
+	<rule ref="PluginCheck.CodeAnalysis.Heredoc">
 		<severity>7</severity>
 	</rule>
 

--- a/phpcs-sniffs/PluginCheck/Sniffs/CodeAnalysis/HeredocSniff.php
+++ b/phpcs-sniffs/PluginCheck/Sniffs/CodeAnalysis/HeredocSniff.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * HeredocSniff
+ *
+ * @package PluginCheck
+ */
+
+namespace PluginCheckCS\PluginCheck\Sniffs\CodeAnalysis;
+
+use WordPressCS\WordPress\Sniff;
+
+/**
+ * Detects the use of HEREDOCs.
+ *
+ * @since 1.0.0
+ */
+final class HeredocSniff extends Sniff {
+
+	/**
+	 * Returns an array of tokens this test wants to listen for.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return array<int>
+	 */
+	public function register() {
+		return array(
+			T_START_HEREDOC,
+		);
+	}
+
+	/**
+	 * Processes this test, when one of its tokens is encountered.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param int $stackPtr The position of the current token in the stack.
+	 * @return int|void Integer stack pointer to skip forward or void to continue normal file processing.
+	 */
+	public function process_token( $stackPtr ) {
+		$error = 'Use of heredoc syntax (<<<) is not allowed; use standard strings or inline HTML instead';
+		$this->phpcsFile->addError( $error, $stackPtr, 'NotAllowed' );
+	}
+}

--- a/phpcs-sniffs/PluginCheck/Tests/CodeAnalysis/HeredocUnitTest.inc
+++ b/phpcs-sniffs/PluginCheck/Tests/CodeAnalysis/HeredocUnitTest.inc
@@ -1,0 +1,47 @@
+<?php
+
+/* testHeredocSingleLine */
+echo <<<EOD
+Some $var text
+EOD;
+
+/* testNowdocSingleLine */
+echo <<<'MARKER'
+Some text
+MARKER;
+
+/* testHeredocMultiLine */
+echo <<<"😬"
+Lorum ipsum
+Some $var text
+dolor sit amet
+😬;
+
+/* testNowdocMultiLine */
+echo <<<'multi_line'
+Lorum ipsum
+Some text
+dolor sit amet
+multi_line;
+
+/* testHeredocEndsOnBlankLine */
+echo <<<EOD
+Lorum ipsum
+dolor sit amet
+
+EOD;
+
+/* testNowdocEndsOnBlankLine */
+echo <<<'EOD'
+Lorum ipsum
+dolor sit amet
+
+EOD;
+
+/* testNowdocShort */
+echo <<<'JS'
+function test() {
+	return true;
+}
+JS;
+

--- a/phpcs-sniffs/PluginCheck/Tests/CodeAnalysis/HeredocUnitTest.php
+++ b/phpcs-sniffs/PluginCheck/Tests/CodeAnalysis/HeredocUnitTest.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * Unit tests for HeredocSniff.
+ *
+ * @package PluginCheck
+ */
+
+namespace PluginCheckCS\PluginCheck\Tests\CodeAnalysis;
+
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PluginCheckCS\PluginCheck\Sniffs\CodeAnalysis\HeredocSniff;
+use PluginCheckCS\PluginCheck\Tests\AbstractSniffUnitTest;
+
+/**
+ * Unit tests for HeredocSniff.
+ */
+final class HeredocUnitTest extends AbstractSniffUnitTest {
+
+	/**
+	 * Returns the lines where errors should occur.
+	 *
+	 * @return array <int line number> => <int number of errors>
+	 */
+	public function getErrorList() {
+		return array(
+			4  => 1, // Case: testHeredocSingleLine.
+			14 => 1, // Case: testHeredocMultiLine.
+			28 => 1, // Case: testHeredocEndsOnBlankLine.
+		);
+	}
+
+	/**
+	 * Returns the lines where warnings should occur.
+	 *
+	 * @return array <int line number> => <int number of warnings>
+	 */
+	public function getWarningList() {
+		return array();
+	}
+
+	/**
+	 * Returns the fully qualified class name (FQCN) of the sniff.
+	 *
+	 * @return string The fully qualified class name of the sniff.
+	 */
+	protected function get_sniff_fqcn() {
+		return HeredocSniff::class;
+	}
+
+	/**
+	 * Sets the parameters for the sniff.
+	 *
+	 * @throws \RuntimeException If unable to set the ruleset parameters required for the test.
+	 *
+	 * @param Sniff $sniff The sniff being tested.
+	 */
+	public function set_sniff_parameters( Sniff $sniff ) {
+	}
+}

--- a/phpcs-sniffs/PluginCheck/ruleset.xml
+++ b/phpcs-sniffs/PluginCheck/ruleset.xml
@@ -5,6 +5,7 @@
 
 	<rule ref="PluginCheck.CodeAnalysis.DiscouragedFunctions" />
 	<rule ref="PluginCheck.CodeAnalysis.EnqueuedResourceOffloading" />
+	<rule ref="PluginCheck.CodeAnalysis.Heredoc" />
 	<rule ref="PluginCheck.CodeAnalysis.Localhost" />
 	<rule ref="PluginCheck.CodeAnalysis.Offloading" />
 	<rule ref="PluginCheck.CodeAnalysis.RequiredFunctionParameters" />

--- a/tests/phpunit/testdata/plugins/test-plugin-review-phpcs-errors/load.php
+++ b/tests/phpunit/testdata/plugins/test-plugin-review-phpcs-errors/load.php
@@ -57,3 +57,10 @@ do_shortcode_tag( $shortcode_tag );
 get_post_type_labels( $post_type );
 wp_get_sidebars_widgets();
 wp_get_widget_defaults( $widget_id );
+
+// NOWDOC example; Should not trigger error.
+$str = <<<'NOWDOC'
+Example of string
+spanning multiple lines
+using nowdoc syntax.
+NOWDOC;

--- a/tests/phpunit/tests/Checker/Checks/Plugin_Review_PHPCS_Check_Tests.php
+++ b/tests/phpunit/tests/Checker/Checks/Plugin_Review_PHPCS_Check_Tests.php
@@ -33,8 +33,11 @@ class Plugin_Review_PHPCS_Check_Tests extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'code', $errors['load.php'][6][1][0] );
 		$this->assertEquals( 'Generic.PHP.DisallowShortOpenTag.Found', $errors['load.php'][6][1][0]['code'] );
 
-		// Check for Squiz.PHP.Heredoc.NotAllowed error on Line no 28 and column no at 8.
-		$this->assertEquals( 'Squiz.PHP.Heredoc.NotAllowed', $errors['load.php'][28][8][0]['code'] );
+		// Check for PluginCheck.CodeAnalysis.Heredoc.NotAllowed error on Line no 28 and column no at 8.
+		$this->assertArrayHasKey( 28, $errors['load.php'] );
+		$this->assertArrayHasKey( 8, $errors['load.php'][28] );
+		$this->assertArrayHasKey( 'code', $errors['load.php'][28][8][0] );
+		$this->assertEquals( 'PluginCheck.CodeAnalysis.Heredoc.NotAllowed', $errors['load.php'][28][8][0]['code'] );
 
 		// Check for WordPress.WP.DeprecatedFunctions.the_author_emailFound error on Line no 12 and column no at 5.
 		$this->assertArrayHasKey( 12, $errors['load.php'] );


### PR DESCRIPTION
Fixes https://github.com/WordPress/plugin-check/issues/1036

- Add Heredoc sniff
- Heredoc is restricted but Nowdoc is allowed now