### PR TITLE
Added External Link Validation for Admin Menus

### DIFF
--- a/includes/Checker/Checks/Plugin_Repo/External_Admin_Menu_Links_Check.php
+++ b/includes/Checker/Checks/Plugin_Repo/External_Admin_Menu_Links_Check.php
@@ -100,15 +100,15 @@ class External_Admin_Menu_Links_Check extends Abstract_File_Check {
 		// - Function name from the list
 		// - Opening parenthesis
 		// - First 3 parameters (non-greedy, can be strings with single/double quotes or variables)
-		// - 4th parameter containing http://, https://, or // at the start of a string
+		// - 4th parameter containing http://, https://, or // at the start of a string.
 		$pattern = '/\b(' . $functions_pattern . ')\s*\(\s*' .
-			// First parameter
+			// First parameter. 
 			'(?:[^,]+)\s*,\s*' .
-			// Second parameter
+			// Second parameter.
 			'(?:[^,]+)\s*,\s*' .
-			// Third parameter
+			// Third parameter.
 			'(?:[^,]+)\s*,\s*' .
-			// Fourth parameter - look for external URL (http://, https://, or //)
+			// Fourth parameter - look for external URL (http://, https://, or //).
 			'[\'"](?:https?:)?\/\/[^\'"]+[\'"]/i';
 
 		$files = self::files_preg_match_all( $pattern, $php_files );

--- a/includes/Checker/Checks/Plugin_Repo/External_Admin_Menu_Links_Check.php
+++ b/includes/Checker/Checks/Plugin_Repo/External_Admin_Menu_Links_Check.php
@@ -21,7 +21,7 @@ use WordPress\Plugin_Check\Traits\Stable_Check;
  * as the menu slug parameter in WordPress admin menu functions. This practice violates
  * WordPress.org Plugin Directory Guideline #11 which prohibits hijacking the admin experience.
  *
- * @since 1.8.0
+ * @since 1.9.0
  */
 class External_Admin_Menu_Links_Check extends Abstract_File_Check {
 
@@ -35,7 +35,7 @@ class External_Admin_Menu_Links_Check extends Abstract_File_Check {
 	 * External URLs in submenus (add_submenu_page, add_options_page, etc.) are
 	 * acceptable for documentation, support links, and other resources.
 	 *
-	 * @since 1.8.0
+	 * @since 1.9.0
 	 * @var array
 	 */
 	protected $menu_functions = array(
@@ -47,7 +47,7 @@ class External_Admin_Menu_Links_Check extends Abstract_File_Check {
 	 *
 	 * Every check must have at least one category.
 	 *
-	 * @since 1.8.0
+	 * @since 1.9.0
 	 *
 	 * @return array The categories for the check.
 	 */
@@ -58,7 +58,7 @@ class External_Admin_Menu_Links_Check extends Abstract_File_Check {
 	/**
 	 * Amends the given result by running the check on the given list of files.
 	 *
-	 * @since 1.8.0
+	 * @since 1.9.0
 	 *
 	 * @param Check_Result $result The check result to amend, including the plugin context to check.
 	 * @param array        $files  List of absolute file paths.
@@ -75,7 +75,7 @@ class External_Admin_Menu_Links_Check extends Abstract_File_Check {
 	/**
 	 * Looks for external URLs in admin menu functions and amends the given result with an error if found.
 	 *
-	 * @since 1.8.0
+	 * @since 1.9.0
 	 *
 	 * @param Check_Result $result    The check result to amend, including the plugin context to check.
 	 * @param array        $php_files List of absolute PHP file paths.
@@ -107,7 +107,7 @@ class External_Admin_Menu_Links_Check extends Abstract_File_Check {
 				$this->add_result_error_for_file(
 					$result,
 					__(
-						'<strong>External URL used in top-level admin menu.</strong><br>Plugins should not add external links directly to the top-level WordPress admin menu using add_menu_page(). This disrupts the expected user experience and navigation patterns. Instead, create an admin page within WordPress that contains external links with clear descriptions, or add external links as submenu items using add_submenu_page().',
+						'<strong>External URL used in top-level admin menu.</strong><br>Plugins should not use add_menu_page() for external links as it disrupts the WordPress navigation experience.',
 						'plugin-check'
 					),
 					'external_admin_menu_link',
@@ -115,7 +115,7 @@ class External_Admin_Menu_Links_Check extends Abstract_File_Check {
 					$file['line'],
 					$file['column'],
 					'https://developer.wordpress.org/plugins/wordpress-org/detailed-plugin-guidelines/#11-plugins-should-not-hijack-the-admin',
-					9
+					7
 				);
 			}
 		}
@@ -126,7 +126,7 @@ class External_Admin_Menu_Links_Check extends Abstract_File_Check {
 	 *
 	 * Every check must have a short description explaining what the check does.
 	 *
-	 * @since 1.8.0
+	 * @since 1.9.0
 	 *
 	 * @return string Description.
 	 */
@@ -139,7 +139,7 @@ class External_Admin_Menu_Links_Check extends Abstract_File_Check {
 	 *
 	 * Every check must have a URL with further information about the check.
 	 *
-	 * @since 1.8.0
+	 * @since 1.9.0
 	 *
 	 * @return string The documentation URL.
 	 */

--- a/includes/Checker/Checks/Plugin_Repo/External_Admin_Menu_Links_Check.php
+++ b/includes/Checker/Checks/Plugin_Repo/External_Admin_Menu_Links_Check.php
@@ -102,7 +102,7 @@ class External_Admin_Menu_Links_Check extends Abstract_File_Check {
 		// - First 3 parameters (non-greedy, can be strings with single/double quotes or variables)
 		// - 4th parameter containing http://, https://, or // at the start of a string.
 		$pattern = '/\b(' . $functions_pattern . ')\s*\(\s*' .
-			// First parameter. 
+			// First parameter.
 			'(?:[^,]+)\s*,\s*' .
 			// Second parameter.
 			'(?:[^,]+)\s*,\s*' .

--- a/includes/Checker/Checks/Plugin_Repo/External_Admin_Menu_Links_Check.php
+++ b/includes/Checker/Checks/Plugin_Repo/External_Admin_Menu_Links_Check.php
@@ -29,28 +29,17 @@ class External_Admin_Menu_Links_Check extends Abstract_File_Check {
 	use Stable_Check;
 
 	/**
-	 * List of admin menu functions to check.
+	 * List of top-level admin menu functions to check.
 	 *
-	 * The 4th parameter (index 3) is the menu slug in all these functions.
-	 * add_submenu_page is intentionally excluded as it may legitimately link to
-	 * support pages or external resources.
+	 * Only add_menu_page is checked as it adds to the top-level admin menu.
+	 * External URLs in submenus (add_submenu_page, add_options_page, etc.) are
+	 * acceptable for documentation, support links, and other resources.
 	 *
 	 * @since 1.8.0
 	 * @var array
 	 */
 	protected $menu_functions = array(
 		'add_menu_page',
-		'add_options_page',
-		'add_management_page',
-		'add_theme_page',
-		'add_plugins_page',
-		'add_users_page',
-		'add_dashboard_page',
-		'add_posts_page',
-		'add_media_page',
-		'add_links_page',
-		'add_pages_page',
-		'add_comments_page',
 	);
 
 	/**
@@ -97,9 +86,9 @@ class External_Admin_Menu_Links_Check extends Abstract_File_Check {
 
 		// Pattern to match menu function calls with external URLs in the 4th parameter.
 		// This regex matches:
-		// - Function name from the list
-		// - Opening parenthesis
-		// - First 3 parameters (non-greedy, can be strings with single/double quotes or variables)
+		// - Function name from the list.
+		// - Opening parenthesis.
+		// - First 3 parameters (non-greedy, can be strings with single/double quotes or variables).
 		// - 4th parameter containing http://, https://, or // at the start of a string.
 		$pattern = '/\b(' . $functions_pattern . ')\s*\(\s*' .
 			// First parameter.
@@ -117,13 +106,9 @@ class External_Admin_Menu_Links_Check extends Abstract_File_Check {
 			foreach ( $files as $file ) {
 				$this->add_result_error_for_file(
 					$result,
-					sprintf(
-						/* translators: %s: Comma-separated list of admin menu function names. */
-						__(
-							'<strong>External URL used in admin menu.</strong><br>Plugins should not add external links directly to the WordPress admin menu. This disrupts the expected user experience and navigation patterns. Instead, create an admin page within WordPress that contains external links with clear descriptions, or add external links within the plugin\'s settings page or help section. Please review usage of: %s',
-							'plugin-check'
-						),
-						implode( ', ', $this->menu_functions )
+					__(
+						'<strong>External URL used in top-level admin menu.</strong><br>Plugins should not add external links directly to the top-level WordPress admin menu using add_menu_page(). This disrupts the expected user experience and navigation patterns. Instead, create an admin page within WordPress that contains external links with clear descriptions, or add external links as submenu items using add_submenu_page().',
+						'plugin-check'
 					),
 					'external_admin_menu_link',
 					$file['file'],
@@ -146,7 +131,7 @@ class External_Admin_Menu_Links_Check extends Abstract_File_Check {
 	 * @return string Description.
 	 */
 	public function get_description(): string {
-		return __( 'Detects external URLs used in WordPress admin menu functions, which disrupts the expected user experience.', 'plugin-check' );
+		return __( 'Detects external URLs used in top-level WordPress admin menu, which disrupts the expected user experience.', 'plugin-check' );
 	}
 
 	/**

--- a/includes/Checker/Checks/Plugin_Repo/External_Admin_Menu_Links_Check.php
+++ b/includes/Checker/Checks/Plugin_Repo/External_Admin_Menu_Links_Check.php
@@ -1,0 +1,164 @@
+<?php
+/**
+ * Class External_Admin_Menu_Links_Check.
+ *
+ * @package plugin-check
+ */
+
+namespace WordPress\Plugin_Check\Checker\Checks\Plugin_Repo;
+
+use Exception;
+use WordPress\Plugin_Check\Checker\Check_Categories;
+use WordPress\Plugin_Check\Checker\Check_Result;
+use WordPress\Plugin_Check\Checker\Checks\Abstract_File_Check;
+use WordPress\Plugin_Check\Traits\Amend_Check_Result;
+use WordPress\Plugin_Check\Traits\Stable_Check;
+
+/**
+ * Check to detect external URLs used in WordPress admin menu functions.
+ *
+ * This check detects when plugins use external URLs (starting with http://, https://, or //)
+ * as the menu slug parameter in WordPress admin menu functions. This practice violates
+ * WordPress.org Plugin Directory Guideline #11 which prohibits hijacking the admin experience.
+ *
+ * @since 1.8.0
+ */
+class External_Admin_Menu_Links_Check extends Abstract_File_Check {
+
+	use Amend_Check_Result;
+	use Stable_Check;
+
+	/**
+	 * List of admin menu functions to check.
+	 *
+	 * The 4th parameter (index 3) is the menu slug in all these functions.
+	 * add_submenu_page is intentionally excluded as it may legitimately link to
+	 * support pages or external resources.
+	 *
+	 * @since 1.8.0
+	 * @var array
+	 */
+	protected $menu_functions = array(
+		'add_menu_page',
+		'add_options_page',
+		'add_management_page',
+		'add_theme_page',
+		'add_plugins_page',
+		'add_users_page',
+		'add_dashboard_page',
+		'add_posts_page',
+		'add_media_page',
+		'add_links_page',
+		'add_pages_page',
+		'add_comments_page',
+	);
+
+	/**
+	 * Gets the categories for the check.
+	 *
+	 * Every check must have at least one category.
+	 *
+	 * @since 1.8.0
+	 *
+	 * @return array The categories for the check.
+	 */
+	public function get_categories() {
+		return array( Check_Categories::CATEGORY_PLUGIN_REPO );
+	}
+
+	/**
+	 * Amends the given result by running the check on the given list of files.
+	 *
+	 * @since 1.8.0
+	 *
+	 * @param Check_Result $result The check result to amend, including the plugin context to check.
+	 * @param array        $files  List of absolute file paths.
+	 *
+	 * @throws Exception Thrown when the check fails with a critical error (unrelated to any errors detected as part of
+	 *                   the check).
+	 */
+	protected function check_files( Check_Result $result, array $files ) {
+		$php_files = self::filter_files_by_extension( $files, 'php' );
+
+		$this->look_for_external_menu_links( $result, $php_files );
+	}
+
+	/**
+	 * Looks for external URLs in admin menu functions and amends the given result with an error if found.
+	 *
+	 * @since 1.8.0
+	 *
+	 * @param Check_Result $result    The check result to amend, including the plugin context to check.
+	 * @param array        $php_files List of absolute PHP file paths.
+	 */
+	protected function look_for_external_menu_links( Check_Result $result, array $php_files ) {
+		// Build regex pattern for all menu functions.
+		$functions_pattern = implode( '|', array_map( 'preg_quote', $this->menu_functions ) );
+
+		// Pattern to match menu function calls with external URLs in the 4th parameter.
+		// This regex matches:
+		// - Function name from the list
+		// - Opening parenthesis
+		// - First 3 parameters (non-greedy, can be strings with single/double quotes or variables)
+		// - 4th parameter containing http://, https://, or // at the start of a string
+		$pattern = '/\b(' . $functions_pattern . ')\s*\(\s*' .
+			// First parameter
+			'(?:[^,]+)\s*,\s*' .
+			// Second parameter
+			'(?:[^,]+)\s*,\s*' .
+			// Third parameter
+			'(?:[^,]+)\s*,\s*' .
+			// Fourth parameter - look for external URL (http://, https://, or //)
+			'[\'"](?:https?:)?\/\/[^\'"]+[\'"]/i';
+
+		$files = self::files_preg_match_all( $pattern, $php_files );
+
+		if ( ! empty( $files ) ) {
+			foreach ( $files as $file ) {
+				$this->add_result_error_for_file(
+					$result,
+					sprintf(
+						/* translators: %s: Comma-separated list of admin menu function names. */
+						__(
+							'<strong>External URL used in admin menu.</strong><br>Plugins should not add external links directly to the WordPress admin menu. This disrupts the expected user experience and navigation patterns. Instead, create an admin page within WordPress that contains external links with clear descriptions, or add external links within the plugin\'s settings page or help section. Please review usage of: %s',
+							'plugin-check'
+						),
+						implode( ', ', $this->menu_functions )
+					),
+					'external_admin_menu_link',
+					$file['file'],
+					$file['line'],
+					$file['column'],
+					'https://developer.wordpress.org/plugins/wordpress-org/detailed-plugin-guidelines/#11-plugins-should-not-hijack-the-admin',
+					9
+				);
+			}
+		}
+	}
+
+	/**
+	 * Gets the description for the check.
+	 *
+	 * Every check must have a short description explaining what the check does.
+	 *
+	 * @since 1.8.0
+	 *
+	 * @return string Description.
+	 */
+	public function get_description(): string {
+		return __( 'Detects external URLs used in WordPress admin menu functions, which disrupts the expected user experience.', 'plugin-check' );
+	}
+
+	/**
+	 * Gets the documentation URL for the check.
+	 *
+	 * Every check must have a URL with further information about the check.
+	 *
+	 * @since 1.8.0
+	 *
+	 * @return string The documentation URL.
+	 */
+	public function get_documentation_url(): string {
+		return __( 'https://developer.wordpress.org/plugins/wordpress-org/detailed-plugin-guidelines/#11-plugins-should-not-hijack-the-admin', 'plugin-check' );
+	}
+}

--- a/includes/Checker/Default_Check_Repository.php
+++ b/includes/Checker/Default_Check_Repository.php
@@ -100,6 +100,7 @@ class Default_Check_Repository extends Empty_Check_Repository {
 				'direct_db'                  => new Checks\Security\Direct_DB_Check(),
 				'minified_files'             => new Checks\Plugin_Repo\Minified_Files_Check(),
 				'direct_file_access'         => new Checks\Plugin_Repo\Direct_File_Access_Check(),
+				'external_admin_menu_links'  => new Checks\Plugin_Repo\External_Admin_Menu_Links_Check(),
 			)
 		);
 

--- a/tests/phpunit/testdata/plugins/test-plugin-external-admin-menu-links-with-errors/load.php
+++ b/tests/phpunit/testdata/plugins/test-plugin-external-admin-menu-links-with-errors/load.php
@@ -16,10 +16,11 @@
  */
 
 /**
- * These are examples of problematic code that adds external links to admin menu.
+ * These are examples of problematic code that adds external links to
+ * the TOP-LEVEL admin menu using add_menu_page().
  */
 
-// ❌ Adding external link to main menu with https.
+// ❌ Adding external link to top-level menu with https.
 add_menu_page(
 	'External Resource',
 	'External Resource',
@@ -30,55 +31,18 @@ add_menu_page(
 	30
 );
 
-// ❌ Adding external link to options page with http.
-add_options_page(
-	'Settings',
-	'Settings',
+// ❌ Adding external link to top-level menu with http.
+add_menu_page(
+	'HTTP External',
+	'HTTP External',
 	'manage_options',
-	'http://example.com/settings'
+	'http://example.com/http-page',
+	'',
+	'dashicons-admin-site',
+	31
 );
 
-// ❌ Adding external link to management page.
-add_management_page(
-	'Tools',
-	'Tools',
-	'manage_options',
-	'https://example.com/tools'
-);
-
-// ❌ Adding external link to theme page.
-add_theme_page(
-	'Theme Options',
-	'Theme Options',
-	'manage_options',
-	'https://example.com/theme-options'
-);
-
-// ❌ Adding external link to plugins page.
-add_plugins_page(
-	'Plugin Settings',
-	'Plugin Settings',
-	'manage_options',
-	'https://example.com/plugin-settings'
-);
-
-// ❌ Adding external link to users page.
-add_users_page(
-	'User Import',
-	'User Import',
-	'manage_options',
-	'https://example.com/user-import'
-);
-
-// ❌ Adding external link to dashboard page.
-add_dashboard_page(
-	'Dashboard Widget',
-	'Dashboard Widget',
-	'manage_options',
-	'https://example.com/dashboard-widget'
-);
-
-// ❌ Adding external link with protocol-relative URL.
+// ❌ Adding external link with protocol-relative URL to top-level menu.
 add_menu_page(
 	'Protocol Relative',
 	'Protocol Relative',
@@ -86,5 +50,5 @@ add_menu_page(
 	'//example.com/protocol-relative',
 	'',
 	'dashicons-admin-site',
-	31
+	32
 );

--- a/tests/phpunit/testdata/plugins/test-plugin-external-admin-menu-links-with-errors/load.php
+++ b/tests/phpunit/testdata/plugins/test-plugin-external-admin-menu-links-with-errors/load.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * Plugin Name: Test Plugin External Admin Menu Links With Errors
+ * Plugin URI: https://github.com/WordPress/plugin-check
+ * Description: Test plugin with external URLs in admin menu functions.
+ * Requires at least: 6.0
+ * Requires PHP: 5.6
+ * Version: 1.0.0
+ * Author: WordPress Performance Team
+ * Author URI: https://make.wordpress.org/performance/
+ * License: GPLv2 or later
+ * License URI: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+ * Text Domain: test-plugin-external-admin-menu-links-with-errors
+ *
+ * @package test-plugin-external-admin-menu-links-with-errors
+ */
+
+/**
+ * These are examples of problematic code that adds external links to admin menu.
+ */
+
+// ❌ Adding external link to main menu with https.
+add_menu_page(
+	'External Resource',
+	'External Resource',
+	'manage_options',
+	'https://example.com/external-page',
+	'',
+	'dashicons-admin-site',
+	30
+);
+
+// ❌ Adding external link to options page with http.
+add_options_page(
+	'Settings',
+	'Settings',
+	'manage_options',
+	'http://example.com/settings'
+);
+
+// ❌ Adding external link to management page.
+add_management_page(
+	'Tools',
+	'Tools',
+	'manage_options',
+	'https://example.com/tools'
+);
+
+// ❌ Adding external link to theme page.
+add_theme_page(
+	'Theme Options',
+	'Theme Options',
+	'manage_options',
+	'https://example.com/theme-options'
+);
+
+// ❌ Adding external link to plugins page.
+add_plugins_page(
+	'Plugin Settings',
+	'Plugin Settings',
+	'manage_options',
+	'https://example.com/plugin-settings'
+);
+
+// ❌ Adding external link to users page.
+add_users_page(
+	'User Import',
+	'User Import',
+	'manage_options',
+	'https://example.com/user-import'
+);
+
+// ❌ Adding external link to dashboard page.
+add_dashboard_page(
+	'Dashboard Widget',
+	'Dashboard Widget',
+	'manage_options',
+	'https://example.com/dashboard-widget'
+);
+
+// ❌ Adding external link with protocol-relative URL.
+add_menu_page(
+	'Protocol Relative',
+	'Protocol Relative',
+	'manage_options',
+	'//example.com/protocol-relative',
+	'',
+	'dashicons-admin-site',
+	31
+);

--- a/tests/phpunit/testdata/plugins/test-plugin-external-admin-menu-links-without-errors/load.php
+++ b/tests/phpunit/testdata/plugins/test-plugin-external-admin-menu-links-without-errors/load.php
@@ -94,6 +94,22 @@ add_submenu_page(
 	''
 );
 
+// ✅ External URLs in submenu functions are allowed for docs, support, etc.
+add_options_page(
+	'Plugin Documentation',
+	'Documentation',
+	'manage_options',
+	'https://example.com/plugin-docs'
+);
+
+// ✅ External URL in management page for support link.
+add_management_page(
+	'Support',
+	'Get Support',
+	'manage_options',
+	'https://example.com/support'
+);
+
 // ✅ Adding submenu page with internal slug.
 add_submenu_page(
 	'my-plugin-settings',

--- a/tests/phpunit/testdata/plugins/test-plugin-external-admin-menu-links-without-errors/load.php
+++ b/tests/phpunit/testdata/plugins/test-plugin-external-admin-menu-links-without-errors/load.php
@@ -1,0 +1,140 @@
+<?php
+/**
+ * Plugin Name: Test Plugin External Admin Menu Links Without Errors
+ * Plugin URI: https://github.com/WordPress/plugin-check
+ * Description: Test plugin with proper internal admin menu usage.
+ * Requires at least: 6.0
+ * Requires PHP: 5.6
+ * Version: 1.0.0
+ * Author: WordPress Performance Team
+ * Author URI: https://make.wordpress.org/performance/
+ * License: GPLv2 or later
+ * License URI: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+ * Text Domain: test-plugin-external-admin-menu-links-without-errors
+ *
+ * @package test-plugin-external-admin-menu-links-without-errors
+ */
+
+/**
+ * These are examples of correct admin menu usage with internal slugs.
+ */
+
+// ✅ Adding internal page to main menu.
+add_menu_page(
+	'My Plugin Settings',
+	'My Plugin',
+	'manage_options',
+	'my-plugin-settings',
+	'my_plugin_settings_page',
+	'dashicons-admin-generic',
+	30
+);
+
+// ✅ Adding internal page to options menu.
+add_options_page(
+	'My Plugin Options',
+	'My Plugin',
+	'manage_options',
+	'my-plugin-options',
+	'my_plugin_options_page'
+);
+
+// ✅ Adding internal page to management/tools menu.
+add_management_page(
+	'My Plugin Tools',
+	'My Plugin Tools',
+	'manage_options',
+	'my-plugin-tools',
+	'my_plugin_tools_page'
+);
+
+// ✅ Adding internal page to theme menu.
+add_theme_page(
+	'Theme Settings',
+	'Theme Settings',
+	'manage_options',
+	'my-theme-settings',
+	'my_theme_settings_page'
+);
+
+// ✅ Adding internal page to plugins menu.
+add_plugins_page(
+	'Plugin Manager',
+	'Plugin Manager',
+	'manage_options',
+	'my-plugin-manager',
+	'my_plugin_manager_page'
+);
+
+// ✅ Adding internal page to users menu.
+add_users_page(
+	'User Settings',
+	'User Settings',
+	'manage_options',
+	'my-user-settings',
+	'my_user_settings_page'
+);
+
+// ✅ Adding internal page to dashboard menu.
+add_dashboard_page(
+	'Dashboard Info',
+	'Dashboard Info',
+	'manage_options',
+	'my-dashboard-info',
+	'my_dashboard_info_page'
+);
+
+// ✅ Adding submenu page with external URL is allowed.
+add_submenu_page(
+	'my-plugin-settings',
+	'Documentation',
+	'Documentation',
+	'manage_options',
+	'https://example.com/docs',
+	''
+);
+
+// ✅ Adding submenu page with internal slug.
+add_submenu_page(
+	'my-plugin-settings',
+	'Advanced Settings',
+	'Advanced',
+	'manage_options',
+	'my-plugin-advanced',
+	'my_plugin_advanced_page'
+);
+
+/**
+ * Callback functions for admin pages.
+ */
+function my_plugin_settings_page() {
+	echo '<div class="wrap"><h1>My Plugin Settings</h1></div>';
+}
+
+function my_plugin_options_page() {
+	echo '<div class="wrap"><h1>My Plugin Options</h1></div>';
+}
+
+function my_plugin_tools_page() {
+	echo '<div class="wrap"><h1>My Plugin Tools</h1></div>';
+}
+
+function my_theme_settings_page() {
+	echo '<div class="wrap"><h1>Theme Settings</h1></div>';
+}
+
+function my_plugin_manager_page() {
+	echo '<div class="wrap"><h1>Plugin Manager</h1></div>';
+}
+
+function my_user_settings_page() {
+	echo '<div class="wrap"><h1>User Settings</h1></div>';
+}
+
+function my_dashboard_info_page() {
+	echo '<div class="wrap"><h1>Dashboard Info</h1></div>';
+}
+
+function my_plugin_advanced_page() {
+	echo '<div class="wrap"><h1>Advanced Settings</h1></div>';
+}

--- a/tests/phpunit/tests/Checker/Checks/External_Admin_Menu_Links_Check_Tests.php
+++ b/tests/phpunit/tests/Checker/Checks/External_Admin_Menu_Links_Check_Tests.php
@@ -10,7 +10,7 @@ use WordPress\Plugin_Check\Checker\Check_Context;
 use WordPress\Plugin_Check\Checker\Check_Result;
 use WordPress\Plugin_Check\Checker\Checks\Plugin_Repo\External_Admin_Menu_Links_Check;
 
-class External_Admin_Menu_Links_Check_Tests extends \WP_UnitTestCase {
+class External_Admin_Menu_Links_Check_Tests extends WP_UnitTestCase {
 
 	/**
 	 * Test that external URLs in admin menu functions are detected as errors.

--- a/tests/phpunit/tests/Checker/Checks/External_Admin_Menu_Links_Check_Tests.php
+++ b/tests/phpunit/tests/Checker/Checks/External_Admin_Menu_Links_Check_Tests.php
@@ -1,0 +1,93 @@
+<?php
+/**
+ * Tests for the External_Admin_Menu_Links_Check class.
+ *
+ * @package plugin-check
+ */
+
+use WordPress\Plugin_Check\Checker\Check_Categories;
+use WordPress\Plugin_Check\Checker\Check_Context;
+use WordPress\Plugin_Check\Checker\Check_Result;
+use WordPress\Plugin_Check\Checker\Checks\Plugin_Repo\External_Admin_Menu_Links_Check;
+
+class External_Admin_Menu_Links_Check_Tests extends \WP_UnitTestCase {
+
+	/**
+	 * Test that external URLs in admin menu functions are detected as errors.
+	 */
+	public function test_detect_external_admin_menu_links_with_errors() {
+		$check_context = new Check_Context( UNIT_TESTS_PLUGIN_DIR . 'test-plugin-external-admin-menu-links-with-errors/load.php' );
+		$check_result  = new Check_Result( $check_context );
+
+		$check = new External_Admin_Menu_Links_Check();
+		$check->run( $check_result );
+
+		$errors = $check_result->get_errors();
+
+		$this->assertNotEmpty( $errors );
+		$this->assertArrayHasKey( 'load.php', $errors );
+		$this->assertGreaterThan( 0, $check_result->get_error_count() );
+
+		// Check that the error code is correct.
+		$found_external_menu_error = false;
+		foreach ( $errors['load.php'] as $line => $columns ) {
+			foreach ( $columns as $column => $messages ) {
+				foreach ( $messages as $message ) {
+					if ( 'external_admin_menu_link' === $message['code'] ) {
+						$found_external_menu_error = true;
+						break 3;
+					}
+				}
+			}
+		}
+		$this->assertTrue( $found_external_menu_error, 'Expected external_admin_menu_link error code not found.' );
+	}
+
+	/**
+	 * Test that internal admin menu slugs do not trigger errors.
+	 */
+	public function test_no_errors_for_internal_admin_menu_links() {
+		$check_context = new Check_Context( UNIT_TESTS_PLUGIN_DIR . 'test-plugin-external-admin-menu-links-without-errors/load.php' );
+		$check_result  = new Check_Result( $check_context );
+
+		$check = new External_Admin_Menu_Links_Check();
+		$check->run( $check_result );
+
+		$errors = $check_result->get_errors();
+
+		$this->assertEmpty( $errors );
+		$this->assertSame( 0, $check_result->get_error_count() );
+	}
+
+	/**
+	 * Test that the check returns the correct categories.
+	 */
+	public function test_get_categories() {
+		$check      = new External_Admin_Menu_Links_Check();
+		$categories = $check->get_categories();
+
+		$this->assertContains( Check_Categories::CATEGORY_PLUGIN_REPO, $categories );
+	}
+
+	/**
+	 * Test that the check has a description.
+	 */
+	public function test_get_description() {
+		$check       = new External_Admin_Menu_Links_Check();
+		$description = $check->get_description();
+
+		$this->assertNotEmpty( $description );
+		$this->assertIsString( $description );
+	}
+
+	/**
+	 * Test that the check has a documentation URL.
+	 */
+	public function test_get_documentation_url() {
+		$check = new External_Admin_Menu_Links_Check();
+		$url   = $check->get_documentation_url();
+
+		$this->assertNotEmpty( $url );
+		$this->assertStringContainsString( 'https://', $url );
+	}
+}

--- a/tests/phpunit/tests/Checker/Checks/External_Admin_Menu_Links_Check_Tests.php
+++ b/tests/phpunit/tests/Checker/Checks/External_Admin_Menu_Links_Check_Tests.php
@@ -13,7 +13,7 @@ use WordPress\Plugin_Check\Checker\Checks\Plugin_Repo\External_Admin_Menu_Links_
 class External_Admin_Menu_Links_Check_Tests extends WP_UnitTestCase {
 
 	/**
-	 * Test that external URLs in admin menu functions are detected as errors.
+	 * Test that external URLs in add_menu_page() (top-level menu) are detected as errors.
 	 */
 	public function test_detect_external_admin_menu_links_with_errors() {
 		$check_context = new Check_Context( UNIT_TESTS_PLUGIN_DIR . 'test-plugin-external-admin-menu-links-with-errors/load.php' );
@@ -44,7 +44,7 @@ class External_Admin_Menu_Links_Check_Tests extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test that internal admin menu slugs do not trigger errors.
+	 * Test that internal slugs and external URLs in submenu functions do not trigger errors.
 	 */
 	public function test_no_errors_for_internal_admin_menu_links() {
 		$check_context = new Check_Context( UNIT_TESTS_PLUGIN_DIR . 'test-plugin-external-admin-menu-links-without-errors/load.php' );


### PR DESCRIPTION
Hello

I’ve completed the changes to block external links in the WordPress admin menu, as discussed in issue #1184 

 The functionality is working as expected and ensures compliance with plugin directory guidelines.

Kindly review the changes at your convenience. If everything meets your approval, I would greatly appreciate it if we could proceed with merging this into the main branch.

Thanks for your time and consideration!

