### PR TITLE
Fix readme contributors validation for trailing commas

### DIFF
--- a/includes/Checker/Checks/Plugin_Repo/Plugin_Readme_Check.php
+++ b/includes/Checker/Checks/Plugin_Repo/Plugin_Readme_Check.php
@@ -755,7 +755,7 @@ class Plugin_Readme_Check extends Abstract_File_Check {
 		}
 
 		$usernames = explode( ',', trim( $matches[1], ' ,' ) );
-		$usernames = array_filter( array_unique( array_map( 'trim', $usernames ) ), 'strlen' );
+		$usernames = array_filter( array_unique( array_map( 'trim', $usernames ) ) );
 
 		$valid = true;
 

--- a/includes/Checker/Checks/Plugin_Repo/Plugin_Readme_Check.php
+++ b/includes/Checker/Checks/Plugin_Repo/Plugin_Readme_Check.php
@@ -754,9 +754,8 @@ class Plugin_Readme_Check extends Abstract_File_Check {
 			return;
 		}
 
-		$usernames = explode( ',', $matches[1] );
-
-		$usernames = array_unique( array_map( 'trim', $usernames ) );
+		$usernames = explode( ',', trim( $matches[1], ' ,' ) );
+		$usernames = array_filter( array_unique( array_map( 'trim', $usernames ) ), 'strlen' );
 
 		$valid = true;
 

--- a/tests/phpunit/testdata/plugins/test-plugin-readme-contributors-formatting/load.php
+++ b/tests/phpunit/testdata/plugins/test-plugin-readme-contributors-formatting/load.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * Plugin Name: Test Plugin Readme Contributors Formatting
+ * Plugin URI: https://github.com/WordPress/plugin-check
+ * Description: Test plugin for the Readme check contributors formatting functionality.
+ * Requires at least: 6.0
+ * Requires PHP: 5.6
+ * Version: 1.0.0
+ * Author: WordPress Performance Team
+ * Author URI: https://make.wordpress.org/performance/
+ * License: GPLv2 or later
+ * License URI: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+ * Text Domain: test-plugin-check-contributors-formatting
+ *
+ * @package test-plugin-check-contributors-formatting
+ */
+

--- a/tests/phpunit/testdata/plugins/test-plugin-readme-contributors-formatting/readme.txt
+++ b/tests/phpunit/testdata/plugins/test-plugin-readme-contributors-formatting/readme.txt
@@ -1,0 +1,13 @@
+=== Test Plugin Readme Contributors Formatting ===
+
+Contributors:      johndoe, janedoe,
+Requires at least: 6.0 or above
+Tested up to:      6.6
+Requires PHP:      5.6
+Stable tag:        1.0.0
+License:           GPLv2 or later
+License URI:       https://www.gnu.org/licenses/gpl-2.0.html
+Tags:              testing, security
+
+Plugin description.
+

--- a/tests/phpunit/tests/Checker/Checks/Plugin_Readme_Check_Tests.php
+++ b/tests/phpunit/tests/Checker/Checks/Plugin_Readme_Check_Tests.php
@@ -608,6 +608,19 @@ class Plugin_Readme_Check_Tests extends WP_UnitTestCase {
 		$this->assertCount( 0, wp_list_filter( $warnings['readme.txt'][0][0], array( 'code' => 'readme_invalid_contributors' ) ) );
 	}
 
+	public function test_run_without_errors_readme_contributors_formatting() {
+		$readme_check  = new Plugin_Readme_Check();
+		$check_context = new Check_Context( UNIT_TESTS_PLUGIN_DIR . 'test-plugin-readme-contributors-formatting/load.php' );
+		$check_result  = new Check_Result( $check_context );
+
+		$readme_check->run( $check_result );
+
+		$warnings = $check_result->get_warnings();
+
+		// Should not contain contributors warning even with leading/trailing spaces and commas.
+		$this->assertCount( 0, wp_list_filter( $warnings['readme.txt'][0][0], array( 'code' => 'readme_invalid_contributors' ) ) );
+	}
+
 	public function test_run_with_mismatched_requires_headers() {
 		$check         = new Plugin_Readme_Check();
 		$check_context = new Check_Context( UNIT_TESTS_PLUGIN_DIR . 'test-trademarks-plugin-readme-errors/load.php' );


### PR DESCRIPTION
**Issue**

This is a pretty edge case. When contributors have a trailing comma, the code incorrectly triggers a `readme_invalid_contributors` error for valid contributors:

**Minimal example:**
```
Contributors: username1, username2, username3,
```

Meta handles this correctly. This PR brings parity with Meta.

**This PR:**

- Fixes the trim logic to properly handle trailing commas and spaces
- Adds a test case to verify contributors with trailing commas are handled correctly

