### PR TITLE
Fix fatal on WP 7.0 by deferring to core AI client

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -41,7 +41,13 @@ function wp_plugin_check_load() {
 	}
 
 	// Load the Composer autoloader.
-	require_once WP_PLUGIN_CHECK_PLUGIN_DIR_PATH . 'vendor/autoload.php';
+	$autoloader = require_once WP_PLUGIN_CHECK_PLUGIN_DIR_PATH . 'vendor/autoload.php';
+
+	// Avoid conflicts with the AI client bundled in WordPress core (7.0+).
+	if ( wp_plugin_check_has_core_ai_client() && $autoloader instanceof \Composer\Autoload\ClassLoader ) {
+		$autoloader->setPsr4( 'WordPress\\AiClient\\', array() );
+		$autoloader->setPsr4( 'WordPress\\AI_Client\\', array() );
+	}
 
 	// Setup the plugin.
 	$instance = new Plugin_Main( WP_PLUGIN_CHECK_MAIN_FILE );
@@ -77,6 +83,17 @@ function wp_plugin_check_display_composer_autoload_notice() {
 		'<code>composer install</code>'
 	);
 	echo '</p></div>';
+}
+
+/**
+ * Checks whether the current WordPress install includes the AI client in core.
+ *
+ * @since 1.8.1
+ *
+ * @return bool True if core provides the AI client, false otherwise.
+ */
+function wp_plugin_check_has_core_ai_client() {
+	return defined( 'ABSPATH' ) && defined( 'WPINC' ) && file_exists( ABSPATH . WPINC . '/ai-client/bootstrap.php' );
 }
 
 wp_plugin_check_load();

--- a/plugin.php
+++ b/plugin.php
@@ -14,6 +14,7 @@
  * @package plugin-check
  */
 
+use Composer\Autoload\ClassLoader;
 use WordPress\Plugin_Check\Plugin_Main;
 
 define( 'WP_PLUGIN_CHECK_VERSION', '1.8.0' );
@@ -44,7 +45,7 @@ function wp_plugin_check_load() {
 	$autoloader = require_once WP_PLUGIN_CHECK_PLUGIN_DIR_PATH . 'vendor/autoload.php';
 
 	// Avoid conflicts with the AI client bundled in WordPress core (7.0+).
-	if ( wp_plugin_check_has_core_ai_client() && $autoloader instanceof \Composer\Autoload\ClassLoader ) {
+	if ( wp_plugin_check_has_core_ai_client() && $autoloader instanceof ClassLoader ) {
 		$autoloader->setPsr4( 'WordPress\\AiClient\\', array() );
 		$autoloader->setPsr4( 'WordPress\\AI_Client\\', array() );
 	}

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -5,8 +5,32 @@
  * @package plugin-check
  */
 
+use Composer\Autoload\ClassLoader;
+
 define( 'TESTS_PLUGIN_DIR', dirname( __DIR__, 2 ) );
 define( 'UNIT_TESTS_PLUGIN_DIR', TESTS_PLUGIN_DIR . '/tests/phpunit/testdata/plugins/' );
+
+/**
+ * Attempts to determine the WordPress core root from the tests root.
+ *
+ * @since 1.8.1
+ *
+ * @param string $_test_root The tests root path.
+ * @return string|null The WordPress core root or null if unknown.
+ */
+function wp_plugin_check_get_core_root_from_tests_root( $_test_root ) {
+	$_test_root = rtrim( $_test_root, '/' );
+
+	if ( str_ends_with( $_test_root, '/tests/phpunit' ) ) {
+		return dirname( $_test_root, 2 );
+	}
+
+	if ( str_ends_with( $_test_root, '/wp-tests-lib' ) ) {
+		return dirname( $_test_root );
+	}
+
+	return null;
+}
 
 // Detect where to load the WordPress tests environment from.
 if ( false !== getenv( 'WP_TESTS_DIR' ) ) {
@@ -22,6 +46,20 @@ if ( false !== getenv( 'WP_TESTS_DIR' ) ) {
 }
 
 require_once $_test_root . '/includes/functions.php';
+
+// If core ships the AI client, ensure the Composer autoloader doesn't register its own.
+$_core_root = wp_plugin_check_get_core_root_from_tests_root( $_test_root );
+if ( $_core_root && file_exists( $_core_root . '/wp-includes/ai-client/bootstrap.php' ) ) {
+	foreach ( (array) spl_autoload_functions() as $autoload_function ) {
+		if (
+			is_array( $autoload_function ) &&
+			$autoload_function[0] instanceof ClassLoader
+		) {
+			$autoload_function[0]->setPsr4( 'WordPress\\AiClient\\', array() );
+			$autoload_function[0]->setPsr4( 'WordPress\\AI_Client\\', array() );
+		}
+	}
+}
 
 // Force plugin to be active.
 $GLOBALS['wp_tests_options'] = array(

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -8,10 +8,6 @@
 define( 'TESTS_PLUGIN_DIR', dirname( __DIR__, 2 ) );
 define( 'UNIT_TESTS_PLUGIN_DIR', TESTS_PLUGIN_DIR . '/tests/phpunit/testdata/plugins/' );
 
-if ( file_exists( TESTS_PLUGIN_DIR . '/vendor/autoload.php' ) ) {
-	require_once TESTS_PLUGIN_DIR . '/vendor/autoload.php';
-}
-
 // Detect where to load the WordPress tests environment from.
 if ( false !== getenv( 'WP_TESTS_DIR' ) ) {
 	$_test_root = getenv( 'WP_TESTS_DIR' );
@@ -34,3 +30,8 @@ $GLOBALS['wp_tests_options'] = array(
 
 // Start up the WP testing environment.
 require $_test_root . '/includes/bootstrap.php';
+
+// Load Composer autoloader after core bootstrap to avoid core AI client conflicts.
+if ( file_exists( TESTS_PLUGIN_DIR . '/vendor/autoload.php' ) ) {
+	require_once TESTS_PLUGIN_DIR . '/vendor/autoload.php';
+}


### PR DESCRIPTION
**Summary**
- Prevents class/interface signature conflicts between the plugin’s bundled AI client and WordPress 7.0 core AI client.
- After loading the plugin’s Composer autoloader, if core AI client is present, unregisters `WordPress\AiClient\` and `WordPress\AI_Client\` PSR-4 mappings so core classes are used.
- Adds a small helper to detect the core AI client bootstrap.

**Testing**
- Local environment