### PR TITLE
Fix PayPal donation URL validation for complex query strings

### DIFF
--- a/includes/Traits/URL_Utils.php
+++ b/includes/Traits/URL_Utils.php
@@ -23,14 +23,39 @@ trait URL_Utils {
 	 * @return bool true if the URL is valid, otherwise false.
 	 */
 	protected function is_valid_url( string $url ): bool {
-		if ( filter_var( $url, FILTER_VALIDATE_URL ) !== $url || ! str_starts_with( $url, 'http' ) ) {
+		// Must start with http or https.
+		if ( ! str_starts_with( $url, 'http' ) ) {
 			return false;
 		}
 
-		// Detect duplicated protocol (e.g., "https://http://example.com/").
+		// Parse the URL to validate its structure.
 		$parsed_url = wp_parse_url( $url );
 
-		if ( isset( $parsed_url['scheme'] ) && str_contains( substr( $url, strlen( $parsed_url['scheme'] ) + 3 ), '://' ) ) {
+		// wp_parse_url returns false on parse failure.
+		if ( false === $parsed_url || ! is_array( $parsed_url ) ) {
+			return false;
+		}
+
+		// Must have a valid scheme and host.
+		if ( empty( $parsed_url['scheme'] ) || empty( $parsed_url['host'] ) ) {
+			return false;
+		}
+
+		// Scheme must be http or https.
+		if ( ! in_array( $parsed_url['scheme'], array( 'http', 'https' ), true ) ) {
+			return false;
+		}
+
+		// Detect duplicated protocol in the host/path portion (e.g., "https://http://example.com/").
+		// Only check up to the query string to avoid false positives with URLs in query parameters.
+		$url_without_query = strtok( $url, '?' );
+		if ( false !== $url_without_query && str_contains( substr( $url_without_query, strlen( $parsed_url['scheme'] ) + 3 ), '://' ) ) {
+			return false;
+		}
+
+		// Validate host doesn't contain obviously invalid characters.
+		// Allow alphanumeric, dots, hyphens, and underscores (for localhost, etc.).
+		if ( preg_match( '/[^a-z0-9.\-_]/i', $parsed_url['host'] ) ) {
 			return false;
 		}
 

--- a/includes/Traits/URL_Utils.php
+++ b/includes/Traits/URL_Utils.php
@@ -36,16 +36,29 @@ trait URL_Utils {
 			return false;
 		}
 
-		// Must have a valid scheme and host.
+		// Must have a valid scheme and host, and scheme must be http or https.
 		if ( empty( $parsed_url['scheme'] ) || empty( $parsed_url['host'] ) ) {
 			return false;
 		}
 
-		// Scheme must be http or https.
 		if ( ! in_array( $parsed_url['scheme'], array( 'http', 'https' ), true ) ) {
 			return false;
 		}
 
+		// Check for duplicated protocol and invalid host characters.
+		return $this->validate_url_structure( $url, $parsed_url );
+	}
+
+	/**
+	 * Validates URL structure for duplicated protocols and invalid host characters.
+	 *
+	 * @since 1.6.0
+	 *
+	 * @param string $url        The full URL.
+	 * @param array  $parsed_url Parsed URL array.
+	 * @return bool true if the URL structure is valid, otherwise false.
+	 */
+	private function validate_url_structure( string $url, array $parsed_url ): bool {
 		// Detect duplicated protocol in the host/path portion (e.g., "https://http://example.com/").
 		// Only check up to the query string to avoid false positives with URLs in query parameters.
 		$url_without_query = strtok( $url, '?' );

--- a/includes/Traits/URL_Utils.php
+++ b/includes/Traits/URL_Utils.php
@@ -36,39 +36,32 @@ trait URL_Utils {
 			return false;
 		}
 
-		// Must have a valid scheme and host, and scheme must be http or https.
+		// Must have a valid scheme and host.
 		if ( empty( $parsed_url['scheme'] ) || empty( $parsed_url['host'] ) ) {
-			return false;
-		}
-
-		if ( ! in_array( $parsed_url['scheme'], array( 'http', 'https' ), true ) ) {
-			return false;
-		}
-
-		// Check for duplicated protocol and invalid host characters.
-		return $this->validate_url_structure( $url, $parsed_url );
-	}
-
-	/**
-	 * Validates URL structure for duplicated protocols and invalid host characters.
-	 *
-	 * @since 1.6.0
-	 *
-	 * @param string $url        The full URL.
-	 * @param array  $parsed_url Parsed URL array.
-	 * @return bool true if the URL structure is valid, otherwise false.
-	 */
-	private function validate_url_structure( string $url, array $parsed_url ): bool {
-		// Detect duplicated protocol in the host/path portion (e.g., "https://http://example.com/").
-		// Only check up to the query string to avoid false positives with URLs in query parameters.
-		$url_without_query = strtok( $url, '?' );
-		if ( false !== $url_without_query && str_contains( substr( $url_without_query, strlen( $parsed_url['scheme'] ) + 3 ), '://' ) ) {
 			return false;
 		}
 
 		// Validate host doesn't contain obviously invalid characters.
 		// Allow alphanumeric, dots, hyphens, and underscores (for localhost, etc.).
 		if ( preg_match( '/[^a-z0-9.\-_]/i', $parsed_url['host'] ) ) {
+			return false;
+		}
+
+		// Detect duplicated protocol in the host/path portion (e.g., "https://http://example.com/").
+		// Only check up to the query string to avoid false positives with URLs in query parameters.
+		$query_position = strpos( $url, '?' );
+
+		if ( false !== $query_position ) {
+			$url_without_query = substr( $url, 0, $query_position );
+		} else {
+			$url_without_query = $url;
+		}
+
+		// Check for duplicated protocol after the scheme:// portion.
+		$scheme_length = strlen( $parsed_url['scheme'] );
+		$after_scheme  = substr( $url_without_query, $scheme_length + 3 );
+
+		if ( str_contains( $after_scheme, '://' ) ) {
 			return false;
 		}
 

--- a/tests/phpunit/testdata/plugins/test-plugin-plugin-readme-valid-paypal-donate/load.php
+++ b/tests/phpunit/testdata/plugins/test-plugin-plugin-readme-valid-paypal-donate/load.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * Plugin Name: Test Plugin with Valid PayPal Donate Link
+ * Plugin URI:  https://wordpress.org/plugins/test-plugin/
+ * Description: Test plugin for valid PayPal donation URL.
+ * Version:     1.0.0
+ * Author:      plugin-check
+ * Author URI:  https://wordpress.org/plugins/test-plugin/
+ * License:     GPL-2.0+
+ * License URI: https://www.gnu.org/licenses/gpl-2.0.html
+ * Text Domain: test-plugin
+ */

--- a/tests/phpunit/testdata/plugins/test-plugin-plugin-readme-valid-paypal-donate/readme.txt
+++ b/tests/phpunit/testdata/plugins/test-plugin-plugin-readme-valid-paypal-donate/readme.txt
@@ -1,0 +1,13 @@
+=== Test Plugin with Valid PayPal Donate Link ===
+
+Contributors:      plugin-check
+Requires at least: 6.0
+Tested up to:      6.1
+Requires PHP:      5.6
+Stable tag:        1.0.0
+License:           GPLv2 or later
+License URI:       https://www.gnu.org/licenses/gpl-2.0.html
+Donate Link:       https://www.paypal.com/cgi-bin/webscr?cmd=_xclick&business=developer@gmail.com&item_name=WordPress%20Plugin%20Donation&return=https://wordpress.org/plugins/my-plugin/
+Tags:              tag1, testing, security
+
+Here is a short description of the plugin.

--- a/tests/phpunit/tests/Checker/Checks/Plugin_Readme_Check_Tests.php
+++ b/tests/phpunit/tests/Checker/Checks/Plugin_Readme_Check_Tests.php
@@ -652,6 +652,25 @@ class Plugin_Readme_Check_Tests extends WP_UnitTestCase {
 		$this->assertCount( 1, wp_list_filter( $errors['readme.txt'][0][0], array( 'code' => 'readme_invalid_donate_link_domain' ) ) );
 	}
 
+	public function test_run_with_valid_paypal_donate_link() {
+		$check         = new Plugin_Readme_Check();
+		$check_context = new Check_Context( UNIT_TESTS_PLUGIN_DIR . 'test-plugin-plugin-readme-valid-paypal-donate/load.php' );
+		$check_result  = new Check_Result( $check_context );
+
+		$check->run( $check_result );
+
+		$errors = $check_result->get_errors();
+
+		// Should not have invalid donate link error for PayPal URLs with complex query strings.
+		if ( isset( $errors['readme.txt'] ) && isset( $errors['readme.txt'][0][0] ) ) {
+			$invalid_donate_link_errors = wp_list_filter( $errors['readme.txt'][0][0], array( 'code' => 'readme_invalid_donate_link' ) );
+			$this->assertEmpty( $invalid_donate_link_errors, 'PayPal donation URL with complex query string should be recognized as valid' );
+		} else {
+			// If no errors at all, that's also fine - the URL is valid.
+			$this->assertTrue( true );
+		}
+	}
+
 	public function test_run_language_detection_with_non_english_content() {
 		$check         = new Plugin_Readme_Check();
 		$check_context = new Check_Context( UNIT_TESTS_PLUGIN_DIR . 'test-plugin-plugin-readme-errors-language/load.php' );

--- a/tests/phpunit/tests/Traits/URL_Utils_Tests.php
+++ b/tests/phpunit/tests/Traits/URL_Utils_Tests.php
@@ -26,6 +26,11 @@ class URL_Utils_Tests extends WP_UnitTestCase {
 			array( 'https://example.com/page.html', true ),
 			array( 'https://http://example.com/', false ),
 			array( 'ftp://example.com/file.txt', false ),
+			// PayPal donation URLs with complex query strings.
+			array( 'https://www.paypal.com/cgi-bin/webscr?cmd=_xclick&business=developer@gmail.com&item_name=WordPress%20Plugin%20Donation&return=https://wordpress.org/plugins/my-plugin/', true ),
+			array( 'https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=test@example.com&item_name=Support%20My%20Plugin', true ),
+			array( 'https://paypal.me/username/5USD', true ),
+			array( 'https://www.paypal.com/donate/?hosted_button_id=123456', true ),
 		);
 	}
 


### PR DESCRIPTION
# Description

Fixes #1150 — PayPal donation URLs with complex query strings are now correctly recognized as valid.

The donate link validation incorrectly flagged valid PayPal donation URLs as invalid when they contained URLs in query parameters (e.g., `return=https://wordpress.org/plugins/my-plugin/`).

## Changes

- **Updated `is_valid_url()` method** (`includes/Traits/URL_Utils.php`):
  - Replaced strict `filter_var()` validation with a more lenient approach using `wp_parse_url()`
  - Added proper handling for when `wp_parse_url()` returns `false` or non-array values
  - Fixed duplicated protocol detection to only check the URL portion before the query string (`?`), preventing false positives when URLs appear in query parameters
  - Improved host validation to allow valid characters (alphanumeric, dots, hyphens, underscores)

- **Added test cases** (`tests/phpunit/tests/Traits/URL_Utils_Tests.php`):
  - Added test cases for PayPal donation URLs including:
    - The exact URL from issue #1150
    - Other PayPal donation URL formats (`paypal.me`, `paypal.com/donate`, etc.)

- **Added integration test** (`tests/phpunit/tests/Checker/Checks/Plugin_Readme_Check_Tests.php`):
  - Added `test_run_with_valid_paypal_donate_link()` to verify the full check flow
  - Created test plugin `test-plugin-plugin-readme-valid-paypal-donate` with a valid PayPal donation URL

## Benefits

- PayPal donation URLs with complex query strings are now correctly validated
- Reduces false positives for valid donation links
- Maintains security by still detecting truly invalid URLs and duplicated protocols
- Better handling of URLs that contain other URLs in query parameters

## Checklist

- [x] Code follows WordPress Coding Standards
- [x] Self-reviewed the code
- [x] Added necessary comments
- [x] No new linter errors
- [x] Added test cases to prevent regression
- [x] All existing tests pass
- [x] New tests pass
