### PR TITLE
Added functionality to downlaod the scan report via PDF/CSV file

### DIFF
--- a/assets/js/plugin-check-admin.js
+++ b/assets/js/plugin-check-admin.js
@@ -286,6 +286,59 @@
 				type: messageType,
 				message: messageText,
 			} ) + resultsContainer.innerHTML;
+
+		// Wire up Download Report dropdown and links.
+		const downloadBtn = document.getElementById( 'pcp-download-report-button' );
+		const downloadMenu = document.getElementById( 'pcp-download-menu' );
+		const csvLink = document.getElementById( 'pcp-export-csv' );
+		const pdfLink = document.getElementById( 'pcp-export-pdf' );
+
+		if ( downloadBtn && downloadMenu && csvLink && pdfLink ) {
+			// Build query params from current selections.
+			const params = new URLSearchParams();
+			params.set( 'plugin', pluginsList.value );
+			params.set(
+				'include-experimental',
+				includeExperimental && includeExperimental.checked ? '1' : '0'
+			);
+			params.set( '_wpnonce', pluginCheck.exportNonce );
+
+			for ( let i = 0; i < categoriesList.length; i++ ) {
+				if ( categoriesList[ i ].checked ) {
+					params.append( 'categories[]', categoriesList[ i ].value );
+				}
+			}
+
+			const csvUrl = `${ pluginCheck.adminPostUrl }?action=${ encodeURIComponent(
+				pluginCheck.exportCsvAction
+			) }&${ params.toString() }`;
+			const pdfUrl = `${ pluginCheck.adminPostUrl }?action=${ encodeURIComponent(
+				pluginCheck.exportPdfAction
+			) }&${ params.toString() }`;
+
+			csvLink.setAttribute( 'href', csvUrl );
+			pdfLink.setAttribute( 'href', pdfUrl );
+
+			downloadBtn.addEventListener( 'click', function () {
+				// Toggle visibility.
+				if ( 'none' === downloadMenu.style.display ) {
+					downloadMenu.style.display = 'block';
+				} else {
+					downloadMenu.style.display = 'none';
+				}
+			} );
+
+			// Hide the menu if clicking elsewhere.
+			document.addEventListener( 'click', function ( evt ) {
+				if (
+					downloadMenu.style.display === 'block' &&
+					! downloadMenu.contains( evt.target ) &&
+					evt.target !== downloadBtn
+				) {
+					downloadMenu.style.display = 'none';
+				}
+			} );
+		}
 	}
 
 	/**

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,8 @@
     "composer/installers": "^2.2",
     "dealerdirect/phpcodesniffer-composer-installer": "^1.0.0",
     "plugin-check/phpcs-sniffs": "@dev",
-    "wp-coding-standards/wpcs": "^3.1.0"
+    "wp-coding-standards/wpcs": "^3.1.0",
+    "dompdf/dompdf": "^3.1"
   },
   "require-dev": {
     "phpcompatibility/php-compatibility": "^9.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6a37ae8d9c7ce2f2111461a1d3fb5ed9",
+    "content-hash": "06589b7a7a6a18eadab1806b1a59ea3a",
     "packages": [
         {
             "name": "automattic/vipwpcs",
@@ -303,6 +303,228 @@
             "time": "2025-07-17T20:45:56+00:00"
         },
         {
+            "name": "dompdf/dompdf",
+            "version": "v3.1.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/dompdf/dompdf.git",
+                "reference": "db712c90c5b9868df3600e64e68da62e78a34623"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/dompdf/dompdf/zipball/db712c90c5b9868df3600e64e68da62e78a34623",
+                "reference": "db712c90c5b9868df3600e64e68da62e78a34623",
+                "shasum": ""
+            },
+            "require": {
+                "dompdf/php-font-lib": "^1.0.0",
+                "dompdf/php-svg-lib": "^1.0.0",
+                "ext-dom": "*",
+                "ext-mbstring": "*",
+                "masterminds/html5": "^2.0",
+                "php": "^7.1 || ^8.0"
+            },
+            "require-dev": {
+                "ext-gd": "*",
+                "ext-json": "*",
+                "ext-zip": "*",
+                "mockery/mockery": "^1.3",
+                "phpunit/phpunit": "^7.5 || ^8 || ^9 || ^10 || ^11",
+                "squizlabs/php_codesniffer": "^3.5",
+                "symfony/process": "^4.4 || ^5.4 || ^6.2 || ^7.0"
+            },
+            "suggest": {
+                "ext-gd": "Needed to process images",
+                "ext-gmagick": "Improves image processing performance",
+                "ext-imagick": "Improves image processing performance",
+                "ext-zlib": "Needed for pdf stream compression"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Dompdf\\": "src/"
+                },
+                "classmap": [
+                    "lib/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-2.1"
+            ],
+            "authors": [
+                {
+                    "name": "The Dompdf Community",
+                    "homepage": "https://github.com/dompdf/dompdf/blob/master/AUTHORS.md"
+                }
+            ],
+            "description": "DOMPDF is a CSS 2.1 compliant HTML to PDF converter",
+            "homepage": "https://github.com/dompdf/dompdf",
+            "support": {
+                "issues": "https://github.com/dompdf/dompdf/issues",
+                "source": "https://github.com/dompdf/dompdf/tree/v3.1.4"
+            },
+            "time": "2025-10-29T12:43:30+00:00"
+        },
+        {
+            "name": "dompdf/php-font-lib",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/dompdf/php-font-lib.git",
+                "reference": "6137b7d4232b7f16c882c75e4ca3991dbcf6fe2d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/dompdf/php-font-lib/zipball/6137b7d4232b7f16c882c75e4ca3991dbcf6fe2d",
+                "reference": "6137b7d4232b7f16c882c75e4ca3991dbcf6fe2d",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "php": "^7.1 || ^8.0"
+            },
+            "require-dev": {
+                "symfony/phpunit-bridge": "^3 || ^4 || ^5 || ^6"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "FontLib\\": "src/FontLib"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-2.1-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "The FontLib Community",
+                    "homepage": "https://github.com/dompdf/php-font-lib/blob/master/AUTHORS.md"
+                }
+            ],
+            "description": "A library to read, parse, export and make subsets of different types of font files.",
+            "homepage": "https://github.com/dompdf/php-font-lib",
+            "support": {
+                "issues": "https://github.com/dompdf/php-font-lib/issues",
+                "source": "https://github.com/dompdf/php-font-lib/tree/1.0.1"
+            },
+            "time": "2024-12-02T14:37:59+00:00"
+        },
+        {
+            "name": "dompdf/php-svg-lib",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/dompdf/php-svg-lib.git",
+                "reference": "eb045e518185298eb6ff8d80d0d0c6b17aecd9af"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/dompdf/php-svg-lib/zipball/eb045e518185298eb6ff8d80d0d0c6b17aecd9af",
+                "reference": "eb045e518185298eb6ff8d80d0d0c6b17aecd9af",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "php": "^7.1 || ^8.0",
+                "sabberworm/php-css-parser": "^8.4"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Svg\\": "src/Svg"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "The SvgLib Community",
+                    "homepage": "https://github.com/dompdf/php-svg-lib/blob/master/AUTHORS.md"
+                }
+            ],
+            "description": "A library to read, parse and export to PDF SVG files.",
+            "homepage": "https://github.com/dompdf/php-svg-lib",
+            "support": {
+                "issues": "https://github.com/dompdf/php-svg-lib/issues",
+                "source": "https://github.com/dompdf/php-svg-lib/tree/1.0.0"
+            },
+            "time": "2024-04-29T13:26:35+00:00"
+        },
+        {
+            "name": "masterminds/html5",
+            "version": "2.10.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Masterminds/html5-php.git",
+                "reference": "fcf91eb64359852f00d921887b219479b4f21251"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Masterminds/html5-php/zipball/fcf91eb64359852f00d921887b219479b4f21251",
+                "reference": "fcf91eb64359852f00d921887b219479b4f21251",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "php": ">=5.3.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8.35 || ^5.7.21 || ^6 || ^7 || ^8 || ^9"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.7-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Masterminds\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Matt Butcher",
+                    "email": "technosophos@gmail.com"
+                },
+                {
+                    "name": "Matt Farina",
+                    "email": "matt@mattfarina.com"
+                },
+                {
+                    "name": "Asmir Mustafic",
+                    "email": "goetas@gmail.com"
+                }
+            ],
+            "description": "An HTML5 parser and serializer.",
+            "homepage": "http://masterminds.github.io/html5-php",
+            "keywords": [
+                "HTML5",
+                "dom",
+                "html",
+                "parser",
+                "querypath",
+                "serializer",
+                "xml"
+            ],
+            "support": {
+                "issues": "https://github.com/Masterminds/html5-php/issues",
+                "source": "https://github.com/Masterminds/html5-php/tree/2.10.0"
+            },
+            "time": "2025-07-25T09:04:22+00:00"
+        },
+        {
             "name": "phpcsstandards/phpcsextra",
             "version": "1.4.0",
             "source": {
@@ -543,6 +765,72 @@
                 "symlink": false,
                 "relative": true
             }
+        },
+        {
+            "name": "sabberworm/php-css-parser",
+            "version": "v8.9.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/MyIntervals/PHP-CSS-Parser.git",
+                "reference": "d8e916507b88e389e26d4ab03c904a082aa66bb9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/MyIntervals/PHP-CSS-Parser/zipball/d8e916507b88e389e26d4ab03c904a082aa66bb9",
+                "reference": "d8e916507b88e389e26d4ab03c904a082aa66bb9",
+                "shasum": ""
+            },
+            "require": {
+                "ext-iconv": "*",
+                "php": "^5.6.20 || ^7.0.0 || ~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "5.7.27 || 6.5.14 || 7.5.20 || 8.5.41",
+                "rawr/cross-data-providers": "^2.0.0"
+            },
+            "suggest": {
+                "ext-mbstring": "for parsing UTF-8 CSS"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "9.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Sabberworm\\CSS\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Raphael Schweikert"
+                },
+                {
+                    "name": "Oliver Klee",
+                    "email": "github@oliverklee.de"
+                },
+                {
+                    "name": "Jake Hotson",
+                    "email": "jake.github@qzdesign.co.uk"
+                }
+            ],
+            "description": "Parser for CSS Files written in PHP",
+            "homepage": "https://www.sabberworm.com/blog/2010/6/10/php-css-parser",
+            "keywords": [
+                "css",
+                "parser",
+                "stylesheet"
+            ],
+            "support": {
+                "issues": "https://github.com/MyIntervals/PHP-CSS-Parser/issues",
+                "source": "https://github.com/MyIntervals/PHP-CSS-Parser/tree/v8.9.0"
+            },
+            "time": "2025-07-11T13:20:48+00:00"
         },
         {
             "name": "sirbrillig/phpcs-variable-analysis",

--- a/includes/Admin/Admin_Page.php
+++ b/includes/Admin/Admin_Page.php
@@ -11,6 +11,7 @@ use WordPress\Plugin_Check\Checker\Check;
 use WordPress\Plugin_Check\Checker\Check_Categories;
 use WordPress\Plugin_Check\Checker\Check_Repository;
 use WordPress\Plugin_Check\Checker\Default_Check_Repository;
+use WordPress\Plugin_Check\Admin\Report_Exporter;
 
 /**
  * Class is handling admin tools page functionality.
@@ -196,6 +197,10 @@ final class Admin_Page {
 			'const PLUGIN_CHECK = ' . json_encode(
 				array(
 					'nonce'                           => $this->admin_ajax->get_nonce(),
+					'exportNonce'                     => wp_create_nonce( Report_Exporter::NONCE_ACTION ),
+					'adminPostUrl'                    => admin_url( 'admin-post.php' ),
+					'exportCsvAction'                 => Report_Exporter::ACTION_EXPORT_CSV,
+					'exportPdfAction'                 => Report_Exporter::ACTION_EXPORT_PDF,
 					'actionGetChecksToRun'            => Admin_AJAX::ACTION_GET_CHECKS_TO_RUN,
 					'actionSetUpRuntimeEnvironment'   => Admin_AJAX::ACTION_SET_UP_ENVIRONMENT,
 					'actionRunChecks'                 => Admin_AJAX::ACTION_RUN_CHECKS,

--- a/includes/Admin/Report_Exporter.php
+++ b/includes/Admin/Report_Exporter.php
@@ -1,0 +1,297 @@
+<?php
+/**
+ * Class WordPress\Plugin_Check\Admin\Report_Exporter
+ *
+ * @package plugin-check
+ */
+
+namespace WordPress\Plugin_Check\Admin;
+
+use Exception;
+use WordPress\Plugin_Check\Checker\AJAX_Runner;
+use WP_Error;
+
+/**
+ * Handles exporting Plugin Check results as CSV or PDF.
+ *
+ * @since 1.7.0
+ */
+final class Report_Exporter {
+
+	/**
+	 * Nonce action for report exports.
+	 *
+	 * @since 1.7.0
+	 * @var string
+	 */
+	const NONCE_ACTION = 'pcp-export-report';
+
+	/**
+	 * CSV export action slug.
+	 *
+	 * @since 1.7.0
+	 * @var string
+	 */
+	const ACTION_EXPORT_CSV = 'pcp_export_csv';
+
+	/**
+	 * PDF export action slug.
+	 *
+	 * @since 1.7.0
+	 * @var string
+	 */
+	const ACTION_EXPORT_PDF = 'pcp_export_pdf';
+
+	/**
+	 * Register admin-post hooks for exports.
+	 *
+	 * @since 1.7.0
+	 */
+	public function add_hooks() {
+		add_action( 'admin_post_' . self::ACTION_EXPORT_CSV, array( __CLASS__, 'export_csv' ) );
+		add_action( 'admin_post_' . self::ACTION_EXPORT_PDF, array( __CLASS__, 'export_pdf' ) );
+	}
+
+	/**
+	 * Export the report as CSV.
+	 *
+	 * @since 1.7.0
+	 */
+	public static function export_csv() {
+		self::guard_request();
+
+		list( $plugin, $categories, $include_experimental ) = self::read_request_params();
+
+		try {
+			$data = self::prepare_report_data( $plugin, $categories, $include_experimental );
+		} catch ( Exception $e ) {
+			wp_die( esc_html( $e->getMessage() ), esc_html__( 'Export failed', 'plugin-check' ), array( 'response' => 500 ) );
+		}
+
+		$filename = sprintf( 'plugin-check-report-%s.csv', wp_date( 'Y-m-d-His' ) );
+
+		nocache_headers();
+		header( 'Content-Type: text/csv; charset=utf-8' );
+		header( 'Content-Disposition: attachment; filename=' . $filename );
+		header( 'Pragma: public' );
+
+		// UTF-8 BOM for Excel compatibility.
+		echo "\xEF\xBB\xBF";
+
+		$fh = fopen( 'php://output', 'w' );
+
+		// Header.
+		fputcsv( $fh, array( 'Severity', 'File', 'Line', 'Message' ) );
+
+		foreach ( $data['rows'] as $row ) {
+			fputcsv(
+				$fh,
+				array(
+					$row['severity'],
+					$row['file'],
+					$row['line'],
+					$row['message'],
+				)
+			);
+		}
+
+		fclose( $fh );
+		exit;
+	}
+
+	/**
+	 * Export the report as PDF.
+	 *
+	 * Uses DOMPDF if available. If DOMPDF is not installed, a helpful message is shown.
+	 *
+	 * @since 1.7.0
+	 */
+	public static function export_pdf() {
+		self::guard_request();
+
+		list( $plugin, $categories, $include_experimental ) = self::read_request_params();
+
+		try {
+			$data = self::prepare_report_data( $plugin, $categories, $include_experimental );
+		} catch ( Exception $e ) {
+			wp_die( esc_html( $e->getMessage() ), esc_html__( 'Export failed', 'plugin-check' ), array( 'response' => 500 ) );
+		}
+
+		if ( ! class_exists( '\Dompdf\Dompdf' ) ) {
+			$message  = esc_html__( 'PDF export requires DOMPDF. Please install the dependency:', 'plugin-check' );
+			$message .= '<br><code>composer require dompdf/dompdf</code>';
+			wp_die( $message, esc_html__( 'Dependency missing', 'plugin-check' ), 500 );
+		}
+
+		// Build minimal HTML for the PDF.
+		$title     = esc_html__( 'Plugin Check Report', 'plugin-check' );
+		$timestamp = esc_html( wp_date( 'Y-m-d H:i:s' ) );
+		$plugin_h  = esc_html( $data['plugin'] );
+
+		$rows_html = '';
+		foreach ( $data['rows'] as $row ) {
+			$rows_html .= sprintf(
+				'<tr><td>%s</td><td>%s</td><td>%s</td><td>%s</td></tr>',
+				esc_html( $row['severity'] ),
+				esc_html( $row['file'] ),
+				esc_html( (string) $row['line'] ),
+				esc_html( $row['message'] )
+			);
+		}
+
+		$html = '
+			<html>
+			<head>
+				<meta charset="utf-8">
+				<style>
+					body { font-family: DejaVu Sans, Arial, sans-serif; font-size: 12px; }
+					h1 { font-size: 20px; margin-bottom: 8px; }
+					p.meta { margin: 0 0 12px 0; color: #444; }
+					table { width: 100%; border-collapse: collapse; }
+					th, td { border: 1px solid #ccc; padding: 6px; text-align: left; }
+					th { background: #f3f4f5; }
+				</style>
+			</head>
+			<body>
+				<h1>' . $title . '</h1>
+				<p class="meta">' . esc_html__( 'Plugin:', 'plugin-check' ) . ' ' . $plugin_h . '</p>
+				<p class="meta">' . esc_html__( 'Generated:', 'plugin-check' ) . ' ' . $timestamp . '</p>
+				<table>
+					<thead>
+						<tr>
+							<th>' . esc_html__( 'Severity', 'plugin-check' ) . '</th>
+							<th>' . esc_html__( 'File', 'plugin-check' ) . '</th>
+							<th>' . esc_html__( 'Line', 'plugin-check' ) . '</th>
+							<th>' . esc_html__( 'Message', 'plugin-check' ) . '</th>
+						</tr>
+					</thead>
+					<tbody>' . $rows_html . '</tbody>
+				</table>
+			</body>
+			</html>
+		';
+
+		$dompdf = new \Dompdf\Dompdf();
+		$dompdf->loadHtml( $html, 'UTF-8' );
+		$dompdf->setPaper( 'A4', 'portrait' );
+		$dompdf->render();
+
+		$filename = sprintf( 'plugin-check-report-%s.pdf', wp_date( 'Y-m-d-His' ) );
+		$dompdf->stream( $filename, array( 'Attachment' => 1 ) );
+		exit;
+	}
+
+	/**
+	 * Prepare normalized report data by running checks.
+	 *
+	 * This regenerates results based on request parameters.
+	 *
+	 * @since 1.7.0
+	 *
+	 * @param string $plugin               Plugin slug or basename.
+	 * @param array  $categories           Selected categories.
+	 * @param bool   $include_experimental Whether to include experimental checks.
+	 * @return array {
+	 *     @type string $plugin Plugin basename.
+	 *     @type array  $rows   List of normalized rows with severity, file, line, message.
+	 * }
+	 *
+	 * @throws Exception When the run fails.
+	 */
+	public static function prepare_report_data( $plugin, array $categories, $include_experimental ) {
+		$runner = new AJAX_Runner();
+
+		// Set parameters.
+		$runner->set_plugin( $plugin );
+		$runner->set_categories( $categories );
+		$runner->set_experimental_flag( (bool) $include_experimental );
+
+		// Determine checks, then run.
+		$checks_to_run = $runner->get_checks_to_run();
+		$runner->set_check_slugs( array_keys( $checks_to_run ) );
+
+		$results = $runner->run();
+
+		$errors   = $results->get_errors();
+		$warnings = $results->get_warnings();
+
+		$rows = array();
+
+		// Normalize errors.
+		foreach ( $errors as $file => $lines ) {
+			foreach ( $lines as $line => $columns ) {
+				foreach ( $columns as $messages ) {
+					foreach ( $messages as $message_data ) {
+						$rows[] = array(
+							'severity' => 'ERROR',
+							'file'     => (string) $file,
+							'line'     => (int) $line,
+							'message'  => (string) $message_data['message'],
+						);
+					}
+				}
+			}
+		}
+
+		// Normalize warnings.
+		foreach ( $warnings as $file => $lines ) {
+			foreach ( $lines as $line => $columns ) {
+				foreach ( $columns as $messages ) {
+					foreach ( $messages as $message_data ) {
+						$rows[] = array(
+							'severity' => 'WARNING',
+							'file'     => (string) $file,
+							'line'     => (int) $line,
+							'message'  => (string) $message_data['message'],
+						);
+					}
+				}
+			}
+		}
+
+		return array(
+			'plugin' => $runner->get_plugin_basename(),
+			'rows'   => $rows,
+		);
+	}
+
+	/**
+	 * Validate nonce and capability for export requests.
+	 *
+	 * @since 1.7.0
+	 */
+	private static function guard_request() {
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$nonce = isset( $_REQUEST['_wpnonce'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['_wpnonce'] ) ) : '';
+		if ( ! wp_verify_nonce( $nonce, self::NONCE_ACTION ) ) {
+			wp_die( esc_html__( 'Invalid request nonce.', 'plugin-check' ), esc_html__( 'Unauthorized', 'plugin-check' ), 403 );
+		}
+
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_die( esc_html__( 'You do not have permission to export reports.', 'plugin-check' ), esc_html__( 'Forbidden', 'plugin-check' ), 403 );
+		}
+	}
+
+	/**
+	 * Read and sanitize request parameters.
+	 *
+	 * @since 1.7.0
+	 *
+	 * @return array Array with [ plugin, categories, include_experimental ].
+	 */
+	private static function read_request_params() {
+		$plugin               = filter_input( INPUT_GET, 'plugin', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
+		$include_experimental = 1 === filter_input( INPUT_GET, 'include-experimental', FILTER_VALIDATE_INT );
+
+		$categories = filter_input( INPUT_GET, 'categories', FILTER_DEFAULT, FILTER_FORCE_ARRAY );
+		$categories = is_null( $categories ) ? array() : array_map( 'sanitize_text_field', $categories );
+
+		if ( empty( $plugin ) ) {
+			wp_die( esc_html__( 'Missing plugin parameter.', 'plugin-check' ), esc_html__( 'Bad request', 'plugin-check' ), 400 );
+		}
+
+		return array( $plugin, $categories, $include_experimental );
+	}
+}
+
+

--- a/includes/Plugin_Main.php
+++ b/includes/Plugin_Main.php
@@ -9,6 +9,7 @@ namespace WordPress\Plugin_Check;
 
 use WordPress\Plugin_Check\Admin\Admin_AJAX;
 use WordPress\Plugin_Check\Admin\Admin_Page;
+use WordPress\Plugin_Check\Admin\Report_Exporter;
 
 /**
  * Main class for the plugin.
@@ -67,5 +68,9 @@ class Plugin_Main {
 		// Create the Admin page.
 		$admin_page = new Admin_Page( $admin_ajax );
 		$admin_page->add_hooks();
+
+		// Register export endpoints.
+		$exporter = new Report_Exporter();
+		$exporter->add_hooks();
 	}
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,6 +58,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.25.7.tgz",
       "integrity": "sha512-yJ474Zv3cwiSOO9nXJuqzvwEeM+chDuQ8GJirw+pZ91sCGCyOZ3dJkVE09fTV0VEVzXyLWhh3G/AolYTPX7Mow==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.25.7",
@@ -1979,6 +1980,7 @@
           "url": "https://opencollective.com/csstools"
         }
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -2001,6 +2003,7 @@
           "url": "https://opencollective.com/csstools"
         }
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -3114,6 +3117,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -3135,6 +3139,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.30.1.tgz",
       "integrity": "sha512-s5vvxXPVdjqS3kTLKMeBMvop9hbWkwzBpu+mUO2M7sZtlkyDJGwFe33wRKnbaYDo8ExRVBIIdwIGrqpxHuKttA==",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=14"
       },
@@ -3147,6 +3152,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.30.1.tgz",
       "integrity": "sha512-OOCM2C/QIURhJMuKaekP3TRBxBKxG/TWWA0TL2J6nXUtDnuCtccy49LUJF8xPFXMX+0LMcxFpCo8M9cGY1W6rQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@opentelemetry/semantic-conventions": "1.28.0"
       },
@@ -3600,6 +3606,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.30.1.tgz",
       "integrity": "sha512-5UxZqiAgLYGFjS4s9qm5mBVo433u+dSPUFWVWXmLAD4wB65oMCoXaJP1KJa9DIYYMeHu3z4BZcStG3LC593cWA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "1.30.1",
         "@opentelemetry/semantic-conventions": "1.28.0"
@@ -3625,6 +3632,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.30.1.tgz",
       "integrity": "sha512-jVPgBbH1gCy2Lb7X0AVQ8XAfgg0pJ4nvl8/IiQA6nxOsPvS+0zMJaFSs2ltXe0J6C8dqjcnpyqINDJmU30+uOg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "1.30.1",
         "@opentelemetry/resources": "1.30.1",
@@ -3651,6 +3659,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.36.0.tgz",
       "integrity": "sha512-TtxJSRD8Ohxp6bKkhrm27JRHAxPczQA7idtcTOMYI+wQRRrfgqxHv1cFbCApcSnNjtXkmzFozn6jQtFrOmbjPQ==",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=14"
       }
@@ -4585,6 +4594,7 @@
       "resolved": "https://registry.npmjs.org/@svgr/core/-/core-8.1.0.tgz",
       "integrity": "sha512-8QqtOQT5ACVlmsvKOJNEaWmRPmcojMOzCz4Hs2BGG/toAp/K38LcsMRyLp349glq5AzJbCEeimEoxaX6v/fLrA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@babel/core": "^7.21.3",
         "@svgr/babel-preset": "8.1.0",
@@ -4816,6 +4826,7 @@
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz",
       "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@types/estree": "*",
         "@types/json-schema": "*"
@@ -4995,7 +5006,8 @@
       "version": "20.4.9",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.4.9.tgz",
       "integrity": "sha512-8e2HYcg7ohnTUbHk8focoklEQYvemQmu9M/f43DZVx43kHn0tE3BY/6gSDxS7k0SprtS0NHvj+L80cGLnoOUcQ==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "node_modules/@types/node-forge": {
       "version": "1.3.11",
@@ -5179,6 +5191,7 @@
       "resolved": "https://registry.npmjs.org/@types/webpack/-/webpack-4.41.38.tgz",
       "integrity": "sha512-oOW7E931XJU1mVfCnxCVgv8GLFL768pDO5u2Gzk82i8yTIgX6i7cntyZOkZYb/JtYM8252SN9bQp9tgkVDSsRw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@types/node": "*",
         "@types/tapable": "^1",
@@ -5295,6 +5308,7 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.21.0.tgz",
       "integrity": "sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "6.21.0",
         "@typescript-eslint/types": "6.21.0",
@@ -6195,6 +6209,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
       "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
       "dev": true,
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -6268,6 +6283,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -7173,6 +7189,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001688",
         "electron-to-chromium": "^1.5.73",
@@ -8955,7 +8972,8 @@
       "version": "0.0.1478340",
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1478340.tgz",
       "integrity": "sha512-EqhRVWo+j3O1a5LEvZi5fFlBRhvciqYoCHpsEfPcIpA/Abh0W1LF+V3AIvQD9Z4Apj0+p3U07vb7uXfn2hm3HQ==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "node_modules/diff-sequences": {
       "version": "29.6.3",
@@ -9533,6 +9551,7 @@
       "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -9588,6 +9607,7 @@
       "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.10.2.tgz",
       "integrity": "sha512-/IGJ6+Dka158JnP5n5YFMOszjDWrXggGz1LaK/guZq9vZTmniaKlHcsscvkAhn9y4U+BU3JuUdYvtAMcv30y4A==",
       "dev": true,
+      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -12870,6 +12890,7 @@
       "resolved": "https://registry.npmjs.org/jest/-/jest-29.7.0.tgz",
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -13956,7 +13977,8 @@
       "version": "0.0.1475386",
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1475386.tgz",
       "integrity": "sha512-RQ809ykTfJ+dgj9bftdeL2vRVxASAuGU+I9LEx9Ij5TXU5HrgAQVmzi72VA+mkzscE12uzlRv5/tWWv9R9J1SA==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "node_modules/lighthouse/node_modules/puppeteer-core/node_modules/ws": {
       "version": "8.18.3",
@@ -14931,6 +14953,7 @@
       "resolved": "https://registry.npmjs.org/npm-package-json-lint/-/npm-package-json-lint-6.4.0.tgz",
       "integrity": "sha512-cuXAJJB1Rdqz0UO6w524matlBqDBjcNt7Ru+RDIu4y6RI1gVqiWBnylrK8sPRk81gGBA0X8hJbDXolVOoTc+sA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "ajv": "^6.12.6",
         "ajv-errors": "^1.0.1",
@@ -15957,7 +15980,6 @@
       "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.54.2.tgz",
       "integrity": "sha512-Hu/BMoA1NAdRUuulyvQC0pEqZ4vQbGfn8f7wPXcnqQmM+zct9UliKxsIkLNmz/ku7LElUNqmaiv1TG/aL5ACsw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "playwright-core": "1.54.2"
       },
@@ -15976,7 +15998,6 @@
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.54.2.tgz",
       "integrity": "sha512-n5r4HFbMmWsB4twG7tJLDN9gmBUeSPcsBZiWSE4DnYz9mJMAFqr2ID7+eGC9kpEnxExJ1epttwR59LEWCk8mtA==",
       "dev": true,
-      "peer": true,
       "bin": {
         "playwright-core": "cli.js"
       },
@@ -15994,7 +16015,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
@@ -16042,6 +16062,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -16704,6 +16725,7 @@
       "resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-3.0.3.tgz",
       "integrity": "sha512-X4UlrxDTH8oom9qXlcjnydsjAOD2BmB6yFmvS4Z2zdTzqqpRWb+fbqrH412+l+OUXmbzJlSXjlMFYPgYG12IAA==",
       "dev": true,
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -17078,6 +17100,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -17110,6 +17133,7 @@
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.2.tgz",
       "integrity": "sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -17796,7 +17820,6 @@
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
       "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       }
@@ -17825,6 +17848,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -18955,6 +18979,7 @@
           "url": "https://github.com/sponsors/stylelint"
         }
       ],
+      "peer": true,
       "dependencies": {
         "@csstools/css-parser-algorithms": "^3.0.5",
         "@csstools/css-tokenizer": "^3.0.4",
@@ -19326,6 +19351,7 @@
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.0.tgz",
       "integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -19969,6 +19995,7 @@
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
       "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -20472,6 +20499,7 @@
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.97.1.tgz",
       "integrity": "sha512-EksG6gFY3L1eFMROS/7Wzgrii5mBAFe4rIr3r2BTfo7bcc+DWwFZ4OJ/miOuHJO/A85HwyI4eQ0F6IKXesO7Fg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.6",
@@ -20574,6 +20602,7 @@
       "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-5.1.4.tgz",
       "integrity": "sha512-pIDJHIEI9LR0yxHXQ+Qh95k2EvXpWzZ5l+d+jIo+RdSm9MiHfzazIxwwni/p7+x4eJZuvG1AJwgC4TNQ7NRgsg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@discoveryjs/json-ext": "^0.5.0",
         "@webpack-cli/configtest": "^2.1.1",
@@ -20651,6 +20680,7 @@
       "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-4.15.2.tgz",
       "integrity": "sha512-0XavAZbNJ5sDrCbkpWL8mia0o5WPOd2YGtxrEiZkBK9FjLppIUK2TgxK6qGD2P3hUXTJNNPVibrerKcx5WkR1g==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@types/bonjour": "^3.5.9",
         "@types/connect-history-api-fallback": "^1.3.5",
@@ -21226,6 +21256,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.25.7.tgz",
       "integrity": "sha512-yJ474Zv3cwiSOO9nXJuqzvwEeM+chDuQ8GJirw+pZ91sCGCyOZ3dJkVE09fTV0VEVzXyLWhh3G/AolYTPX7Mow==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.25.7",
@@ -22532,13 +22563,15 @@
       "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
       "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
       "dev": true,
+      "peer": true,
       "requires": {}
     },
     "@csstools/css-tokenizer": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
       "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "@csstools/media-query-list-parser": {
       "version": "3.0.1",
@@ -23364,7 +23397,8 @@
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "@opentelemetry/api-logs": {
       "version": "0.57.2",
@@ -23380,6 +23414,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.30.1.tgz",
       "integrity": "sha512-s5vvxXPVdjqS3kTLKMeBMvop9hbWkwzBpu+mUO2M7sZtlkyDJGwFe33wRKnbaYDo8ExRVBIIdwIGrqpxHuKttA==",
       "dev": true,
+      "peer": true,
       "requires": {}
     },
     "@opentelemetry/core": {
@@ -23387,6 +23422,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.30.1.tgz",
       "integrity": "sha512-OOCM2C/QIURhJMuKaekP3TRBxBKxG/TWWA0TL2J6nXUtDnuCtccy49LUJF8xPFXMX+0LMcxFpCo8M9cGY1W6rQ==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@opentelemetry/semantic-conventions": "1.28.0"
       },
@@ -23681,6 +23717,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.30.1.tgz",
       "integrity": "sha512-5UxZqiAgLYGFjS4s9qm5mBVo433u+dSPUFWVWXmLAD4wB65oMCoXaJP1KJa9DIYYMeHu3z4BZcStG3LC593cWA==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@opentelemetry/core": "1.30.1",
         "@opentelemetry/semantic-conventions": "1.28.0"
@@ -23699,6 +23736,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.30.1.tgz",
       "integrity": "sha512-jVPgBbH1gCy2Lb7X0AVQ8XAfgg0pJ4nvl8/IiQA6nxOsPvS+0zMJaFSs2ltXe0J6C8dqjcnpyqINDJmU30+uOg==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@opentelemetry/core": "1.30.1",
         "@opentelemetry/resources": "1.30.1",
@@ -23717,7 +23755,8 @@
       "version": "1.36.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.36.0.tgz",
       "integrity": "sha512-TtxJSRD8Ohxp6bKkhrm27JRHAxPczQA7idtcTOMYI+wQRRrfgqxHv1cFbCApcSnNjtXkmzFozn6jQtFrOmbjPQ==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "@opentelemetry/sql-common": {
       "version": "0.40.1",
@@ -24255,6 +24294,7 @@
       "resolved": "https://registry.npmjs.org/@svgr/core/-/core-8.1.0.tgz",
       "integrity": "sha512-8QqtOQT5ACVlmsvKOJNEaWmRPmcojMOzCz4Hs2BGG/toAp/K38LcsMRyLp349glq5AzJbCEeimEoxaX6v/fLrA==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@babel/core": "^7.21.3",
         "@svgr/babel-preset": "8.1.0",
@@ -24435,6 +24475,7 @@
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz",
       "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@types/estree": "*",
         "@types/json-schema": "*"
@@ -24613,7 +24654,8 @@
       "version": "20.4.9",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.4.9.tgz",
       "integrity": "sha512-8e2HYcg7ohnTUbHk8focoklEQYvemQmu9M/f43DZVx43kHn0tE3BY/6gSDxS7k0SprtS0NHvj+L80cGLnoOUcQ==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "@types/node-forge": {
       "version": "1.3.11",
@@ -24795,6 +24837,7 @@
       "resolved": "https://registry.npmjs.org/@types/webpack/-/webpack-4.41.38.tgz",
       "integrity": "sha512-oOW7E931XJU1mVfCnxCVgv8GLFL768pDO5u2Gzk82i8yTIgX6i7cntyZOkZYb/JtYM8252SN9bQp9tgkVDSsRw==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@types/node": "*",
         "@types/tapable": "^1",
@@ -24889,6 +24932,7 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.21.0.tgz",
       "integrity": "sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@typescript-eslint/scope-manager": "6.21.0",
         "@typescript-eslint/types": "6.21.0",
@@ -25528,7 +25572,8 @@
       "version": "8.14.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
       "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "acorn-globals": {
       "version": "7.0.1",
@@ -25583,6 +25628,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
+      "peer": true,
       "requires": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -26216,6 +26262,7 @@
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.4.tgz",
       "integrity": "sha512-KDi1Ny1gSePi1vm0q4oxSF8b4DR44GF4BbmS2YdhPLOEqd8pDviZOGH/GsmRwoWJ2+5Lr085X7naowMwKHDG1A==",
       "dev": true,
+      "peer": true,
       "requires": {
         "caniuse-lite": "^1.0.30001688",
         "electron-to-chromium": "^1.5.73",
@@ -27484,7 +27531,8 @@
       "version": "0.0.1478340",
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1478340.tgz",
       "integrity": "sha512-EqhRVWo+j3O1a5LEvZi5fFlBRhvciqYoCHpsEfPcIpA/Abh0W1LF+V3AIvQD9Z4Apj0+p3U07vb7uXfn2hm3HQ==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "diff-sequences": {
       "version": "29.6.3",
@@ -27922,6 +27970,7 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.1.tgz",
       "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -28044,6 +28093,7 @@
       "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.10.2.tgz",
       "integrity": "sha512-/IGJ6+Dka158JnP5n5YFMOszjDWrXggGz1LaK/guZq9vZTmniaKlHcsscvkAhn9y4U+BU3JuUdYvtAMcv30y4A==",
       "dev": true,
+      "peer": true,
       "requires": {}
     },
     "eslint-import-resolver-node": {
@@ -30279,6 +30329,7 @@
       "resolved": "https://registry.npmjs.org/jest/-/jest-29.7.0.tgz",
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -31108,7 +31159,8 @@
               "version": "0.0.1475386",
               "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1475386.tgz",
               "integrity": "sha512-RQ809ykTfJ+dgj9bftdeL2vRVxASAuGU+I9LEx9Ij5TXU5HrgAQVmzi72VA+mkzscE12uzlRv5/tWWv9R9J1SA==",
-              "dev": true
+              "dev": true,
+              "peer": true
             },
             "ws": {
               "version": "8.18.3",
@@ -31857,6 +31909,7 @@
       "resolved": "https://registry.npmjs.org/npm-package-json-lint/-/npm-package-json-lint-6.4.0.tgz",
       "integrity": "sha512-cuXAJJB1Rdqz0UO6w524matlBqDBjcNt7Ru+RDIu4y6RI1gVqiWBnylrK8sPRk81gGBA0X8hJbDXolVOoTc+sA==",
       "dev": true,
+      "peer": true,
       "requires": {
         "ajv": "^6.12.6",
         "ajv-errors": "^1.0.1",
@@ -32625,7 +32678,6 @@
       "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.54.2.tgz",
       "integrity": "sha512-Hu/BMoA1NAdRUuulyvQC0pEqZ4vQbGfn8f7wPXcnqQmM+zct9UliKxsIkLNmz/ku7LElUNqmaiv1TG/aL5ACsw==",
       "dev": true,
-      "peer": true,
       "requires": {
         "fsevents": "2.3.2",
         "playwright-core": "1.54.2"
@@ -32636,8 +32688,7 @@
           "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
           "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
           "dev": true,
-          "optional": true,
-          "peer": true
+          "optional": true
         }
       }
     },
@@ -32645,8 +32696,7 @@
       "version": "1.54.2",
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.54.2.tgz",
       "integrity": "sha512-n5r4HFbMmWsB4twG7tJLDN9gmBUeSPcsBZiWSE4DnYz9mJMAFqr2ID7+eGC9kpEnxExJ1epttwR59LEWCk8mtA==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "plur": {
       "version": "4.0.0",
@@ -32668,6 +32718,7 @@
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
       "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
       "dev": true,
+      "peer": true,
       "requires": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -33071,7 +33122,8 @@
       "version": "npm:wp-prettier@3.0.3",
       "resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-3.0.3.tgz",
       "integrity": "sha512-X4UlrxDTH8oom9qXlcjnydsjAOD2BmB6yFmvS4Z2zdTzqqpRWb+fbqrH412+l+OUXmbzJlSXjlMFYPgYG12IAA==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "prettier-linter-helpers": {
       "version": "1.0.0",
@@ -33346,6 +33398,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "dev": true,
+      "peer": true,
       "requires": {
         "loose-envify": "^1.1.0"
       }
@@ -33371,7 +33424,8 @@
       "version": "0.14.2",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.2.tgz",
       "integrity": "sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "read-pkg": {
       "version": "5.2.0",
@@ -33867,7 +33921,6 @@
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
       "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
       "dev": true,
-      "peer": true,
       "requires": {
         "loose-envify": "^1.1.0"
       }
@@ -33889,6 +33942,7 @@
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
           "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
           "dev": true,
+          "peer": true,
           "requires": {
             "fast-deep-equal": "^3.1.3",
             "fast-uri": "^3.0.1",
@@ -34788,6 +34842,7 @@
       "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-16.23.1.tgz",
       "integrity": "sha512-dNvDTsKV1U2YtiUDfe9d2gp902veFeo3ecCWdGlmLm2WFrAV0+L5LoOj/qHSBABQwMsZPJwfC4bf39mQm1S5zw==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@csstools/css-parser-algorithms": "^3.0.5",
         "@csstools/css-tokenizer": "^3.0.4",
@@ -34961,6 +35016,7 @@
           "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.0.tgz",
           "integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
           "dev": true,
+          "peer": true,
           "requires": {
             "cssesc": "^3.0.0",
             "util-deprecate": "^1.0.2"
@@ -35528,7 +35584,8 @@
       "version": "0.21.3",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
       "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "type-is": {
       "version": "1.6.18",
@@ -35901,6 +35958,7 @@
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.97.1.tgz",
       "integrity": "sha512-EksG6gFY3L1eFMROS/7Wzgrii5mBAFe4rIr3r2BTfo7bcc+DWwFZ4OJ/miOuHJO/A85HwyI4eQ0F6IKXesO7Fg==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.6",
@@ -35980,6 +36038,7 @@
       "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-5.1.4.tgz",
       "integrity": "sha512-pIDJHIEI9LR0yxHXQ+Qh95k2EvXpWzZ5l+d+jIo+RdSm9MiHfzazIxwwni/p7+x4eJZuvG1AJwgC4TNQ7NRgsg==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@discoveryjs/json-ext": "^0.5.0",
         "@webpack-cli/configtest": "^2.1.1",
@@ -36022,6 +36081,7 @@
       "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-4.15.2.tgz",
       "integrity": "sha512-0XavAZbNJ5sDrCbkpWL8mia0o5WPOd2YGtxrEiZkBK9FjLppIUK2TgxK6qGD2P3hUXTJNNPVibrerKcx5WkR1g==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@types/bonjour": "^3.5.9",
         "@types/connect-history-api-fallback": "^1.3.5",

--- a/templates/results-complete.php
+++ b/templates/results-complete.php
@@ -1,3 +1,13 @@
 <div class="notice notice-{{ data.type }}">
-    <p><?php esc_html_e( 'Checks complete.', 'plugin-check' ); ?> {{ data.message }}</p>
+	<p><?php esc_html_e( 'Checks complete.', 'plugin-check' ); ?> {{ data.message }}</p>
+</div>
+
+<div class="pcp-download-report" style="margin:12px 0;">
+	<button type="button" class="button button-primary" id="pcp-download-report-button">
+		<?php esc_html_e( 'Download Report', 'plugin-check' ); ?>
+	</button>
+	<div id="pcp-download-menu" class="hide-if-js" style="display:none; margin-top:6px;">
+		<a id="pcp-export-csv" class="button" href="#"><?php esc_html_e( 'Download as CSV', 'plugin-check' ); ?></a>
+		<a id="pcp-export-pdf" class="button" href="#"><?php esc_html_e( 'Download as PDF', 'plugin-check' ); ?></a>
+	</div>
 </div>


### PR DESCRIPTION
**Summary**

This PR adds the ability for users to download Plugin Check scan results as PDF or CSV files directly from the results page.
The export feature helps developers and site owners store, share, and review scan reports outside the WordPress admin.

**Key Features Added**

1. PDF Export - Generates a clean, printable PDF version of the scan report, which includes Report title, Timestamp, and Table of issues with severity, file, line, and message.
2. CSV Export - Produces a UTF-8 CSV file compatible with Excel, Google Sheets, etc.
3. UI Enhancements - Added a “Download Report” dropdown button in the results screen.
4. New Export Handler - Added new class: includes/Admin/Report_Exporter.php
This class Prepares scan result data, Handles export logic for both PDF and CSV, Performs capability checks, Validates nonces, Sends proper content headers
5. Hooks & Endpoints

**Security**

- Export actions protected via: Nonces, current_user_can( 'manage_options' ) capability checks, and Sanitization and escaping of parameters

**Testing Done**

- Verified PDF downloads correctly with valid formatting.
- Verified CSV downloads and opens in spreadsheet tools.
- Checked nonce expiration behavior.
- Ensured PHPCS compliance with WordPress coding standards.