### PR TITLE
Respect wp_supports_ai() and improve AI-disabled notice in Namer

### DIFF
--- a/includes/Admin/Namer_Page.php
+++ b/includes/Admin/Namer_Page.php
@@ -54,7 +54,6 @@ final class Namer_Page {
 		add_action( 'admin_menu', array( $this, 'add_page' ) );
 		add_action( 'admin_post_' . self::ACTION_ANALYZE, array( $this, 'handle_analyze' ) );
 		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
-		add_action( 'admin_notices', array( $this, 'render_ai_notice' ) );
 		add_action( 'wp_ajax_plugin_check_namer_analyze', array( $this, 'ajax_analyze' ) );
 	}
 
@@ -212,40 +211,6 @@ final class Namer_Page {
 	protected function get_author_name_from_request() {
 		$author = isset( $_POST['author_name'] ) ? sanitize_text_field( wp_unslash( $_POST['author_name'] ) ) : '';
 		return trim( $author );
-	}
-
-	/**
-	 * Renders admin notice when AI connectors are not configured.
-	 *
-	 * @since 1.9.0
-	 */
-	public function render_ai_notice() {
-		$screen = get_current_screen();
-		if ( ! $screen || $screen->id !== $this->hook_suffix ) {
-			return;
-		}
-
-		if ( ! current_user_can( 'manage_options' ) ) {
-			return;
-		}
-
-		$ai_config = $this->get_ai_config();
-		if ( ! is_wp_error( $ai_config ) ) {
-			return;
-		}
-		?>
-		<div class="notice notice-warning is-dismissible">
-			<p>
-				<?php
-				printf(
-					/* translators: %s: Error message. */
-					__( 'To use the Namer tool, configure AI connectors in WordPress 7.0+ settings. Details: %s', 'plugin-check' ),
-					esc_html( $ai_config->get_error_message() )
-				);
-				?>
-			</p>
-		</div>
-		<?php
 	}
 
 	/**

--- a/includes/Admin/Namer_Page.php
+++ b/includes/Admin/Namer_Page.php
@@ -268,15 +268,24 @@ final class Namer_Page {
 			<?php
 			if ( is_wp_error( $ai_config ) ) {
 				?>
-				<p class="description">
-					<?php esc_html_e( 'The Plugin Namer requires WordPress 7.0+ with configured AI connectors. Please enable AI connectors in core to use this tool.', 'plugin-check' ); ?>
-				</p>
-				<p>
-					<a class="button button-primary" href="<?php echo esc_url( admin_url( 'options-connectors.php' ) ); ?>">
-						<?php esc_html_e( 'Configure AI Connectors', 'plugin-check' ); ?>
-					</a>
-				</p>
+				<div class="notice notice-error">
+					<p>
+						<?php
+						echo esc_html( $ai_config->get_error_message() );
+						?>
+					</p>
+				</div>
+
 				<?php
+				if ( true === $this->check_ai_prerequisites() && is_wp_error( $this->check_ai_connectors() ) ) {
+					?>
+					<p>
+						<a class="button button-primary" href="<?php echo esc_url( admin_url( 'options-connectors.php' ) ); ?>">
+							<?php esc_html_e( 'Configure AI Connectors', 'plugin-check' ); ?>
+						</a>
+					</p>
+					<?php
+				}
 				return;
 			}
 			?>

--- a/includes/Traits/AI_Utils.php
+++ b/includes/Traits/AI_Utils.php
@@ -18,6 +18,65 @@ use WP_Error;
 trait AI_Utils {
 
 	/**
+	 * Checks AI prerequisites: feature flag, function availability, and version.
+	 *
+	 * @since 1.9.0
+	 *
+	 * @return true|WP_Error True if all prerequisites are met, WP_Error otherwise.
+	 */
+	protected function check_ai_prerequisites() {
+
+		if ( function_exists( 'wp_supports_ai' ) && ! wp_supports_ai() ) {
+			return new WP_Error(
+				'ai_disabled',
+				__( 'The Plugin Check Namer feature requires AI support to be enabled on this site. Please enable AI functionality to use this feature.', 'plugin-check' )
+			);
+		}
+
+		if ( ! function_exists( 'wp_ai_client_prompt' ) ) {
+			return new WP_Error(
+				'ai_client_not_available',
+				sprintf(
+					/* translators: %s: WordPress version. */
+					__( 'The Plugin Check Namer Tool requires WordPress version 7.0 or newer. You are running WordPress version %s.', 'plugin-check' ),
+					get_bloginfo( 'version' )
+				)
+			);
+		}
+
+		if ( ! is_wp_version_compatible( '7.0' ) ) {
+			return new WP_Error(
+				'ai_client_not_available',
+				sprintf(
+					/* translators: %s: WordPress version. */
+					__( 'The Plugin Check Namer Tool requires WordPress version 7.0 or higher. You are running WordPress version %s.', 'plugin-check' ),
+					get_bloginfo( 'version' )
+				)
+			);
+		}
+
+		return true;
+	}
+
+	/**
+	 * Checks that at least one AI connector is configured and active.
+	 *
+	 * @since 1.9.0
+	 *
+	 * @return true|WP_Error True if a connector is available, WP_Error otherwise.
+	 */
+	protected function check_ai_connectors() {
+		if ( $this->has_no_active_ai_connectors() ) {
+			return new WP_Error(
+				'ai_not_configured',
+				__( 'AI connectors are not configured. Please connect and enable an AI provider in WordPress 7.0+ settings.', 'plugin-check' )
+			);
+		}
+
+		return true;
+	}
+
+	/**
 	 * Gets AI configuration from core AI connectors.
 	 *
 	 * @since 1.9.0
@@ -26,25 +85,14 @@ trait AI_Utils {
 	 * @return array|WP_Error AI config array or error.
 	 */
 	protected function get_ai_config( $model_preference = '' ) {
-		if ( ! function_exists( 'wp_ai_client_prompt' ) ) {
-			return new WP_Error(
-				'ai_client_not_available',
-				__( 'The AI client is not available. This feature requires WordPress 7.0 or newer.', 'plugin-check' )
-			);
+		$prerequisites = $this->check_ai_prerequisites();
+		if ( is_wp_error( $prerequisites ) ) {
+			return $prerequisites;
 		}
 
-		if ( ! is_wp_version_compatible( '7.0' ) ) {
-			return new WP_Error(
-				'ai_client_not_available',
-				__( 'The AI client is only available in WordPress 7.0 or newer.', 'plugin-check' )
-			);
-		}
-
-		if ( $this->has_no_active_ai_connectors() ) {
-			return new WP_Error(
-				'ai_not_configured',
-				__( 'AI connectors are not configured. Please connect and enable an AI provider in WordPress 7.0+ settings.', 'plugin-check' )
-			);
+		$connectors = $this->check_ai_connectors();
+		if ( is_wp_error( $connectors ) ) {
+			return $connectors;
 		}
 
 		$builder = wp_ai_client_prompt( 'Plugin Check AI availability test.' );

--- a/includes/Traits/AI_Utils.php
+++ b/includes/Traits/AI_Utils.php
@@ -33,17 +33,6 @@ trait AI_Utils {
 			);
 		}
 
-		if ( ! function_exists( 'wp_ai_client_prompt' ) ) {
-			return new WP_Error(
-				'ai_client_not_available',
-				sprintf(
-					/* translators: %s: WordPress version. */
-					__( 'The Plugin Check Namer Tool requires WordPress version 7.0 or newer. You are running WordPress version %s.', 'plugin-check' ),
-					get_bloginfo( 'version' )
-				)
-			);
-		}
-
 		if ( ! is_wp_version_compatible( '7.0' ) ) {
 			return new WP_Error(
 				'ai_client_not_available',
@@ -99,7 +88,11 @@ trait AI_Utils {
 		if ( ! function_exists( 'wp_ai_client_prompt' ) ) {
 			return new WP_Error(
 				'ai_client_not_available',
-				__( 'The AI client is not available. This feature requires WordPress 7.0 or newer.', 'plugin-check' )
+				sprintf(
+					/* translators: %s: WordPress version. */
+					__( 'The Plugin Check Namer Tool requires WordPress version 7.0 or newer. You are running WordPress version %s.', 'plugin-check' ),
+					get_bloginfo( 'version' )
+				)
 			);
 		}
 

--- a/includes/Traits/AI_Utils.php
+++ b/includes/Traits/AI_Utils.php
@@ -20,7 +20,7 @@ trait AI_Utils {
 	/**
 	 * Checks AI prerequisites: feature flag, function availability, and version.
 	 *
-	 * @since 1.9.0
+	 * @since 2.0.0
 	 *
 	 * @return true|WP_Error True if all prerequisites are met, WP_Error otherwise.
 	 */
@@ -61,7 +61,7 @@ trait AI_Utils {
 	/**
 	 * Checks that at least one AI connector is configured and active.
 	 *
-	 * @since 1.9.0
+	 * @since 2.0.0
 	 *
 	 * @return true|WP_Error True if a connector is available, WP_Error otherwise.
 	 */
@@ -85,6 +85,7 @@ trait AI_Utils {
 	 * @return array|WP_Error AI config array or error.
 	 */
 	protected function get_ai_config( $model_preference = '' ) {
+
 		$prerequisites = $this->check_ai_prerequisites();
 		if ( is_wp_error( $prerequisites ) ) {
 			return $prerequisites;

--- a/includes/Traits/AI_Utils.php
+++ b/includes/Traits/AI_Utils.php
@@ -96,6 +96,13 @@ trait AI_Utils {
 			return $connectors;
 		}
 
+		if ( ! function_exists( 'wp_ai_client_prompt' ) ) {
+			return new WP_Error(
+				'ai_client_not_available',
+				__( 'The AI client is not available. This feature requires WordPress 7.0 or newer.', 'plugin-check' )
+			);
+		}
+
 		$builder = wp_ai_client_prompt( 'Plugin Check AI availability test.' );
 		if ( is_wp_error( $builder ) ) {
 			return $builder;


### PR DESCRIPTION
## What?
Closes https://github.com/WordPress/plugin-check/issues/1222

This PR updates the Plugin Check Namer flow to respect WordPress AI support controls and present clearer UI messaging when AI functionality is unavailable.

## Why?
The Namer tool should not initialize AI-dependent behavior when AI is disabled at the site level (for example via `WP_AI_SUPPORT` or the `wp_supports_ai` filter). This aligns Plugin Check with core AI capability controls and avoids confusing behavior for site administrators.

## How?
- Refactors AI readiness checks in `AI_Utils` into dedicated methods:
  - `check_ai_prerequisites()`
  - `check_ai_connectors()`
  - `get_ai_config()` as orchestrator
- Adds an explicit `wp_supports_ai()` prerequisite check (when available) and returns a specific `WP_Error` when AI is disabled.
- Keeps connector checks separate so UI can decide whether to show the “Configure AI Connectors” CTA only when prerequisites are met but connectors are missing.
- Updates Namer page rendering to show the concrete prerequisite/connector error message and conditionally show connector setup action.

### Use of AI Tools
I used GitHub Copilot (GPT-5.3-Codex) to assist with drafting/refactoring code and preparing the PR text. I reviewed and validated the final changes manually.

## Testing Instructions
1. Install and activate Plugin Check on a WordPress 7.0+ site.
2. Visit Tools → Plugin Check Namer.
3. Confirm normal behavior with AI support enabled and a connector configured.
4. Disable AI support (for example by filtering `wp_supports_ai` to false).
5. Reload the Namer page and verify an error notice appears indicating AI support is disabled.
6. Re-enable AI support but remove/disable AI connectors.
7. Reload the Namer page and verify connector-related guidance appears with a Configure AI Connectors button.
8. Run PHPCS on the changed files and confirm no new violations.

### Testing Instructions for Keyboard
1. Navigate to Tools → Plugin Check Namer using keyboard only.
2. Verify focus order reaches the notice and action button when shown.
3. Activate the Configure AI Connectors button using keyboard (Enter/Space) and confirm navigation works.

## Screenshots or screencast

https://github.com/user-attachments/assets/5df0d779-8c17-46b5-94ed-bee54b4939e5


