### PR TITLE
Accept WTFPL as a GPL-compatible license 

### DIFF
--- a/includes/Traits/License_Utils.php
+++ b/includes/Traits/License_Utils.php
@@ -56,8 +56,10 @@ trait License_Utils {
 		$license = preg_replace( '/GPL\s*[-|\.]*\s*[v]?([0-9])(\.[0])?/i', 'GPL$1', $license, 1 );
 		$license = preg_replace( '/Apache.*?([0-9])(\.[0])?/i', 'Apache$1', $license );
 		$license = preg_replace( '/(The\s+)?Unlicense/i', 'Unlicense', $license );
-		// Normalize WTFPL variations.
+		// Normalize WTFPL variations - must come before version removal to catch full text.
 		$license = preg_replace( '/Do\s+What\s+The\s+F[^\s]*\s+You\s+Want\s+To\s+Public\s+License/i', 'WTFPL', $license );
+		// Remove version numbers from WTFPL (e.g., "WTFPL v2" -> "WTFPL").
+		$license = preg_replace( '/WTFPL\s*[v]?([0-9])/i', 'WTFPL', $license );
 		$license = str_replace( '.', '', $license );
 
 		return $license;
@@ -86,6 +88,12 @@ trait License_Utils {
 	 * @return bool true if the license is GPL compatible, otherwise false.
 	 */
 	protected function is_license_gpl_compatible( $license ) {
+		// Check for WTFPL in full text form before normalization.
+		$wtfpl_match = preg_match( '/Do\s+What\s+The\s+F[^\s]*\s+You\s+Want\s+To\s+Public\s+License/i', $license );
+		if ( $wtfpl_match ) {
+			return true;
+		}
+
 		$match = preg_match( '/GPL|GNU|MIT|FreeBSD|New BSD|BSD-3-Clause|BSD 3 Clause|OpenLDAP|Expat|Apache2|MPL20|ISC|CC0|Unlicense|WTFPL/im', $license );
 
 		return ( false === $match || 0 === $match ) ? false : true;

--- a/includes/Traits/License_Utils.php
+++ b/includes/Traits/License_Utils.php
@@ -56,6 +56,8 @@ trait License_Utils {
 		$license = preg_replace( '/GPL\s*[-|\.]*\s*[v]?([0-9])(\.[0])?/i', 'GPL$1', $license, 1 );
 		$license = preg_replace( '/Apache.*?([0-9])(\.[0])?/i', 'Apache$1', $license );
 		$license = preg_replace( '/(The\s+)?Unlicense/i', 'Unlicense', $license );
+		// Normalize WTFPL variations.
+		$license = preg_replace( '/Do\s+What\s+The\s+F[^\s]*\s+You\s+Want\s+To\s+Public\s+License/i', 'WTFPL', $license );
 		$license = str_replace( '.', '', $license );
 
 		return $license;
@@ -84,7 +86,7 @@ trait License_Utils {
 	 * @return bool true if the license is GPL compatible, otherwise false.
 	 */
 	protected function is_license_gpl_compatible( $license ) {
-		$match = preg_match( '/GPL|GNU|MIT|FreeBSD|New BSD|BSD-3-Clause|BSD 3 Clause|OpenLDAP|Expat|Apache2|MPL20|ISC|CC0|Unlicense/im', $license );
+		$match = preg_match( '/GPL|GNU|MIT|FreeBSD|New BSD|BSD-3-Clause|BSD 3 Clause|OpenLDAP|Expat|Apache2|MPL20|ISC|CC0|Unlicense|WTFPL/im', $license );
 
 		return ( false === $match || 0 === $match ) ? false : true;
 	}

--- a/tests/phpunit/testdata/plugins/test-plugin-wtfpl-license/load.php
+++ b/tests/phpunit/testdata/plugins/test-plugin-wtfpl-license/load.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * Plugin Name: Test Plugin with WTFPL License
+ * Plugin URI:  https://wordpress.org/plugins/test-plugin/
+ * Description: Test plugin for WTFPL license validation.
+ * Version:     1.0.0
+ * Author:      plugin-check
+ * Author URI:  https://wordpress.org/plugins/test-plugin/
+ * License:     WTFPL
+ * License URI: http://www.wtfpl.net/
+ * Text Domain: test-plugin
+ */

--- a/tests/phpunit/tests/Checker/Checks/Plugin_Header_Fields_Check_Tests.php
+++ b/tests/phpunit/tests/Checker/Checks/Plugin_Header_Fields_Check_Tests.php
@@ -128,6 +128,25 @@ class Plugin_Header_Fields_Check_Tests extends WP_UnitTestCase {
 		$this->assertCount( 1, wp_list_filter( $errors['load.php'][0][0], array( 'code' => 'plugin_header_invalid_license' ) ) );
 	}
 
+	public function test_run_with_valid_wtfpl_license() {
+		$check         = new Plugin_Header_Fields_Check();
+		$check_context = new Check_Context( UNIT_TESTS_PLUGIN_DIR . 'test-plugin-wtfpl-license/load.php' );
+		$check_result  = new Check_Result( $check_context );
+
+		$check->run( $check_result );
+
+		$errors = $check_result->get_errors();
+
+		// Should not have invalid license error for WTFPL.
+		if ( isset( $errors['load.php'] ) && isset( $errors['load.php'][0][0] ) ) {
+			$invalid_license_errors = wp_list_filter( $errors['load.php'][0][0], array( 'code' => 'plugin_header_invalid_license' ) );
+			$this->assertEmpty( $invalid_license_errors, 'WTFPL license should be recognized as GPL-compatible' );
+		} else {
+			// If no errors at all, that's also fine - the license is valid.
+			$this->assertTrue( true );
+		}
+	}
+
 	public function test_run_with_invalid_header_fields() {
 		$check         = new Plugin_Header_Fields_Check();
 		$check_context = new Check_Context( UNIT_TESTS_PLUGIN_DIR . 'test-plugin-late-escaping-errors/load.php' );

--- a/tests/phpunit/tests/Traits/License_Utils_Tests.php
+++ b/tests/phpunit/tests/Traits/License_Utils_Tests.php
@@ -78,6 +78,11 @@ class License_Utils_Tests extends WP_UnitTestCase {
 
 			array( 'The Unlicense', 'Unlicense' ),
 			array( 'Unlicense', 'Unlicense' ),
+
+			array( 'WTFPL', 'WTFPL' ),
+			array( 'WTFPL v2', 'WTFPL' ),
+			array( 'Do What The F*ck You Want To Public License', 'WTFPL' ),
+			array( 'Do What The Fuck You Want To Public License', 'WTFPL' ),
 		);
 	}
 
@@ -120,6 +125,10 @@ class License_Utils_Tests extends WP_UnitTestCase {
 			array( 'CC0 1.0 Universal', true ),
 			array( 'The Unlicense', true ),
 			array( 'Unlicense', true ),
+			array( 'WTFPL', true ),
+			array( 'WTFPL v2', true ),
+			array( 'Do What The F*ck You Want To Public License', true ),
+			array( 'Do What The Fuck You Want To Public License', true ),
 
 			array( 'EPL', false ),
 			array( 'EUPL', false ),


### PR DESCRIPTION
Adds WTFPL (Do What The F*ck You Want To Public License) as a recognized GPL-compatible license in Plugin Check. The GNU license list marks WTFPL as GPL-compatible, but Plugin Check was flagging it as invalid.

Fixes #1157

## Changes

- Updated `is_license_gpl_compatible()` in `includes/Traits/License_Utils.php`:
  - Added `WTFPL` to the regex pattern for GPL-compatible licenses
- Updated `get_normalized_license()` in `includes/Traits/License_Utils.php`:
  - Added normalization to convert WTFPL variations (e.g., "Do What The F*ck You Want To Public License") to "WTFPL"
- Added test cases in `tests/phpunit/tests/Traits/License_Utils_Tests.php`:
  - Normalization tests for WTFPL variations
  - GPL compatibility tests for WTFPL
- Added integration test in `tests/phpunit/tests/Checker/Checks/Plugin_Header_Fields_Check_Tests.php`:
  - `test_run_with_valid_wtfpl_license()` to verify WTFPL is accepted in plugin headers
- Created test plugin `test-plugin-wtfpl-license` with WTFPL license for integration testing

## Benefits

- WTFPL is now recognized as GPL-compatible, aligning with the GNU license list
- Reduces false positives for valid GPL-compatible licenses
- Supports common WTFPL variations in plugin headers
- Maintains existing validation for other licenses

## Checklist

- [x] Code follows WordPress Coding Standards
- [x] Self-reviewed the code
- [x] Added necessary comments
- [x] No new linter errors
- [x] Added test cases to prevent regression
- [x] All existing tests pass
- [x] New tests pass
- [x] Integration test created and verified