### PR TITLE
Fix wp-env warning

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -22,7 +22,9 @@ tests
 .phpunit.result.cache
 .typos.toml
 .wp-env.json
+.wp-env.tests.json
 .wp-env.override.json
+.wp-env.tests.override.json
 behat.yml
 codecov.yml
 composer.lock

--- a/.gitattributes
+++ b/.gitattributes
@@ -17,6 +17,7 @@
 /.nvmrc export-ignore
 /.typos.toml export-ignore
 /.wp-env.json export-ignore
+/.wp-env.tests.json export-ignore
 /composer.lock export-ignore
 /package.json export-ignore
 /package-lock.json export-ignore

--- a/.github/workflows/php-test.yml
+++ b/.github/workflows/php-test.yml
@@ -93,9 +93,9 @@ jobs:
       - name: Start WordPress
         run: |
           if [[ ${{ matrix.coverage == true }} == true ]]; then
-            npm run wp-env start -- --config=.wp-env.tests.json --xdebug=coverage
+            npm run wp-env:start:tests -- --xdebug=coverage
           else
-            npm run wp-env start -- --config=.wp-env.tests.json
+            npm run wp-env:start:tests
           fi
 
       - name: Run tests

--- a/.github/workflows/php-test.yml
+++ b/.github/workflows/php-test.yml
@@ -10,6 +10,7 @@ on:
       - '.github/workflows/php-test.yml'
       - '**.php'
       - '.wp-env.json'
+      - '.wp-env.tests.json'
       - '**/package.json'
       - 'package-lock.json'
       - 'phpcs-rulesets/*.xml'
@@ -26,6 +27,7 @@ on:
       - '.github/workflows/php-test.yml'
       - '**.php'
       - '.wp-env.json'
+      - '.wp-env.tests.json'
       - '**/package.json'
       - 'package-lock.json'
       - 'phpcs-rulesets/*.xml'
@@ -91,9 +93,9 @@ jobs:
       - name: Start WordPress
         run: |
           if [[ ${{ matrix.coverage == true }} == true ]]; then
-            npm run wp-env start -- --xdebug=coverage
+            npm run wp-env start -- --config=.wp-env.tests.json --xdebug=coverage
           else
-            npm run wp-env start
+            npm run wp-env start -- --config=.wp-env.tests.json
           fi
 
       - name: Run tests

--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,4 @@ temp/
 ############
 
 .wp-env.override.json
+.wp-env.tests.override.json

--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://schemas.wp.org/trunk/wp-env.json",
   "core": null,
-  "plugins": [ "." ],
-  "testsEnvironment": false
+  "plugins": [ "." ]
 }

--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,6 +1,6 @@
 {
-	"$schema": "https://schemas.wp.org/trunk/wp-env.json",
-	"core": null,
-	"plugins": [ "." ],
-	"testsEnvironment": false
+  "$schema": "https://schemas.wp.org/trunk/wp-env.json",
+  "core": null,
+  "plugins": [ "." ],
+  "testsEnvironment": false
 }

--- a/.wp-env.tests.json
+++ b/.wp-env.tests.json
@@ -1,8 +1,7 @@
 {
-	"$schema": "https://schemas.wp.org/trunk/wp-env.json",
-	"core": null,
-	"plugins": [ "." ],
-	"testsEnvironment": false,
-	"phpVersion": "7.4",
-	"port": 8889
+  "$schema": "https://schemas.wp.org/trunk/wp-env.json",
+  "core": null,
+  "plugins": [ "." ],
+  "phpVersion": "7.4",
+  "port": 8889
 }

--- a/.wp-env.tests.json
+++ b/.wp-env.tests.json
@@ -2,5 +2,7 @@
 	"$schema": "https://schemas.wp.org/trunk/wp-env.json",
 	"core": null,
 	"plugins": [ "." ],
-	"testsEnvironment": false
+	"testsEnvironment": false,
+	"phpVersion": "7.4",
+	"port": 8889
 }

--- a/.wp-env.tests.json
+++ b/.wp-env.tests.json
@@ -3,5 +3,6 @@
   "core": null,
   "plugins": [ "." ],
   "phpVersion": "7.4",
-  "port": 8889
+  "port": 8889,
+  "testsPort": 8890
 }

--- a/README.md
+++ b/README.md
@@ -55,14 +55,23 @@ npm install
 
 With the above commands, you can use the plugin in any development environment as you like. The recommended way is to use the built-in development environment, which is based on the [`@wordpress/env` package](https://www.npmjs.com/package/@wordpress/env), as that will allow you to use the preconfigured commands to e.g. run unit tests, linting etc. You will need to have Docker installed to use this environment.
 
-You can start the built-in environment as follows:
+Start the **development** site:
+
 ```
 npm run wp-env start
 ```
 
-If you want to stop the environment again, you can use:
+Start the **tests** stack:
+
+```
+npm run wp-env:start:tests
+```
+
+Stop each stack when finished:
+
 ```
 npm run wp-env stop
+npm run wp-env:stop:tests
 ```
 
 For further information on contributing, please see the [contributing guide](/CONTRIBUTING.md).

--- a/docs/running-unit-tests.md
+++ b/docs/running-unit-tests.md
@@ -8,7 +8,7 @@ Follow these instructions to configure and run tests:
 
 1. You would need npm installed in your computer.
 2. Ensure that you have installed all npm dependencies with `npm ci`.
-3. You need to have Docker installed and running wp-env environment `npm run wp-env start`.
+3. You need Docker installed. Start the tests wp-env stack with `npm run wp-env:start:tests`.
 4. Run tests with npm command `npm run test-php`.
 
 The full test suite is run against PRs as a GitHub action ([example](https://github.com/WordPress/plugin-check/actions/runs/9660204610)) so tests can be run against all supported environments. Passing tests is a requirement for merging PRs. Being able to run them locally is meant to help developers while working on or debugging tests, prior to submitting their code for review.
@@ -18,8 +18,8 @@ The full test suite is run against PRs as a GitHub action ([example](https://git
 We have this structure for the tests folder:
 
 - `tests/phpunit` Unit tests for the plugin.
-  - `tests/phpunit/tests/` All PHPUnit tests that run as part of the suite.  
-  - `tests/phpunit/testdata/` Example classes or plugins that can be used in tests.  
-  - `tests/phpunit/utils/` Shared helpers that can be used across different test classes.  
+  - `tests/phpunit/tests/` All PHPUnit tests that run as part of the suite.
+  - `tests/phpunit/testdata/` Example classes or plugins that can be used in tests.
+  - `tests/phpunit/utils/` Shared helpers that can be used across different test classes.
 
 Ensure that you create your check and unit test at same time.

--- a/package.json
+++ b/package.json
@@ -16,15 +16,17 @@
   },
   "scripts": {
     "wp-env": "wp-env",
+    "wp-env:start:tests": "wp-env start --config=.wp-env.tests.json",
+    "wp-env:stop:tests": "wp-env stop --config=.wp-env.tests.json",
     "lint-js": "wp-scripts lint-js",
     "format-js": "npm run lint-js -- --fix",
     "lint-gherkin": "gherkin-lint",
-    "phpstan": "wp-env run tests-cli --env-cwd=wp-content/plugins/$(basename \"$(pwd)\")/ composer run-script phpstan",
-    "lint-php": "wp-env run tests-cli --env-cwd=wp-content/plugins/$(basename \"$(pwd)\")/ composer run-script lint",
-    "format-php": "wp-env run tests-cli --env-cwd=wp-content/plugins/$(basename \"$(pwd)\")/ composer run-script format",
-    "test-php": "wp-env run tests-cli --env-cwd=/var/www/html/wp-content/plugins/$(basename \"$(pwd)\") vendor/bin/phpunit -c phpunit.xml.dist",
-    "test-php-coverage": "wp-env run tests-cli --env-cwd=/var/www/html/wp-content/plugins/$(basename \"$(pwd)\") vendor/bin/phpunit -c phpunit.xml.dist --coverage-clover build/logs/php-coverage.xml",
-    "test-php-multisite": "wp-env run tests-cli --env-cwd=/var/www/html/wp-content/plugins/$(basename \"$(pwd)\") vendor/bin/phpunit -c tests/phpunit/multisite.xml",
-    "test-php-multisite-coverage": "wp-env run tests-cli --env-cwd=/var/www/html/wp-content/plugins/$(basename \"$(pwd)\") vendor/bin/phpunit -c tests/phpunit/multisite.xml --coverage-clover build/logs/php-coverage-multisite.xml"
+    "phpstan": "wp-env --config=.wp-env.tests.json run cli --env-cwd=wp-content/plugins/$(basename \"$(pwd)\")/ composer run-script phpstan",
+    "lint-php": "wp-env --config=.wp-env.tests.json run cli --env-cwd=wp-content/plugins/$(basename \"$(pwd)\")/ composer run-script lint",
+    "format-php": "wp-env --config=.wp-env.tests.json run cli --env-cwd=wp-content/plugins/$(basename \"$(pwd)\")/ composer run-script format",
+    "test-php": "wp-env --config=.wp-env.tests.json run cli --env-cwd=/var/www/html/wp-content/plugins/$(basename \"$(pwd)\") vendor/bin/phpunit -c phpunit.xml.dist",
+    "test-php-coverage": "wp-env --config=.wp-env.tests.json run cli --env-cwd=/var/www/html/wp-content/plugins/$(basename \"$(pwd)\") vendor/bin/phpunit -c phpunit.xml.dist --coverage-clover build/logs/php-coverage.xml",
+    "test-php-multisite": "wp-env --config=.wp-env.tests.json run cli --env-cwd=/var/www/html/wp-content/plugins/$(basename \"$(pwd)\") vendor/bin/phpunit -c tests/phpunit/multisite.xml",
+    "test-php-multisite-coverage": "wp-env --config=.wp-env.tests.json run cli --env-cwd=/var/www/html/wp-content/plugins/$(basename \"$(pwd)\") vendor/bin/phpunit -c tests/phpunit/multisite.xml --coverage-clover build/logs/php-coverage-multisite.xml"
   }
 }


### PR DESCRIPTION
Fixes https://github.com/WordPress/plugin-check/issues/1236

- [x] Fix `.wp-env.json` indentation to use 2-space indentation (per `.editorconfig`)
- [x] Fix `.wp-env.tests.json` indentation to use 2-space indentation (per `.editorconfig`)
- [x] Remove deprecated `testsEnvironment: false` from `.wp-env.tests.json`
- [x] Remove deprecated `testsEnvironment: false` from `.wp-env.json`
- [x] Update `.github/workflows/php-test.yml` to use dedicated npm scripts (`wp-env:start:tests`) instead of hard-coded commands
- [x] Fix CI port conflict: add explicit `testsPort: 8890` to `.wp-env.tests.json` so dev (8889) and tests (8890) environments don't share the same port

<!-- START COPILOT CODING AGENT TIPS -->
---

✨ Let Copilot coding agent [set things up for you](https://github.com/WordPress/plugin-check/issues/new?title=✨+Set+up+Copilot+instructions&body=Configure%20instructions%20for%20this%20repository%20as%20documented%20in%20%5BBest%20practices%20for%20Copilot%20coding%20agent%20in%20your%20repository%5D%28https://gh.io/copilot-coding-agent-tips%29%2E%0A%0A%3COnboard%20this%20repo%3E&assignees=copilot) — coding agent works faster and does higher quality work when set up for your repo.
