### PR TITLE
Change prefixing error type to warning

### DIFF
--- a/includes/Checker/Checks/Plugin_Repo/Prefixing_Check.php
+++ b/includes/Checker/Checks/Plugin_Repo/Prefixing_Check.php
@@ -89,4 +89,27 @@ class Prefixing_Check extends Abstract_PHP_CodeSniffer_Check {
 	public function get_documentation_url(): string {
 		return __( 'https://make.wordpress.org/plugins/handbook/performing-reviews/review-checklist/#code', 'plugin-check' );
 	}
+
+	/**
+	 * Amends the given result with a message for the specified file, including error information.
+	 *
+	 * @since 1.8.0
+	 *
+	 * @param Check_Result $result   The check result to amend, including the plugin context to check.
+	 * @param bool         $error    Whether it is an error or notice.
+	 * @param string       $message  Error message.
+	 * @param string       $code     Error code.
+	 * @param string       $file     Absolute path to the file where the issue was found.
+	 * @param int          $line     The line on which the message occurred. Default is 0 (unknown line).
+	 * @param int          $column   The column on which the message occurred. Default is 0 (unknown column).
+	 * @param string       $docs     URL for further information about the message.
+	 * @param int          $severity Severity level. Default is 5.
+	 */
+	protected function add_result_message_for_file( Check_Result $result, $error, $message, $code, $file, $line = 0, $column = 0, string $docs = '', $severity = 5 ) {
+		// Update error type and severity.
+		$error    = false;
+		$severity = 6;
+
+		parent::add_result_message_for_file( $result, $error, $message, $code, $file, $line, $column, $docs, $severity );
+	}
 }

--- a/tests/phpunit/tests/Checker/Checks/Prefixing_Check_Tests.php
+++ b/tests/phpunit/tests/Checker/Checks/Prefixing_Check_Tests.php
@@ -18,14 +18,14 @@ class Prefixing_Check_Tests extends WP_UnitTestCase {
 
 		$check->run( $check_result );
 
-		$errors = $check_result->get_errors();
+		$warnings = $check_result->get_warnings();
 
-		$this->assertNotEmpty( $errors );
-		$this->assertArrayHasKey( 'load.php', $errors );
+		$this->assertNotEmpty( $warnings );
+		$this->assertArrayHasKey( 'load.php', $warnings );
 
-		$this->assertCount( 1, wp_list_filter( $errors['load.php'][18][9], array( 'code' => 'WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedConstantFound' ) ) );
-		$this->assertCount( 1, wp_list_filter( $errors['load.php'][20][1], array( 'code' => 'WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedFunctionFound' ) ) );
-		$this->assertCount( 1, wp_list_filter( $errors['load.php'][28][1], array( 'code' => 'WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedFunctionFound' ) ) );
-		$this->assertCount( 1, wp_list_filter( $errors['load.php'][41][1], array( 'code' => 'WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedFunctionFound' ) ) );
+		$this->assertCount( 1, wp_list_filter( $warnings['load.php'][18][9], array( 'code' => 'WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedConstantFound' ) ) );
+		$this->assertCount( 1, wp_list_filter( $warnings['load.php'][20][1], array( 'code' => 'WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedFunctionFound' ) ) );
+		$this->assertCount( 1, wp_list_filter( $warnings['load.php'][28][1], array( 'code' => 'WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedFunctionFound' ) ) );
+		$this->assertCount( 1, wp_list_filter( $warnings['load.php'][41][1], array( 'code' => 'WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedFunctionFound' ) ) );
 	}
 }


### PR DESCRIPTION
Since we are getting lots of false positives on this prefixing check, we are converting ERROR to WARNING for now. Keeping severity 6 to provide more visibility if not ERROR.