### PR TITLE
Playground Integration Fixed

### DIFF
--- a/.wordpress-org/blueprints/blueprint.json
+++ b/.wordpress-org/blueprints/blueprint.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://playground.wordpress.net/blueprint-schema.json",
-  "landingPage": "\/wp-admin\/tools.php?page=plugin-check",
+  "landingPage": "/wp-admin/tools.php?page=plugin-check",
   "phpExtensionBundles": [
     "kitchen-sink"
   ],
@@ -13,7 +13,7 @@
     {
       "step": "installPlugin",
       "pluginZipFile": {
-        "resource": "wordpress.org\/plugins",
+        "resource": "wordpress.org/plugins",
         "slug": "plugin-check"
       },
       "options": {


### PR DESCRIPTION
Current blueprint not working. In this Pr, update it.

For Test: [Playground Builder](https://playground.wordpress.net/builder/builder.html)

Fixed #1084

Here is some explanation about this Pr https://github.com/WordPress/performance/pull/2280
