### PR TITLE
Prepare Plugin Check 1.9.0 release

### DIFF
--- a/docs/checks.md
+++ b/docs/checks.md
@@ -6,13 +6,15 @@
 | --- | --- | --- | --- |
 | i18n_usage | general, plugin_repo | Checks for various internationalization best practices. | [Learn more](https://developer.wordpress.org/plugins/internationalization/how-to-internationalize-your-plugin/) |
 | code_obfuscation | plugin_repo | Detects the usage of code obfuscation tools. | [Learn more](https://developer.wordpress.org/plugins/wordpress-org/detailed-plugin-guidelines/) |
+| plugin_content | plugin_repo | Detects content that does not comply with the WordPress.org plugin guidelines. | [Learn more](https://developer.wordpress.org/plugins/wordpress-org/detailed-plugin-guidelines/) |
 | direct_file_access | security, plugin_repo | Checks that plugin files include proper security validation using the ABSPATH constant to prevent direct file access. | [Learn more](https://developer.wordpress.org/plugins/plugin-basics/best-practices/#file-security) |
 | file_type | plugin_repo | Detects the usage of hidden and compressed files, VCS directories, application files, badly named files, AI development directories (.cursor, .claude, .aider, .continue, .windsurf, .ai, .github), and unexpected markdown files in plugin root. | [Learn more](https://developer.wordpress.org/plugins/wordpress-org/detailed-plugin-guidelines/) |
 | plugin_header_fields | plugin_repo | Checks adherence to the Headers requirements, including validation of "Tested up to" header matching between plugin file and readme.txt. | [Learn more](https://developer.wordpress.org/plugins/plugin-basics/header-requirements/) |
 | late_escaping | security, plugin_repo | Checks that all output is escaped before being sent to the browser. | [Learn more](https://developer.wordpress.org/apis/security/escaping/) |
 | safe_redirect | security, plugin_repo | Checks that redirects use wp_safe_redirect() instead of wp_redirect() for security. | [Learn more](https://developer.wordpress.org/reference/functions/wp_safe_redirect/) |
-| nonce_verification | security, plugin_repo | Checks for proper usage of <code>wp_verify_nonce()</code> to prevent CSRF vulnerabilities. | [Learn more](https://developer.wordpress.org/apis/security/nonces/) |
 | plugin_updater | plugin_repo | Prevents altering WordPress update routines or using custom updaters, which are not allowed on WordPress.org. | [Learn more](https://developer.wordpress.org/plugins/wordpress-org/detailed-plugin-guidelines/) |
+| plugin_uninstall | plugin_repo | Checks related to plugin uninstallation. | [Learn more](https://developer.wordpress.org/plugins/plugin-basics/uninstall-methods/#method-2-uninstall-php) |
+| external_admin_menu_links | plugin_repo | Detects external URLs used in top-level WordPress admin menu, which disrupts the expected user experience. | [Learn more](https://developer.wordpress.org/plugins/wordpress-org/detailed-plugin-guidelines/#11-plugins-should-not-hijack-the-admin) |
 | plugin_review_phpcs | plugin_repo | Runs PHP_CodeSniffer to detect certain best practices plugins should follow for submission on WordPress.org, including heredoc usage detection. | [Learn more](https://developer.wordpress.org/plugins/plugin-basics/best-practices/) |
 | direct_db_queries | security, plugin_repo | Checks the usage of direct database queries, which should be avoided. | [Learn more](https://developer.wordpress.org/apis/database/) |
 | direct_db | security, plugin_repo | Checks the escaping in direct database queries. | [Learn more](https://developer.wordpress.org/apis/database/) |
@@ -27,7 +29,6 @@
 | offloading_files | plugin_repo | Prevents using remote services that are not necessary. | [Learn more](https://developer.wordpress.org/plugins/wordpress-org/common-issues/#calling-files-remotely) |
 | setting_sanitization | plugin_repo | Ensures sanitization in register_setting(). | [Learn more](https://developer.wordpress.org/reference/functions/register_setting/) |
 | prefixing | plugin_repo | Checks plugin for unique prefixing for everything the plugin defines in the public namespace. | [Learn more](https://developer.wordpress.org/plugins/plugin-basics/best-practices/) |
-| image_functions | performance | Checks whether images are inserted using recommended functions. | [Learn more](https://developer.wordpress.org/plugins/) |
 | enqueued_scripts_size | performance | Checks whether the cumulative size of all scripts enqueued on a page exceeds 293 KB. | [Learn more](https://developer.wordpress.org/plugins/) |
 | enqueued_styles_size | performance | Checks whether the cumulative size of all stylesheets enqueued on a page exceeds 293 KB. | [Learn more](https://developer.wordpress.org/plugins/) |
 | enqueued_styles_scope | performance | Checks whether any stylesheets are loaded on all pages, which is usually not desirable and can lead to performance issues. | [Learn more](https://developer.wordpress.org/plugins/) |

--- a/plugin.php
+++ b/plugin.php
@@ -5,7 +5,7 @@
  * Description: Plugin Check is a WordPress.org tool which provides checks to help plugins meet the directory requirements and follow various best practices.
  * Requires at least: 6.3
  * Requires PHP: 7.4
- * Version: 1.8.0
+ * Version: 1.9.0
  * Author: WordPress Performance Team and Plugins Team
  * License: GPLv2 or later
  * License URI: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
@@ -16,7 +16,7 @@
 
 use WordPress\Plugin_Check\Plugin_Main;
 
-define( 'WP_PLUGIN_CHECK_VERSION', '1.8.0' );
+define( 'WP_PLUGIN_CHECK_VERSION', '1.9.0' );
 define( 'WP_PLUGIN_CHECK_MINIMUM_PHP', '7.4' );
 define( 'WP_PLUGIN_CHECK_MAIN_FILE', __FILE__ );
 define( 'WP_PLUGIN_CHECK_PLUGIN_DIR_PATH', plugin_dir_path( WP_PLUGIN_CHECK_MAIN_FILE ) );

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 
 Contributors:      wordpressdotorg
 Tested up to:      6.9
-Stable tag:        1.8.0
+Stable tag:        1.9.0
 License:           GPLv2 or later
 License URI:       https://www.gnu.org/licenses/gpl-2.0.html
 Tags:              plugin best practices, testing, accessibility, performance, security
@@ -80,6 +80,18 @@ To be approved in the WordPress.org plugin directory, a plugin must typically pa
 In any case, passing the checks in this tool likely helps to achieve a smooth plugin review process, but is no guarantee that a plugin will be approved in the WordPress.org plugin directory.
 
 == Changelog ==
+
+= 1.9.0 =
+
+* Enhancement - Use the WordPress 7.0 core AI connectors.
+* Enhancement - Add External Admin Menu Links check to detect external URLs in top-level admin menus.
+* Enhancement - Improve Plugin Updater detection to identify Plugin Update Checker (PUC) calls.
+* Enhancement - Accept WTFPL as a GPL-compatible license.
+* Fix - Improve PayPal donation URL validation for complex query strings.
+* Tweak - Convert the `load_plugin_textdomain()` check from error to warning severity.
+* Fix - Improve readme contributors validation when trailing commas are present.
+* Fix - Make markdown file checks case-insensitive.
+* Tweak - Update WordPress.org Plugins Team naming for consistency.
 
 = 1.8.0 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === Plugin Check (PCP) ===
 
 Contributors:      wordpressdotorg
-Tested up to:      6.9
+Tested up to:      7.0
 Stable tag:        1.9.0
 License:           GPLv2 or later
 License URI:       https://www.gnu.org/licenses/gpl-2.0.html
@@ -85,12 +85,14 @@ In any case, passing the checks in this tool likely helps to achieve a smooth pl
 
 * Enhancement - Use the WordPress 7.0 core AI connectors.
 * Enhancement - Add External Admin Menu Links check to detect external URLs in top-level admin menus.
+* Enhancement - Add a block metadata check that requires editor blocks to define `apiVersion` 3 or higher for WordPress 7.0+ iframe editor compatibility.
 * Enhancement - Improve Plugin Updater detection to identify Plugin Update Checker (PUC) calls.
 * Enhancement - Accept WTFPL as a GPL-compatible license.
 * Fix - Improve PayPal donation URL validation for complex query strings.
 * Tweak - Convert the `load_plugin_textdomain()` check from error to warning severity.
 * Fix - Improve readme contributors validation when trailing commas are present.
 * Fix - Make markdown file checks case-insensitive.
+* Chore - Update development dependencies, including `@wordpress/scripts`, `simple-git`, `basic-ftp`, `svgo`, `immutable`, and `@wp-playground/cli`.
 * Tweak - Update WordPress.org Plugins Team naming for consistency.
 
 = 1.8.0 =

--- a/readme.txt
+++ b/readme.txt
@@ -85,13 +85,17 @@ In any case, passing the checks in this tool likely helps to achieve a smooth pl
 
 * Enhancement - Use the WordPress 7.0 core AI connectors.
 * Enhancement - Add External Admin Menu Links check to detect external URLs in top-level admin menus.
-* Enhancement - Add a block metadata check that requires editor blocks to define `apiVersion` 3 or higher for WordPress 7.0+ iframe editor compatibility.
+* Enhancement - Add and refine the block metadata compatibility check to require `apiVersion` 3+ for WordPress 7.0+ iframe editor compatibility, including adjusted severity by mode.
 * Enhancement - Improve Plugin Updater detection to identify Plugin Update Checker (PUC) calls.
 * Enhancement - Accept WTFPL as a GPL-compatible license.
 * Fix - Improve PayPal donation URL validation for complex query strings.
+* Fix - Ensure AI Check uses the configured model preference.
+* Fix - Show a clear Plugin Namer error message when AI connector status is unavailable.
+* Fix - Update the Plugin Namer connector settings page link.
 * Tweak - Convert the `load_plugin_textdomain()` check from error to warning severity.
 * Fix - Improve readme contributors validation when trailing commas are present.
 * Fix - Make markdown file checks case-insensitive.
+* Tweak - Refine escaping sniff error messages for clearer guidance.
 * Chore - Update development dependencies, including `@wordpress/scripts`, `simple-git`, `basic-ftp`, `svgo`, `immutable`, and `@wp-playground/cli`.
 * Tweak - Update WordPress.org Plugins Team naming for consistency.
 


### PR DESCRIPTION
Summary
- bump plugin.php version constants and the readme stable tag to 1.9.0
- refresh changelog entries with the v1.9.0 notes from milestone 23
- update docs/checks.md with the new and revised checks
