### PR TITLE
Add block.json apiVersion 3+ validation to Plugin_Content_Check with mode-based severity

### DIFF
--- a/includes/Checker/Checks/Plugin_Repo/Plugin_Content_Check.php
+++ b/includes/Checker/Checks/Plugin_Repo/Plugin_Content_Check.php
@@ -136,8 +136,8 @@ class Plugin_Content_Check extends Abstract_File_Check {
 	 * @param string       $file   Absolute path to block.json.
 	 */
 	private function add_block_api_version_result( Check_Result $result, string $file ) {
-		$is_error = ! $this->is_update_mode( $result );
-		$severity = $is_error ? 7 : 5;
+		$is_error = true;
+		$severity = $this->is_update_mode( $result ) ? 5 : 7;
 
 		$this->add_result_message_for_file(
 			$result,

--- a/includes/Checker/Checks/Plugin_Repo/Plugin_Content_Check.php
+++ b/includes/Checker/Checks/Plugin_Repo/Plugin_Content_Check.php
@@ -12,6 +12,7 @@ use WordPress\Plugin_Check\Checker\Check_Categories;
 use WordPress\Plugin_Check\Checker\Check_Result;
 use WordPress\Plugin_Check\Checker\Checks\Abstract_File_Check;
 use WordPress\Plugin_Check\Traits\Amend_Check_Result;
+use WordPress\Plugin_Check\Traits\Mode_Aware;
 use WordPress\Plugin_Check\Traits\Stable_Check;
 
 /**
@@ -22,6 +23,7 @@ use WordPress\Plugin_Check\Traits\Stable_Check;
 class Plugin_Content_Check extends Abstract_File_Check {
 
 	use Amend_Check_Result;
+	use Mode_Aware;
 	use Stable_Check;
 
 	/**
@@ -49,9 +51,11 @@ class Plugin_Content_Check extends Abstract_File_Check {
 	 *                   the check).
 	 */
 	protected function check_files( Check_Result $result, array $files ) {
-		$php_files = self::filter_files_by_extension( $files, 'php' );
+		$php_files        = self::filter_files_by_extension( $files, 'php' );
+		$block_json_files = self::filter_files_by_regex( $files, '/(?:^|\/)block\.json$/' );
 
 		$this->look_for_five_star_reviews( $result, $php_files );
+		$this->look_for_incompatible_block_api_versions( $result, $block_json_files );
 	}
 
 	/**
@@ -78,6 +82,73 @@ class Plugin_Content_Check extends Abstract_File_Check {
 				);
 			}
 		}
+	}
+
+	/**
+	 * Looks for block.json files with an apiVersion lower than 3.
+	 *
+	 * @since 1.9.0
+	 *
+	 * @param Check_Result $result           The check result to amend, including the plugin context to check.
+	 * @param array        $block_json_files List of absolute block.json file paths.
+	 */
+	protected function look_for_incompatible_block_api_versions( Check_Result $result, array $block_json_files ) {
+		foreach ( $block_json_files as $file ) {
+			$this->validate_block_api_version( $result, $file );
+		}
+	}
+
+	/**
+	 * Validates apiVersion in a block.json file.
+	 *
+	 * @since 1.9.0
+	 *
+	 * @param Check_Result $result The check result to amend.
+	 * @param string       $file   Absolute path to block.json.
+	 */
+	private function validate_block_api_version( Check_Result $result, string $file ) {
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+		$contents = file_get_contents( $file );
+		if ( false === $contents ) {
+			return;
+		}
+
+		$decoded = json_decode( $contents, true );
+		if ( ! is_array( $decoded ) ) {
+			$this->add_block_api_version_result( $result, $file );
+			return;
+		}
+
+		$api_version = $decoded['apiVersion'] ?? null;
+		if ( is_numeric( $api_version ) && intval( $api_version ) >= 3 ) {
+			return;
+		}
+
+		$this->add_block_api_version_result( $result, $file );
+	}
+
+	/**
+	 * Adds a result for an incompatible block apiVersion.
+	 *
+	 * @since 1.9.0
+	 *
+	 * @param Check_Result $result The check result to amend.
+	 * @param string       $file   Absolute path to block.json.
+	 */
+	private function add_block_api_version_result( Check_Result $result, string $file ) {
+		$is_error = ! $this->is_update_mode( $result );
+
+		$this->add_result_message_for_file(
+			$result,
+			$is_error,
+			__( 'Editor blocks must define "apiVersion" 3 or higher in block.json for WordPress 7.0+ iframe editor compatibility.', 'plugin-check' ),
+			'block_api_version_too_low',
+			$file,
+			0,
+			0,
+			'https://developer.wordpress.org/block-editor/reference-guides/block-api/block-api-versions/block-migration-for-iframe-editor-compatibility/',
+			7
+		);
 	}
 
 	/**

--- a/includes/Checker/Checks/Plugin_Repo/Plugin_Content_Check.php
+++ b/includes/Checker/Checks/Plugin_Repo/Plugin_Content_Check.php
@@ -137,6 +137,7 @@ class Plugin_Content_Check extends Abstract_File_Check {
 	 */
 	private function add_block_api_version_result( Check_Result $result, string $file ) {
 		$is_error = ! $this->is_update_mode( $result );
+		$severity = $is_error ? 7 : 5;
 
 		$this->add_result_message_for_file(
 			$result,
@@ -147,7 +148,7 @@ class Plugin_Content_Check extends Abstract_File_Check {
 			0,
 			0,
 			'https://developer.wordpress.org/block-editor/reference-guides/block-api/block-api-versions/block-migration-for-iframe-editor-compatibility/',
-			7
+			$severity
 		);
 	}
 

--- a/tests/phpunit/testdata/plugins/test-plugin-block-api-version-with-errors/blocks/empty/block.json
+++ b/tests/phpunit/testdata/plugins/test-plugin-block-api-version-with-errors/blocks/empty/block.json
@@ -1,0 +1,6 @@
+{
+  "apiVersion": "",
+  "name": "pcp/empty-version",
+  "title": "Empty API Version",
+  "category": "widgets"
+}

--- a/tests/phpunit/testdata/plugins/test-plugin-block-api-version-with-errors/blocks/missing/block.json
+++ b/tests/phpunit/testdata/plugins/test-plugin-block-api-version-with-errors/blocks/missing/block.json
@@ -1,0 +1,5 @@
+{
+  "name": "pcp/missing-version",
+  "title": "Missing API Version",
+  "category": "widgets"
+}

--- a/tests/phpunit/testdata/plugins/test-plugin-block-api-version-with-errors/blocks/v2/block.json
+++ b/tests/phpunit/testdata/plugins/test-plugin-block-api-version-with-errors/blocks/v2/block.json
@@ -1,0 +1,6 @@
+{
+  "apiVersion": 2,
+  "name": "pcp/v2-version",
+  "title": "V2 API Version",
+  "category": "widgets"
+}

--- a/tests/phpunit/testdata/plugins/test-plugin-block-api-version-with-errors/blocks/v3/block.json
+++ b/tests/phpunit/testdata/plugins/test-plugin-block-api-version-with-errors/blocks/v3/block.json
@@ -1,0 +1,6 @@
+{
+  "apiVersion": 3,
+  "name": "pcp/v3-version",
+  "title": "V3 API Version",
+  "category": "widgets"
+}

--- a/tests/phpunit/testdata/plugins/test-plugin-block-api-version-with-errors/includes/nested-block/block.json
+++ b/tests/phpunit/testdata/plugins/test-plugin-block-api-version-with-errors/includes/nested-block/block.json
@@ -1,0 +1,6 @@
+{
+  "apiVersion": 1,
+  "name": "pcp/nested-v1",
+  "title": "Nested V1 API Version",
+  "category": "widgets"
+}

--- a/tests/phpunit/testdata/plugins/test-plugin-block-api-version-with-errors/load.php
+++ b/tests/phpunit/testdata/plugins/test-plugin-block-api-version-with-errors/load.php
@@ -1,0 +1,4 @@
+<?php
+/**
+ * Plugin Name: Test Plugin Block API Version (Errors)
+ */

--- a/tests/phpunit/testdata/plugins/test-plugin-block-api-version-without-errors/blocks/v3/block.json
+++ b/tests/phpunit/testdata/plugins/test-plugin-block-api-version-without-errors/blocks/v3/block.json
@@ -1,0 +1,6 @@
+{
+  "apiVersion": 3,
+  "name": "pcp/valid-v3",
+  "title": "Valid V3",
+  "category": "widgets"
+}

--- a/tests/phpunit/testdata/plugins/test-plugin-block-api-version-without-errors/blocks/v4/block.json
+++ b/tests/phpunit/testdata/plugins/test-plugin-block-api-version-without-errors/blocks/v4/block.json
@@ -1,0 +1,6 @@
+{
+  "apiVersion": 4,
+  "name": "pcp/valid-v4",
+  "title": "Valid V4",
+  "category": "widgets"
+}

--- a/tests/phpunit/testdata/plugins/test-plugin-block-api-version-without-errors/load.php
+++ b/tests/phpunit/testdata/plugins/test-plugin-block-api-version-without-errors/load.php
@@ -1,0 +1,4 @@
+<?php
+/**
+ * Plugin Name: Test Plugin Block API Version (No Errors)
+ */

--- a/tests/phpunit/tests/Checker/Checks/Plugin_Content_Check_Tests.php
+++ b/tests/phpunit/tests/Checker/Checks/Plugin_Content_Check_Tests.php
@@ -10,6 +10,7 @@ use WordPress\Plugin_Check\Checker\Check_Result;
 use WordPress\Plugin_Check\Checker\Checks\Plugin_Repo\Plugin_Content_Check;
 
 class Plugin_Content_Check_Tests extends WP_UnitTestCase {
+
 	public function test_detect_five_stars_reviews_without_errors() {
 		$check_context = new Check_Context( UNIT_TESTS_PLUGIN_DIR . 'test-plugin-five-stars-without-errors/load.php' );
 		$check_result  = new Check_Result( $check_context );
@@ -26,5 +27,50 @@ class Plugin_Content_Check_Tests extends WP_UnitTestCase {
 		$this->assertSame( 'five_star_reviews_detected', $errors['load.php'][16][12][0]['code'] );
 		$this->assertTrue( isset( $errors['load.php'][17][16][0] ) );
 		$this->assertSame( 'five_star_reviews_detected', $errors['load.php'][17][16][0]['code'] );
+	}
+
+	public function test_detect_block_api_version_errors_in_new_mode() {
+		$check_context = new Check_Context( UNIT_TESTS_PLUGIN_DIR . 'test-plugin-block-api-version-with-errors/load.php', '', 'new' );
+		$check_result  = new Check_Result( $check_context );
+
+		$check = new Plugin_Content_Check();
+		$check->run( $check_result );
+
+		$errors = $check_result->get_errors();
+
+		$this->assertArrayHasKey( 'blocks/missing/block.json', $errors );
+		$this->assertArrayHasKey( 'blocks/empty/block.json', $errors );
+		$this->assertArrayHasKey( 'blocks/v2/block.json', $errors );
+		$this->assertArrayHasKey( 'includes/nested-block/block.json', $errors );
+		$this->assertArrayNotHasKey( 'blocks/v3/block.json', $errors );
+		$this->assertCount( 1, wp_list_filter( $errors['blocks/missing/block.json'][0][0], array( 'code' => 'block_api_version_too_low' ) ) );
+	}
+
+	public function test_detect_block_api_version_warnings_in_update_mode() {
+		$check_context = new Check_Context( UNIT_TESTS_PLUGIN_DIR . 'test-plugin-block-api-version-with-errors/load.php', '', 'update' );
+		$check_result  = new Check_Result( $check_context );
+
+		$check = new Plugin_Content_Check();
+		$check->run( $check_result );
+
+		$this->assertArrayHasKey( 'blocks/missing/block.json', $check_result->get_warnings() );
+		$this->assertArrayHasKey( 'blocks/empty/block.json', $check_result->get_warnings() );
+		$this->assertArrayHasKey( 'blocks/v2/block.json', $check_result->get_warnings() );
+		$this->assertArrayHasKey( 'includes/nested-block/block.json', $check_result->get_warnings() );
+		$this->assertArrayNotHasKey( 'blocks/v3/block.json', $check_result->get_warnings() );
+		$this->assertCount( 0, wp_list_filter( $check_result->get_errors()['blocks/missing/block.json'][0][0] ?? array(), array( 'code' => 'block_api_version_too_low' ) ) );
+	}
+
+	public function test_detect_block_api_version_without_errors() {
+		$check_context = new Check_Context( UNIT_TESTS_PLUGIN_DIR . 'test-plugin-block-api-version-without-errors/load.php' );
+		$check_result  = new Check_Result( $check_context );
+
+		$check = new Plugin_Content_Check();
+		$check->run( $check_result );
+
+		$this->assertEmpty( wp_list_filter( $check_result->get_errors()['blocks/v3/block.json'][0][0] ?? array(), array( 'code' => 'block_api_version_too_low' ) ) );
+		$this->assertEmpty( wp_list_filter( $check_result->get_errors()['blocks/v4/block.json'][0][0] ?? array(), array( 'code' => 'block_api_version_too_low' ) ) );
+		$this->assertEmpty( wp_list_filter( $check_result->get_warnings()['blocks/v3/block.json'][0][0] ?? array(), array( 'code' => 'block_api_version_too_low' ) ) );
+		$this->assertEmpty( wp_list_filter( $check_result->get_warnings()['blocks/v4/block.json'][0][0] ?? array(), array( 'code' => 'block_api_version_too_low' ) ) );
 	}
 }

--- a/tests/phpunit/tests/Checker/Checks/Plugin_Content_Check_Tests.php
+++ b/tests/phpunit/tests/Checker/Checks/Plugin_Content_Check_Tests.php
@@ -44,6 +44,7 @@ class Plugin_Content_Check_Tests extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'includes/nested-block/block.json', $errors );
 		$this->assertArrayNotHasKey( 'blocks/v3/block.json', $errors );
 		$this->assertCount( 1, wp_list_filter( $errors['blocks/missing/block.json'][0][0], array( 'code' => 'block_api_version_too_low' ) ) );
+		$this->assertSame( 7, $errors['blocks/missing/block.json'][0][0][0]['severity'] );
 	}
 
 	public function test_detect_block_api_version_warnings_in_update_mode() {
@@ -59,6 +60,7 @@ class Plugin_Content_Check_Tests extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'includes/nested-block/block.json', $check_result->get_warnings() );
 		$this->assertArrayNotHasKey( 'blocks/v3/block.json', $check_result->get_warnings() );
 		$this->assertCount( 0, wp_list_filter( $check_result->get_errors()['blocks/missing/block.json'][0][0] ?? array(), array( 'code' => 'block_api_version_too_low' ) ) );
+		$this->assertSame( 5, $check_result->get_warnings()['blocks/missing/block.json'][0][0][0]['severity'] );
 	}
 
 	public function test_detect_block_api_version_without_errors() {

--- a/tests/phpunit/tests/Checker/Checks/Plugin_Content_Check_Tests.php
+++ b/tests/phpunit/tests/Checker/Checks/Plugin_Content_Check_Tests.php
@@ -47,20 +47,20 @@ class Plugin_Content_Check_Tests extends WP_UnitTestCase {
 		$this->assertSame( 7, $errors['blocks/missing/block.json'][0][0][0]['severity'] );
 	}
 
-	public function test_detect_block_api_version_warnings_in_update_mode() {
+	public function test_detect_block_api_version_errors_in_update_mode() {
 		$check_context = new Check_Context( UNIT_TESTS_PLUGIN_DIR . 'test-plugin-block-api-version-with-errors/load.php', '', 'update' );
 		$check_result  = new Check_Result( $check_context );
 
 		$check = new Plugin_Content_Check();
 		$check->run( $check_result );
 
-		$this->assertArrayHasKey( 'blocks/missing/block.json', $check_result->get_warnings() );
-		$this->assertArrayHasKey( 'blocks/empty/block.json', $check_result->get_warnings() );
-		$this->assertArrayHasKey( 'blocks/v2/block.json', $check_result->get_warnings() );
-		$this->assertArrayHasKey( 'includes/nested-block/block.json', $check_result->get_warnings() );
-		$this->assertArrayNotHasKey( 'blocks/v3/block.json', $check_result->get_warnings() );
-		$this->assertCount( 0, wp_list_filter( $check_result->get_errors()['blocks/missing/block.json'][0][0] ?? array(), array( 'code' => 'block_api_version_too_low' ) ) );
-		$this->assertSame( 5, $check_result->get_warnings()['blocks/missing/block.json'][0][0][0]['severity'] );
+		$this->assertArrayHasKey( 'blocks/missing/block.json', $check_result->get_errors() );
+		$this->assertArrayHasKey( 'blocks/empty/block.json', $check_result->get_errors() );
+		$this->assertArrayHasKey( 'blocks/v2/block.json', $check_result->get_errors() );
+		$this->assertArrayHasKey( 'includes/nested-block/block.json', $check_result->get_errors() );
+		$this->assertArrayNotHasKey( 'blocks/v3/block.json', $check_result->get_errors() );
+		$this->assertCount( 0, wp_list_filter( $check_result->get_warnings()['blocks/missing/block.json'][0][0] ?? array(), array( 'code' => 'block_api_version_too_low' ) ) );
+		$this->assertSame( 5, $check_result->get_errors()['blocks/missing/block.json'][0][0][0]['severity'] );
 	}
 
 	public function test_detect_block_api_version_without_errors() {


### PR DESCRIPTION
## Summary
This PR addresses [#1205](https://github.com/WordPress/plugin-check/issues/1205) by adding a static validation for block `apiVersion` compatibility with the WordPress 7.0 iframe editor.

Instead of introducing a separate check class, the validation was integrated into the existing `Plugin_Content_Check` to keep plugin-repo content rules consolidated.

## What changed
- Added `block.json` scanning in `Plugin_Content_Check`.
- Added validation to flag blocks where `apiVersion` is:
  - missing
  - empty
  - lower than `3`
  - invalid/non-numeric JSON value
- Included all `block.json` files in plugin scope (including nested paths).

## Severity behavior by mode
- **New plugin mode (`new`)**:
  - reports **error**
  - severity **7**
- **Update mode (`update`)**:
  - reports **error**
  - severity **5**

## Tests
Added coverage in `Plugin_Content_Check_Tests` using dedicated fixtures:
- failing plugin fixture:
  - missing `apiVersion`
  - empty `apiVersion`
  - `apiVersion: 1`
  - `apiVersion: 2`
- passing plugin fixture:
  - `apiVersion: 3`
  - `apiVersion: 4`
- assertions for mode-dependent result type and severity (`7` vs `5`)
