### PR TITLE
Update sniffer repo links

### DIFF
--- a/phpcs-rulesets/plugin-check.ruleset.xml
+++ b/phpcs-rulesets/plugin-check.ruleset.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="WPPluginCheck" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/squizlabs/PHP_CodeSniffer/master/phpcs.xsd">
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="WPPluginCheck" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/PHPCSStandards/PHP_CodeSniffer/master/phpcs.xsd">
 
 	<!-- For more information: https://make.wordpress.org/plugins/handbook/review/ -->
 	<description>Standards any plugin to be published on wordpress.org should comply with.</description>

--- a/phpcs-rulesets/plugin-review.xml
+++ b/phpcs-rulesets/plugin-review.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="WPPluginCheck" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/squizlabs/PHP_CodeSniffer/master/phpcs.xsd">
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="WPPluginCheck" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/PHPCSStandards/PHP_CodeSniffer/master/phpcs.xsd">
 
 	<!-- For more information: https://make.wordpress.org/plugins/handbook/review/ -->
 	<description>Standards any plugin to be published on wordpress.org should comply with.</description>

--- a/phpcs-sniffs/PluginCheck/ruleset.xml
+++ b/phpcs-sniffs/PluginCheck/ruleset.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="PluginCheck" namespace="PluginCheckCS\PluginCheck" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/squizlabs/PHP_CodeSniffer/master/phpcs.xsd">
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="PluginCheck" namespace="PluginCheckCS\PluginCheck" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/PHPCSStandards/PHP_CodeSniffer/master/phpcs.xsd">
 
 	<description>Plugin Check Sniffs</description>
 


### PR DESCRIPTION
- Updated links to use new repo for sniffer - https://github.com/PHPCSStandards/php_codesniffer