### PR TITLE
Fix token usage not displayed in Namer result

### DIFF
--- a/assets/js/plugin-check-namer.js
+++ b/assets/js/plugin-check-namer.js
@@ -268,7 +268,17 @@
 							}
 						}
 
-						tokensText += tokenUsage.total_tokens + ' total';
+						const totalTokens =
+							tokenUsage.total_tokens ||
+							( tokenUsage.prompt_tokens &&
+							tokenUsage.completion_tokens
+								? tokenUsage.prompt_tokens +
+								  tokenUsage.completion_tokens
+								: null );
+
+						if ( totalTokens ) {
+							tokensText += totalTokens + ' total';
+						}
 
 						// Add breakdown with prompt and completion tokens.
 						if (

--- a/includes/Traits/AI_Check_Names.php
+++ b/includes/Traits/AI_Check_Names.php
@@ -163,10 +163,12 @@ trait AI_Check_Names {
 		}
 
 		// Try to generate a rich result first.
+		// Use is_callable() instead of method_exists() to detect methods
+		// provided via __call() magic (e.g. WP_AI_Client_Prompt_Builder).
 		$result = null;
-		if ( method_exists( $builder, 'generate_text_result' ) ) {
+		if ( is_callable( array( $builder, 'generate_text_result' ) ) ) {
 			$result = $builder->generate_text_result();
-		} elseif ( method_exists( $builder, 'generateTextResult' ) ) {
+		} elseif ( is_callable( array( $builder, 'generateTextResult' ) ) ) {
 			$result = $builder->generateTextResult();
 		}
 
@@ -280,6 +282,11 @@ trait AI_Check_Names {
 		$prompt_tokens     = method_exists( $usage, 'get_prompt_tokens' ) ? $usage->get_prompt_tokens() : ( method_exists( $usage, 'getPromptTokens' ) ? $usage->getPromptTokens() : null );
 		$completion_tokens = method_exists( $usage, 'get_completion_tokens' ) ? $usage->get_completion_tokens() : ( method_exists( $usage, 'getCompletionTokens' ) ? $usage->getCompletionTokens() : null );
 		$total_tokens      = method_exists( $usage, 'get_total_tokens' ) ? $usage->get_total_tokens() : ( method_exists( $usage, 'getTotalTokens' ) ? $usage->getTotalTokens() : null );
+
+		// Compute total from prompt + completion if not directly available.
+		if ( null === $total_tokens && null !== $prompt_tokens && null !== $completion_tokens ) {
+			$total_tokens = $prompt_tokens + $completion_tokens;
+		}
 
 		if ( null === $prompt_tokens && null === $completion_tokens && null === $total_tokens ) {
 			return null;


### PR DESCRIPTION
## Summary

Fixes #1220

- **Root cause:** `WP_AI_Client_Prompt_Builder` provides methods like `generate_text_result()` via PHP's `__call()` magic method. The code used `method_exists()` which returns `false` for magic methods, so `generate_text_result()` was never called. Instead, it always fell through to `generate_text()` which returns a plain string with no token usage data — resulting in "undefined total" in the UI.
- **Fix:** Replace `method_exists()` with `is_callable()` in `execute_ai_request()` so the rich result path is used and token usage is returned.
- **Fallback:** Compute `total_tokens` from `prompt_tokens + completion_tokens` in PHP if not directly available, and add defensive JS handling to prevent "undefined total" display.

### Screenshot
<img width="1623" height="816" alt="image" src="https://github.com/user-attachments/assets/88409e17-7936-4859-8a41-91a7d8456b2d" />


## Test plan

- [ ] Go to **WP Admin → Tools → Plugin Check Namer**
- [ ] Enter a plugin name and click **Evaluate name**
- [ ] Verify the **Tokens used** line displays actual numeric values (e.g. `1,234 total (850 prompt + 384 completion)`)
- [ ] Verify the similar name query token count is also displayed when available