### PR TITLE
Fix: Restrict Namer model dropdown to text-generation capable models

### DIFF
--- a/includes/Traits/AI_Utils.php
+++ b/includes/Traits/AI_Utils.php
@@ -386,7 +386,6 @@ trait AI_Utils {
 				$provider_meta = $class_name::metadata();
 
 				foreach ( $class_name::modelMetadataDirectory()->listModelMetadata() as $model_meta ) {
-
 					if ( ! $this->supports_text_io_from_metadata( $model_meta ) ) {
 						continue;
 					}

--- a/includes/Traits/AI_Utils.php
+++ b/includes/Traits/AI_Utils.php
@@ -255,7 +255,12 @@ trait AI_Utils {
 	/**
 	 * Determines whether a model metadata object supports text generation.
 	 *
+	 * Both input and output must be text-based; models that support non-text output
+	 * modalities (e.g. audio, image) are excluded.
+	 *
 	 * @since 1.9.1
+	 *
+	 * @SuppressWarnings(PHPMD.CyclomaticComplexity)
 	 *
 	 * @param object $model_meta Model metadata object.
 	 * @return bool True when the model supports text generation, otherwise false.
@@ -271,17 +276,64 @@ trait AI_Utils {
 			return false;
 		}
 
+		$has_text_generation = false;
 		foreach ( $capabilities as $capability ) {
 			if ( is_string( $capability ) && 'text_generation' === $capability ) {
-				return true;
+				$has_text_generation = true;
+				break;
 			}
 
 			if ( is_object( $capability ) && method_exists( $capability, 'equals' ) && $capability->equals( 'text_generation' ) ) {
-				return true;
+				$has_text_generation = true;
+				break;
 			}
 		}
 
-		return false;
+		if ( ! $has_text_generation ) {
+			return false;
+		}
+
+		// Also ensure all supported output modality combinations are text-only.
+		if ( method_exists( $model_meta, 'getSupportedOptions' ) ) {
+			$options = $model_meta->getSupportedOptions();
+			if ( is_array( $options ) ) {
+				foreach ( $options as $option ) {
+					if ( ! is_object( $option ) || ! method_exists( $option, 'getName' ) ) {
+						continue;
+					}
+					$option_name = $option->getName();
+					if (
+						! is_object( $option_name )
+						|| ! method_exists( $option_name, 'isOutputModalities' )
+						|| ! $option_name->isOutputModalities()
+					) {
+						continue;
+					}
+					if ( ! method_exists( $option, 'getSupportedValues' ) ) {
+						continue;
+					}
+					$supported_values = $option->getSupportedValues();
+					if ( ! is_array( $supported_values ) ) {
+						continue;
+					}
+					foreach ( $supported_values as $combination ) {
+						if ( ! is_array( $combination ) ) {
+							continue;
+						}
+						foreach ( $combination as $modality ) {
+							$is_text = ( is_string( $modality ) && 'text' === $modality )
+								|| ( is_object( $modality ) && method_exists( $modality, 'isText' ) && $modality->isText() )
+								|| ( is_object( $modality ) && isset( $modality->value ) && 'text' === $modality->value );
+							if ( ! $is_text ) {
+								return false;
+							}
+						}
+					}
+				}
+			}
+		}
+
+		return true;
 	}
 
 	/**

--- a/includes/Traits/AI_Utils.php
+++ b/includes/Traits/AI_Utils.php
@@ -224,22 +224,8 @@ trait AI_Utils {
 		// If capabilities metadata is present, require text_generation capability.
 		if ( method_exists( $model_meta, 'getSupportedCapabilities' ) ) {
 			$supported = $model_meta->getSupportedCapabilities();
-			if ( is_array( $supported ) ) {
-				$has_text_gen = false;
-				foreach ( $supported as $cap ) {
-					$val = '';
-					if ( is_object( $cap ) && 'text_generation' === strtolower( (string) $cap ) ) {
-						$has_text_gen = true;
-						break;
-					}
-					if ( is_string( $cap ) && 'text_generation' === strtolower( $cap ) ) {
-						$has_text_gen = true;
-						break;
-					}
-				}
-				if ( ! $has_text_gen ) {
-					return false;
-				}
+			if ( is_array( $supported ) && ! $this->meta_has_text_generation_cap( $supported ) ) {
+				return false;
 			}
 		}
 
@@ -247,67 +233,14 @@ trait AI_Utils {
 		if ( method_exists( $model_meta, 'getSupportedOptions' ) ) {
 			$options = $model_meta->getSupportedOptions();
 			if ( is_array( $options ) ) {
-				$input_has_text  = null;
-				$output_has_text = null;
-
-				foreach ( $options as $option ) {
-					if ( ! is_object( $option ) || ! method_exists( $option, 'getName' ) ) {
-						continue;
-					}
-
-					$name      = $option->getName();
-					$is_input  = false;
-					$is_output = false;
-
-					if ( is_object( $name ) ) {
-						$raw       = strtolower( (string) $name );
-						$is_input  = 'input_modalities' === $raw;
-						$is_output = 'output_modalities' === $raw;
-					} elseif ( is_string( $name ) ) {
-						$raw       = strtolower( $name );
-						$is_input  = 'inputmodalities' === $raw || 'input_modalities' === $raw;
-						$is_output = 'outputmodalities' === $raw || 'output_modalities' === $raw;
-					}
-
-					if ( ! $is_input && ! $is_output ) {
-						continue;
-					}
-
-					if ( ! method_exists( $option, 'getSupportedValues' ) ) {
-						continue;
-					}
-
-					$values   = $option->getSupportedValues();
-					$has_text = $this->modality_values_include_text( $values );
-
-					if ( $is_input ) {
-						$input_has_text = $has_text;
-					}
-					if ( $is_output ) {
-						$output_has_text = $has_text;
-					}
-				}
-
-				// If modality options were present, use them as the authority.
-				if ( null !== $input_has_text || null !== $output_has_text ) {
-					return (bool) $input_has_text && (bool) $output_has_text;
+				$modality = $this->meta_get_modality_text_support( $options );
+				if ( null !== $modality['input'] || null !== $modality['output'] ) {
+					return (bool) $modality['input'] && (bool) $modality['output'];
 				}
 			}
 		}
 
-		// Fall back to name-based inference.
-		if ( method_exists( $model_meta, 'getId' ) ) {
-			$model = strtolower( (string) $model_meta->getId() );
-			if (
-			false !== strpos( $model, 'transcribe' )
-			|| false !== strpos( $model, 'tts' )
-			|| false !== strpos( $model, 'realtime' )
-			) {
-				return false;
-			}
-		}
-
-		return true;
+		return ! $this->meta_is_audio_model_by_name( $model_meta );
 	}
 
 	/**
@@ -341,6 +274,90 @@ trait AI_Utils {
 		}
 
 		return false;
+	}
+
+	/**
+	 * Returns whether a capabilities array contains text_generation.
+	 *
+	 * @since 2.0.0
+	 *
+	 * @param array $supported Capabilities from getSupportedCapabilities().
+	 * @return bool
+	 */
+	private function meta_has_text_generation_cap( array $supported ): bool {
+		foreach ( $supported as $cap ) {
+			if ( is_object( $cap ) && 'text_generation' === strtolower( (string) $cap ) ) {
+				return true;
+			}
+			if ( is_string( $cap ) && 'text_generation' === strtolower( $cap ) ) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	/**
+	 * Returns input/output text-modality support derived from getSupportedOptions().
+	 *
+	 * @since 2.0.0
+	 *
+	 * @param array $options Options from getSupportedOptions().
+	 * @return array
+	 */
+	private function meta_get_modality_text_support( array $options ): array {
+		$input_has_text  = null;
+		$output_has_text = null;
+
+		foreach ( $options as $option ) {
+			if ( ! is_object( $option ) || ! method_exists( $option, 'getName' ) ) {
+				continue;
+			}
+			$name      = $option->getName();
+			$is_input  = false;
+			$is_output = false;
+			if ( is_object( $name ) ) {
+				$raw       = strtolower( (string) $name );
+				$is_input  = 'input_modalities' === $raw;
+				$is_output = 'output_modalities' === $raw;
+			} elseif ( is_string( $name ) ) {
+				$raw       = strtolower( $name );
+				$is_input  = 'inputmodalities' === $raw || 'input_modalities' === $raw;
+				$is_output = 'outputmodalities' === $raw || 'output_modalities' === $raw;
+			}
+			if ( ( ! $is_input && ! $is_output ) || ! method_exists( $option, 'getSupportedValues' ) ) {
+				continue;
+			}
+			$has_text = $this->modality_values_include_text( $option->getSupportedValues() );
+			if ( $is_input ) {
+				$input_has_text = $has_text;
+			}
+			if ( $is_output ) {
+				$output_has_text = $has_text;
+			}
+		}
+
+		return array(
+			'input'  => $input_has_text,
+			'output' => $output_has_text,
+		);
+	}
+
+	/**
+	 * Returns true when model name suggests audio-only (transcription / TTS / realtime).
+	 *
+	 * @since 2.0.0
+	 *
+	 * @param object $model_meta Model metadata object.
+	 * @return bool
+	 */
+	private function meta_is_audio_model_by_name( $model_meta ): bool {
+		if ( ! method_exists( $model_meta, 'getId' ) ) {
+			return false;
+		}
+		$model = strtolower( (string) $model_meta->getId() );
+		return false !== strpos( $model, 'transcribe' )
+			|| false !== strpos( $model, 'tts' )
+			|| false !== strpos( $model, 'realtime' );
 	}
 
 	/**

--- a/includes/Traits/AI_Utils.php
+++ b/includes/Traits/AI_Utils.php
@@ -8,7 +8,6 @@
 namespace WordPress\Plugin_Check\Traits;
 
 use WordPress\AiClient\AiClient;
-use WordPress\AiClient\Common\AbstractEnum;
 use WP_Error;
 
 /**
@@ -229,7 +228,7 @@ trait AI_Utils {
 				$has_text_gen = false;
 				foreach ( $supported as $cap ) {
 					$val = '';
-					if ( $cap instanceof AbstractEnum && 'text_generation' === strtolower( (string) $cap->value ) ) {
+					if ( is_object( $cap ) && 'text_generation' === strtolower( (string) $cap ) ) {
 						$has_text_gen = true;
 						break;
 					}
@@ -260,8 +259,8 @@ trait AI_Utils {
 					$is_input  = false;
 					$is_output = false;
 
-					if ( $name instanceof AbstractEnum ) {
-						$raw       = strtolower( (string) $name->value );
+					if ( is_object( $name ) ) {
+						$raw       = strtolower( (string) $name );
 						$is_input  = 'input_modalities' === $raw;
 						$is_output = 'output_modalities' === $raw;
 					} elseif ( is_string( $name ) ) {
@@ -332,7 +331,7 @@ trait AI_Utils {
 				$text = '';
 				if ( is_string( $modality ) ) {
 					$text = strtolower( $modality );
-				} elseif ( $modality instanceof AbstractEnum && 'text' === strtolower( (string) $modality->value ) ) {
+				} elseif ( is_object( $modality ) && 'text' === strtolower( (string) $modality ) ) {
 					return true;
 				}
 				if ( 'text' === $text ) {

--- a/includes/Traits/AI_Utils.php
+++ b/includes/Traits/AI_Utils.php
@@ -206,6 +206,148 @@ trait AI_Utils {
 	}
 
 	/**
+	 * Returns whether a model metadata object supports text for both input and output.
+	 *
+	 * Checks supported capabilities for text_generation, then inspects input/output
+	 * modality options. Falls back to name-based inference when metadata is insufficient.
+	 *
+	 * @since 2.0.0
+	 *
+	 * @param object $model_meta Model metadata object.
+	 * @return bool True when the model supports text input and text output.
+	 */
+	protected function supports_text_io_from_metadata( $model_meta ) {
+		if ( ! is_object( $model_meta ) ) {
+			return false;
+		}
+
+		// If capabilities metadata is present, require text_generation capability.
+		if ( method_exists( $model_meta, 'getSupportedCapabilities' ) ) {
+			$supported = $model_meta->getSupportedCapabilities();
+			if ( is_array( $supported ) ) {
+				$has_text_gen = false;
+				foreach ( $supported as $cap ) {
+					$val = '';
+					if ( is_object( $cap ) && method_exists( $cap, '__get' ) && 'text_generation' === strtolower( (string) $cap->value ) ) {
+						$has_text_gen = true;
+						break;
+					}
+					if ( is_string( $cap ) && 'text_generation' === strtolower( $cap ) ) {
+						$has_text_gen = true;
+						break;
+					}
+				}
+				if ( ! $has_text_gen ) {
+					return false;
+				}
+			}
+		}
+
+		// Check input/output modality options for text support.
+		if ( method_exists( $model_meta, 'getSupportedOptions' ) ) {
+			$options = $model_meta->getSupportedOptions();
+			if ( is_array( $options ) ) {
+				$input_has_text  = null;
+				$output_has_text = null;
+
+				foreach ( $options as $option ) {
+					if ( ! is_object( $option ) || ! method_exists( $option, 'getName' ) ) {
+						continue;
+					}
+
+					$name      = $option->getName();
+					$is_input  = false;
+					$is_output = false;
+
+					if ( is_object( $name ) ) {
+						if ( method_exists( $name, '__get' ) ) {
+							$raw       = strtolower( (string) $name->value );
+							$is_input  = 'input_modalities' === $raw;
+							$is_output = 'output_modalities' === $raw;
+						}
+					} elseif ( is_string( $name ) ) {
+						$raw       = strtolower( $name );
+						$is_input  = 'inputmodalities' === $raw || 'input_modalities' === $raw;
+						$is_output = 'outputmodalities' === $raw || 'output_modalities' === $raw;
+					}
+
+					if ( ! $is_input && ! $is_output ) {
+						continue;
+					}
+
+					if ( ! method_exists( $option, 'getSupportedValues' ) ) {
+						continue;
+					}
+
+					$values   = $option->getSupportedValues();
+					$has_text = $this->modality_values_include_text( $values );
+
+					if ( $is_input ) {
+						$input_has_text = $has_text;
+					}
+					if ( $is_output ) {
+						$output_has_text = $has_text;
+					}
+				}
+
+				// If modality options were present, use them as the authority.
+				if ( null !== $input_has_text || null !== $output_has_text ) {
+					return (bool) $input_has_text && (bool) $output_has_text;
+				}
+			}
+		}
+
+		// Fall back to name-based inference.
+		if ( method_exists( $model_meta, 'getId' ) ) {
+			$model = strtolower( (string) $model_meta->getId() );
+			if (
+			false !== strpos( $model, 'transcribe' )
+			|| false !== strpos( $model, 'tts' )
+			|| false !== strpos( $model, 'realtime' )
+			) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	/**
+	 * Returns whether a supported-values matrix contains a text modality.
+	 *
+	 * @since 2.0.0
+	 *
+	 * @param mixed $values Supported values from a SupportedOption (array of combinations).
+	 * @return bool True when at least one item resolves to text.
+	 */
+	protected function modality_values_include_text( $values ) {
+		if ( ! is_array( $values ) ) {
+			return false;
+		}
+
+		foreach ( $values as $combination ) {
+			if ( ! is_array( $combination ) ) {
+				continue;
+			}
+			foreach ( $combination as $modality ) {
+				$text = '';
+				if ( is_string( $modality ) ) {
+					$text = strtolower( $modality );
+				} elseif ( is_object( $modality ) ) {
+					if ( method_exists( $modality, '__get' ) && 'text' === strtolower( (string) $modality->value ) ) {
+						return true;
+					}
+				}
+				if ( 'text' === $text ) {
+					return true;
+				}
+			}
+		}
+
+		return false;
+	}
+
+	/**
 	 * Returns models from active/configured providers using the official AI Client registry flow.
 	 *
 	 * @since 1.9.0
@@ -232,7 +374,7 @@ trait AI_Utils {
 
 				foreach ( $class_name::modelMetadataDirectory()->listModelMetadata() as $model_meta ) {
 
-					if ( ! $this->model_supports_text_generation( $model_meta ) ) {
+					if ( ! $this->supports_text_io_from_metadata( $model_meta ) ) {
 						continue;
 					}
 
@@ -250,90 +392,6 @@ trait AI_Utils {
 
 		$models = apply_filters( 'plugin_check_ai_model_preferences', $models );
 		return is_array( $models ) ? $models : array();
-	}
-
-	/**
-	 * Determines whether a model metadata object supports text generation.
-	 *
-	 * Both input and output must be text-based; models that support non-text output
-	 * modalities (e.g. audio, image) are excluded.
-	 *
-	 * @since 1.9.1
-	 *
-	 * @SuppressWarnings(PHPMD.CyclomaticComplexity)
-	 *
-	 * @param object $model_meta Model metadata object.
-	 * @return bool True when the model supports text generation, otherwise false.
-	 */
-	protected function model_supports_text_generation( $model_meta ) {
-
-		if ( ! method_exists( $model_meta, 'getSupportedCapabilities' ) ) {
-			return true;
-		}
-
-		$capabilities = $model_meta->getSupportedCapabilities();
-		if ( ! is_array( $capabilities ) ) {
-			return false;
-		}
-
-		$has_text_generation = false;
-		foreach ( $capabilities as $capability ) {
-			if ( is_string( $capability ) && 'text_generation' === $capability ) {
-				$has_text_generation = true;
-				break;
-			}
-
-			if ( is_object( $capability ) && method_exists( $capability, 'equals' ) && $capability->equals( 'text_generation' ) ) {
-				$has_text_generation = true;
-				break;
-			}
-		}
-
-		if ( ! $has_text_generation ) {
-			return false;
-		}
-
-		// Also ensure all supported output modality combinations are text-only.
-		if ( method_exists( $model_meta, 'getSupportedOptions' ) ) {
-			$options = $model_meta->getSupportedOptions();
-			if ( is_array( $options ) ) {
-				foreach ( $options as $option ) {
-					if ( ! is_object( $option ) || ! method_exists( $option, 'getName' ) ) {
-						continue;
-					}
-					$option_name = $option->getName();
-					if (
-						! is_object( $option_name )
-						|| ! method_exists( $option_name, 'isOutputModalities' )
-						|| ! $option_name->isOutputModalities()
-					) {
-						continue;
-					}
-					if ( ! method_exists( $option, 'getSupportedValues' ) ) {
-						continue;
-					}
-					$supported_values = $option->getSupportedValues();
-					if ( ! is_array( $supported_values ) ) {
-						continue;
-					}
-					foreach ( $supported_values as $combination ) {
-						if ( ! is_array( $combination ) ) {
-							continue;
-						}
-						foreach ( $combination as $modality ) {
-							$is_text = ( is_string( $modality ) && 'text' === $modality )
-								|| ( is_object( $modality ) && method_exists( $modality, 'isText' ) && $modality->isText() )
-								|| ( is_object( $modality ) && isset( $modality->value ) && 'text' === $modality->value );
-							if ( ! $is_text ) {
-								return false;
-							}
-						}
-					}
-				}
-			}
-		}
-
-		return true;
 	}
 
 	/**

--- a/includes/Traits/AI_Utils.php
+++ b/includes/Traits/AI_Utils.php
@@ -231,6 +231,11 @@ trait AI_Utils {
 				$provider_meta = $class_name::metadata();
 
 				foreach ( $class_name::modelMetadataDirectory()->listModelMetadata() as $model_meta ) {
+
+					if ( ! $this->model_supports_text_generation( $model_meta ) ) {
+						continue;
+					}
+
 					$models[] = array(
 						'provider'       => (string) $provider_id,
 						'provider_label' => (string) $provider_meta->getName(),
@@ -245,6 +250,38 @@ trait AI_Utils {
 
 		$models = apply_filters( 'plugin_check_ai_model_preferences', $models );
 		return is_array( $models ) ? $models : array();
+	}
+
+	/**
+	 * Determines whether a model metadata object supports text generation.
+	 *
+	 * @since 1.9.1
+	 *
+	 * @param object $model_meta Model metadata object.
+	 * @return bool True when the model supports text generation, otherwise false.
+	 */
+	protected function model_supports_text_generation( $model_meta ) {
+
+		if ( ! method_exists( $model_meta, 'getSupportedCapabilities' ) ) {
+			return true;
+		}
+
+		$capabilities = $model_meta->getSupportedCapabilities();
+		if ( ! is_array( $capabilities ) ) {
+			return false;
+		}
+
+		foreach ( $capabilities as $capability ) {
+			if ( is_string( $capability ) && 'text_generation' === $capability ) {
+				return true;
+			}
+
+			if ( is_object( $capability ) && method_exists( $capability, 'equals' ) && $capability->equals( 'text_generation' ) ) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	/**

--- a/includes/Traits/AI_Utils.php
+++ b/includes/Traits/AI_Utils.php
@@ -8,6 +8,7 @@
 namespace WordPress\Plugin_Check\Traits;
 
 use WordPress\AiClient\AiClient;
+use WordPress\AiClient\Common\AbstractEnum;
 use WP_Error;
 
 /**
@@ -228,7 +229,7 @@ trait AI_Utils {
 				$has_text_gen = false;
 				foreach ( $supported as $cap ) {
 					$val = '';
-					if ( is_object( $cap ) && method_exists( $cap, '__get' ) && 'text_generation' === strtolower( (string) $cap->value ) ) {
+					if ( $cap instanceof AbstractEnum && 'text_generation' === strtolower( (string) $cap->value ) ) {
 						$has_text_gen = true;
 						break;
 					}
@@ -259,12 +260,10 @@ trait AI_Utils {
 					$is_input  = false;
 					$is_output = false;
 
-					if ( is_object( $name ) ) {
-						if ( method_exists( $name, '__get' ) ) {
-							$raw       = strtolower( (string) $name->value );
-							$is_input  = 'input_modalities' === $raw;
-							$is_output = 'output_modalities' === $raw;
-						}
+					if ( $name instanceof AbstractEnum ) {
+						$raw       = strtolower( (string) $name->value );
+						$is_input  = 'input_modalities' === $raw;
+						$is_output = 'output_modalities' === $raw;
 					} elseif ( is_string( $name ) ) {
 						$raw       = strtolower( $name );
 						$is_input  = 'inputmodalities' === $raw || 'input_modalities' === $raw;
@@ -333,10 +332,8 @@ trait AI_Utils {
 				$text = '';
 				if ( is_string( $modality ) ) {
 					$text = strtolower( $modality );
-				} elseif ( is_object( $modality ) ) {
-					if ( method_exists( $modality, '__get' ) && 'text' === strtolower( (string) $modality->value ) ) {
-						return true;
-					}
+				} elseif ( $modality instanceof AbstractEnum && 'text' === strtolower( (string) $modality->value ) ) {
+					return true;
 				}
 				if ( 'text' === $text ) {
 					return true;


### PR DESCRIPTION
## Summary

Fixes #1219.

The model selection dropdown on the Plugin Check Namer tool displayed **all** available AI models, including those that don't support text-to-text generation (e.g. embedding models, vision-only models, audio models like `gpt-4o-audio-preview`). This caused confusion and would result in errors when a non-text-generation model was selected and used.

## Changes

- **`includes/Traits/AI_Utils.php`**: Added `model_supports_text_generation()` helper method to the `AI_Utils` trait that inspects `ModelMetadata::getSupportedCapabilities()` from the WP 7.0 AI Client and checks for the `text_generation` capability value.
- Modified `get_filtered_ai_models()` to skip models that do not pass the capability check, so only text-generation capable models are returned for the dropdown.
- The helper gracefully falls back to `true` (include the model) when `getSupportedCapabilities()` is not available, ensuring backward compatibility.

## How to Test

1. Ensure you have WordPress 7.0+ with at least one AI connector configured (including a provider that exposes multiple model types, e.g. OpenAI which has both `gpt-4o` and `text-embedding-3-small`).
2. Go to **WP Admin → Tools → Plugin Check Namer**.
3. Open the model dropdown.
4. Verify that only text-generation models are listed — embedding models, audio-only models, and image-generation models should **not** appear.

Closes #1219