### PR TITLE
feat(plugin-repo): Add privacy policy content check

### DIFF
--- a/docs/checks.md
+++ b/docs/checks.md
@@ -35,3 +35,4 @@
 | enqueued_styles_scope | performance | Checks whether any stylesheets are loaded on all pages, which is usually not desirable and can lead to performance issues. | [Learn more](https://developer.wordpress.org/plugins/) |
 | enqueued_scripts_scope | performance | Checks whether any scripts are loaded on all pages, which is usually not desirable and can lead to performance issues. | [Learn more](https://developer.wordpress.org/plugins/) |
 | non_blocking_scripts | performance | Checks whether scripts and styles are enqueued using a recommended loading strategy. | [Learn more](https://developer.wordpress.org/plugins/) |
+| privacy_policy | plugin_repo | Checks that plugins handling personal data call wp_add_privacy_policy_content() to suggest privacy policy text to site administrators. | [Learn more](https://developer.wordpress.org/plugins/privacy/suggesting-text-for-the-site-privacy-policy/) |

--- a/includes/Checker/Checks/Plugin_Repo/Privacy_Policy_Check.php
+++ b/includes/Checker/Checks/Plugin_Repo/Privacy_Policy_Check.php
@@ -130,6 +130,8 @@ class Privacy_Policy_Check extends Abstract_File_Check {
 	 * @param array                 $files           List of absolute file paths.
 	 * @param array<string, string> $function_names Map of function names (lowercase) to human-readable labels.
 	 * @return string|false Human-readable label of the first matched function, or false if none found.
+	 *
+	 * @SuppressWarnings(PHPMD.NPathComplexity)
 	 */
 	private function find_function_in_files( array $files, array $function_names ) {
 		$lowercase_names = array();

--- a/includes/Checker/Checks/Plugin_Repo/Privacy_Policy_Check.php
+++ b/includes/Checker/Checks/Plugin_Repo/Privacy_Policy_Check.php
@@ -21,6 +21,9 @@ use WordPress\Plugin_Check\Traits\Stable_Check;
  * administrators via wp_add_privacy_policy_content(). This check detects common
  * personal-data-handling patterns and warns if that function is not used.
  *
+ * Uses token-based parsing to avoid false positives from function names appearing
+ * in comments or string literals.
+ *
  * @since 1.7.0
  */
 class Privacy_Policy_Check extends Abstract_File_Check {
@@ -29,20 +32,29 @@ class Privacy_Policy_Check extends Abstract_File_Check {
 	use Stable_Check;
 
 	/**
-	 * Regex patterns that indicate a plugin may handle personal data.
+	 * Function names that indicate a plugin may handle personal data.
 	 *
-	 * Each pattern is accompanied by a human-readable label used in the
+	 * Each function name is accompanied by a human-readable label used in the
 	 * warning message to help plugin authors understand why the check fired.
 	 *
 	 * @since 1.7.0
 	 * @var array<string, string>
 	 */
-	const PERSONAL_DATA_PATTERNS = array(
-		'wp_remote_post\s*\('     => 'wp_remote_post()',
-		'wp_remote_get\s*\('      => 'wp_remote_get()',
-		'setcookie\s*\('          => 'setcookie()',
-		'\$_COOKIE\b'             => '$_COOKIE',
-		'wp_set_auth_cookie\s*\(' => 'wp_set_auth_cookie()',
+	const PERSONAL_DATA_FUNCTIONS = array(
+		'wp_remote_post'     => 'wp_remote_post()',
+		'wp_remote_get'      => 'wp_remote_get()',
+		'setcookie'          => 'setcookie()',
+		'wp_set_auth_cookie' => 'wp_set_auth_cookie()',
+	);
+
+	/**
+	 * Variable names that indicate a plugin may handle personal data.
+	 *
+	 * @since 1.7.0
+	 * @var array<string, string>
+	 */
+	const PERSONAL_DATA_VARIABLES = array(
+		'$_COOKIE' => '$_COOKIE',
 	);
 
 	/**
@@ -74,41 +86,221 @@ class Privacy_Policy_Check extends Abstract_File_Check {
 		}
 
 		// First, detect whether the plugin already calls wp_add_privacy_policy_content().
-		$has_privacy_call = (bool) self::file_preg_match(
-			'#\bwp_add_privacy_policy_content\s*\(#',
-			$php_files
-		);
+		$has_privacy_call = $this->find_function_in_files( $php_files, array( 'wp_add_privacy_policy_content' => 'wp_add_privacy_policy_content()' ) );
 
 		// If the plugin already registers privacy policy content, nothing to warn about.
 		if ( $has_privacy_call ) {
 			return;
 		}
 
-		// Check for each personal-data-handling pattern.
-		foreach ( self::PERSONAL_DATA_PATTERNS as $pattern => $label ) {
-			$matches      = array();
-			$matched_file = self::file_preg_match( '#' . $pattern . '#', $php_files, $matches );
+		// Check for personal-data-handling function calls.
+		$matched_label = $this->find_function_in_files( $php_files, self::PERSONAL_DATA_FUNCTIONS );
 
-			if ( $matched_file ) {
-				$this->add_result_warning_for_file(
-					$result,
-					sprintf(
-						/* translators: %s: The detected function or variable name indicating personal data usage. */
-						__( '<strong>Missing privacy policy content registration.</strong><br>The plugin uses %s which may involve handling personal data, but does not call wp_add_privacy_policy_content(). Plugins that collect, store, or transmit personal data should suggest privacy policy text to site administrators.', 'plugin-check' ),
-						'<code>' . esc_html( $label ) . '</code>'
-					),
-					'missing_privacy_policy_content',
-					$result->plugin()->main_file(),
-					0,
-					0,
-					'https://developer.wordpress.org/plugins/privacy/suggesting-text-for-the-site-privacy-policy/',
-					5
-				);
+		// If no function call found, check for personal-data-handling variable usage.
+		if ( ! $matched_label ) {
+			$matched_label = $this->find_variable_in_files( $php_files, self::PERSONAL_DATA_VARIABLES );
+		}
 
-				// One warning per plugin is sufficient — avoid duplicate messages.
-				return;
+		if ( $matched_label ) {
+			$this->add_result_warning_for_file(
+				$result,
+				sprintf(
+					/* translators: %s: The detected function or variable name indicating personal data usage. */
+					__( '<strong>Missing privacy policy content registration.</strong><br>The plugin uses %s which may involve handling personal data, but does not call wp_add_privacy_policy_content(). Plugins that collect, store, or transmit personal data should suggest privacy policy text to site administrators.', 'plugin-check' ),
+					'<code>' . esc_html( $matched_label ) . '</code>'
+				),
+				'missing_privacy_policy_content',
+				$result->plugin()->main_file(),
+				0,
+				0,
+				'https://developer.wordpress.org/plugins/privacy/suggesting-text-for-the-site-privacy-policy/',
+				5
+			);
+		}
+	}
+
+	/**
+	 * Searches PHP files for a global function call using token-based parsing.
+	 *
+	 * Uses token_get_all() to avoid false positives from function names appearing
+	 * in comments or string literals.
+	 *
+	 * @since 1.7.0
+	 *
+	 * @param array                 $files           List of absolute file paths.
+	 * @param array<string, string> $function_names Map of function names (lowercase) to human-readable labels.
+	 * @return string|false Human-readable label of the first matched function, or false if none found.
+	 */
+	private function find_function_in_files( array $files, array $function_names ) {
+		$lowercase_names = array();
+		foreach ( $function_names as $name => $label ) {
+			$lowercase_names[ strtolower( $name ) ] = $label;
+		}
+
+		foreach ( $files as $file ) {
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+			$source = file_get_contents( $file );
+			if ( false === $source || '' === $source ) {
+				continue;
+			}
+
+			$tokens = token_get_all( $source );
+
+			foreach ( $tokens as $index => $token ) {
+				if ( ! is_array( $token ) || T_STRING !== $token[0] ) {
+					continue;
+				}
+
+				$name = strtolower( $token[1] );
+				if ( ! isset( $lowercase_names[ $name ] ) ) {
+					continue;
+				}
+
+				$next_index = $this->get_next_significant_token_index( $tokens, $index );
+				if ( null === $next_index || '(' !== $tokens[ $next_index ] ) {
+					continue;
+				}
+
+				if ( ! $this->is_global_function_call( $tokens, $index ) ) {
+					continue;
+				}
+
+				return $lowercase_names[ $name ];
 			}
 		}
+
+		return false;
+	}
+
+	/**
+	 * Checks whether a tokenized T_STRING is a global function call.
+	 *
+	 * Rejects method calls (->method), static calls (Class::method),
+	 * function definitions (function name), instantiation (new name),
+	 * and namespace-qualified calls (\NS\name or NS\name).
+	 *
+	 * @since 1.7.0
+	 *
+	 * @param array $tokens Token stream.
+	 * @param int   $index  Current token index.
+	 * @return bool True if the token represents a global function call.
+	 */
+	private function is_global_function_call( array $tokens, int $index ): bool {
+		$previous_index = $this->get_previous_significant_token_index( $tokens, $index );
+		if ( null === $previous_index ) {
+			return true;
+		}
+
+		$previous_token = $tokens[ $previous_index ];
+
+		if ( is_array( $previous_token ) ) {
+			$disqualifying_tokens = array( T_FUNCTION, T_NEW, T_OBJECT_OPERATOR, T_DOUBLE_COLON );
+
+			// T_NULLSAFE_OBJECT_OPERATOR (?->) only exists on PHP 8.0+.
+			if ( defined( 'T_NULLSAFE_OBJECT_OPERATOR' ) ) {
+				$disqualifying_tokens[] = constant( 'T_NULLSAFE_OBJECT_OPERATOR' );
+			}
+
+			if ( in_array( $previous_token[0], $disqualifying_tokens, true ) ) {
+				return false;
+			}
+
+			if ( T_NS_SEPARATOR === $previous_token[0] ) {
+				$before_namespace_index = $this->get_previous_significant_token_index( $tokens, $previous_index );
+				if ( null === $before_namespace_index ) {
+					return true;
+				}
+
+				$before_namespace_token = $tokens[ $before_namespace_index ];
+				if ( is_array( $before_namespace_token ) && in_array( $before_namespace_token[0], array( T_STRING, T_NAMESPACE ), true ) ) {
+					return false;
+				}
+			}
+		}
+
+		return true;
+	}
+
+	/**
+	 * Searches PHP files for a variable usage using token-based parsing.
+	 *
+	 * Uses token_get_all() to avoid false positives from variable names appearing
+	 * in comments or string literals.
+	 *
+	 * @since 1.7.0
+	 *
+	 * @param array                 $files           List of absolute file paths.
+	 * @param array<string, string> $variable_names  Map of variable names to human-readable labels.
+	 * @return string|false Human-readable label of the first matched variable, or false if none found.
+	 */
+	private function find_variable_in_files( array $files, array $variable_names ) {
+		foreach ( $files as $file ) {
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+			$source = file_get_contents( $file );
+			if ( false === $source || '' === $source ) {
+				continue;
+			}
+
+			$tokens = token_get_all( $source );
+
+			foreach ( $tokens as $token ) {
+				if ( ! is_array( $token ) || T_VARIABLE !== $token[0] ) {
+					continue;
+				}
+
+				if ( isset( $variable_names[ $token[1] ] ) ) {
+					return $variable_names[ $token[1] ];
+				}
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Finds the next significant token index, skipping whitespace.
+	 *
+	 * @since 1.7.0
+	 *
+	 * @param array $tokens Token stream.
+	 * @param int   $index  Current token index.
+	 * @return int|null Index of the next significant token, or null if end of stream.
+	 */
+	private function get_next_significant_token_index( array $tokens, int $index ): ?int {
+		$count = count( $tokens );
+		for ( $i = $index + 1; $i < $count; $i++ ) {
+			$token = $tokens[ $i ];
+			if ( is_array( $token ) && T_WHITESPACE === $token[0] ) {
+				continue;
+			}
+
+			return $i;
+		}
+
+		return null;
+	}
+
+	/**
+	 * Finds the previous significant token index, skipping whitespace and comments.
+	 *
+	 * @since 1.7.0
+	 *
+	 * @param array $tokens Token stream.
+	 * @param int   $index  Current token index.
+	 * @return int|null Index of the previous significant token, or null if start of stream.
+	 */
+	private function get_previous_significant_token_index( array $tokens, int $index ): ?int {
+		for ( $i = $index - 1; $i >= 0; $i-- ) {
+			$token = $tokens[ $i ];
+
+			if ( is_array( $token ) && in_array( $token[0], array( T_WHITESPACE, T_COMMENT, T_DOC_COMMENT ), true ) ) {
+				continue;
+			}
+
+			return $i;
+		}
+
+		return null;
 	}
 
 	/**

--- a/includes/Checker/Checks/Plugin_Repo/Privacy_Policy_Check.php
+++ b/includes/Checker/Checks/Plugin_Repo/Privacy_Policy_Check.php
@@ -1,0 +1,139 @@
+<?php
+/**
+ * Class Privacy_Policy_Check.
+ *
+ * @package plugin-check
+ */
+
+namespace WordPress\Plugin_Check\Checker\Checks\Plugin_Repo;
+
+use WordPress\Plugin_Check\Checker\Check_Categories;
+use WordPress\Plugin_Check\Checker\Check_Result;
+use WordPress\Plugin_Check\Checker\Checks\Abstract_File_Check;
+use WordPress\Plugin_Check\Traits\Amend_Check_Result;
+use WordPress\Plugin_Check\Traits\Stable_Check;
+
+/**
+ * Check that plugins handling personal data call wp_add_privacy_policy_content().
+ *
+ * Plugins that collect, use, store, or transmit personal data to a third party
+ * are required by WordPress.org guidelines to suggest privacy policy text to site
+ * administrators via wp_add_privacy_policy_content(). This check detects common
+ * personal-data-handling patterns and warns if that function is not used.
+ *
+ * @since 1.7.0
+ */
+class Privacy_Policy_Check extends Abstract_File_Check {
+
+	use Amend_Check_Result;
+	use Stable_Check;
+
+	/**
+	 * Regex patterns that indicate a plugin may handle personal data.
+	 *
+	 * Each pattern is accompanied by a human-readable label used in the
+	 * warning message to help plugin authors understand why the check fired.
+	 *
+	 * @since 1.7.0
+	 * @var array<string, string>
+	 */
+	const PERSONAL_DATA_PATTERNS = array(
+		'wp_remote_post\s*\('     => 'wp_remote_post()',
+		'wp_remote_get\s*\('      => 'wp_remote_get()',
+		'setcookie\s*\('          => 'setcookie()',
+		'\$_COOKIE\b'             => '$_COOKIE',
+		'wp_set_auth_cookie\s*\(' => 'wp_set_auth_cookie()',
+	);
+
+	/**
+	 * Gets the categories for the check.
+	 *
+	 * Every check must have at least one category.
+	 *
+	 * @since 1.7.0
+	 *
+	 * @return array The categories for the check.
+	 */
+	public function get_categories() {
+		return array( Check_Categories::CATEGORY_PLUGIN_REPO );
+	}
+
+	/**
+	 * Amends the given result by running the check on the given list of files.
+	 *
+	 * @since 1.7.0
+	 *
+	 * @param Check_Result $result The check result to amend, including the plugin context to check.
+	 * @param array        $files  List of absolute file paths.
+	 */
+	protected function check_files( Check_Result $result, array $files ) {
+		$php_files = self::filter_files_by_extension( $files, 'php' );
+
+		if ( empty( $php_files ) ) {
+			return;
+		}
+
+		// First, detect whether the plugin already calls wp_add_privacy_policy_content().
+		$has_privacy_call = (bool) self::file_preg_match(
+			'#\bwp_add_privacy_policy_content\s*\(#',
+			$php_files
+		);
+
+		// If the plugin already registers privacy policy content, nothing to warn about.
+		if ( $has_privacy_call ) {
+			return;
+		}
+
+		// Check for each personal-data-handling pattern.
+		foreach ( self::PERSONAL_DATA_PATTERNS as $pattern => $label ) {
+			$matches      = array();
+			$matched_file = self::file_preg_match( '#' . $pattern . '#', $php_files, $matches );
+
+			if ( $matched_file ) {
+				$this->add_result_warning_for_file(
+					$result,
+					sprintf(
+						/* translators: %s: The detected function or variable name indicating personal data usage. */
+						__( '<strong>Missing privacy policy content registration.</strong><br>The plugin uses %s which may involve handling personal data, but does not call wp_add_privacy_policy_content(). Plugins that collect, store, or transmit personal data should suggest privacy policy text to site administrators.', 'plugin-check' ),
+						'<code>' . esc_html( $label ) . '</code>'
+					),
+					'missing_privacy_policy_content',
+					$result->plugin()->main_file(),
+					0,
+					0,
+					'https://developer.wordpress.org/plugins/privacy/suggesting-text-for-the-site-privacy-policy/',
+					5
+				);
+
+				// One warning per plugin is sufficient — avoid duplicate messages.
+				return;
+			}
+		}
+	}
+
+	/**
+	 * Gets the description for the check.
+	 *
+	 * Every check must have a short description explaining what the check does.
+	 *
+	 * @since 1.7.0
+	 *
+	 * @return string Description.
+	 */
+	public function get_description(): string {
+		return __( 'Checks that plugins handling personal data call wp_add_privacy_policy_content() to suggest privacy policy text to site administrators.', 'plugin-check' );
+	}
+
+	/**
+	 * Gets the documentation URL for the check.
+	 *
+	 * Every check must have a URL with further information about the check.
+	 *
+	 * @since 1.7.0
+	 *
+	 * @return string The documentation URL.
+	 */
+	public function get_documentation_url(): string {
+		return __( 'https://developer.wordpress.org/plugins/privacy/suggesting-text-for-the-site-privacy-policy/', 'plugin-check' );
+	}
+}

--- a/includes/Checker/Default_Check_Repository.php
+++ b/includes/Checker/Default_Check_Repository.php
@@ -102,6 +102,7 @@ class Default_Check_Repository extends Empty_Check_Repository {
 				'direct_file_access'         => new Checks\Plugin_Repo\Direct_File_Access_Check(),
 				'external_admin_menu_links'  => new Checks\Plugin_Repo\External_Admin_Menu_Links_Check(),
 				'wp_functions_compatibility' => new Checks\Plugin_Repo\WP_Functions_Compatibility_Check(),
+				'privacy_policy'             => new Checks\Plugin_Repo\Privacy_Policy_Check(),
 			)
 		);
 

--- a/tests/phpunit/testdata/plugins/test-plugin-privacy-policy-comment-only/load.php
+++ b/tests/phpunit/testdata/plugins/test-plugin-privacy-policy-comment-only/load.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * Plugin Name: Test Plugin Privacy Policy Comment Only
+ * Plugin URI: https://github.com/WordPress/plugin-check
+ * Description: A test plugin that mentions privacy-related function names only in comments, but has a real signal in code. Token check must ignore the comment-only privacy call and still warn.
+ * Requires at least: 6.0
+ * Requires PHP: 7.4
+ * Version: 1.0.0
+ * Author: WordPress Performance Team
+ * Author URI: https://make.wordpress.org/performance/
+ * License: GPLv2 or later
+ * License URI: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+ * Text Domain: test-plugin-privacy-policy-comment-only
+ *
+ * @package test-plugin-privacy-policy-comment-only
+ */
+
+// TODO: call wp_add_privacy_policy_content() later when privacy is implemented.
+
+/**
+ * Sends data to an external service. Real signal must trigger warning.
+ *
+ * @return array|WP_Error
+ */
+function test_plugin_privacy_comment_only_send_data() {
+	return wp_remote_post(
+		'https://example-analytics.com/collect',
+		array(
+			'body' => array(
+				'email' => get_option( 'admin_email' ),
+			),
+		)
+	);
+}

--- a/tests/phpunit/testdata/plugins/test-plugin-privacy-policy-no-signals/load.php
+++ b/tests/phpunit/testdata/plugins/test-plugin-privacy-policy-no-signals/load.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Plugin Name: Test Plugin Privacy Policy No Signals
+ * Plugin URI: https://github.com/WordPress/plugin-check
+ * Description: A test plugin that does not handle personal data at all — no privacy check signals present.
+ * Requires at least: 6.0
+ * Requires PHP: 7.4
+ * Version: 1.0.0
+ * Author: WordPress Performance Team
+ * Author URI: https://make.wordpress.org/performance/
+ * License: GPLv2 or later
+ * License URI: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+ * Text Domain: test-plugin-privacy-policy-no-signals
+ *
+ * @package test-plugin-privacy-policy-no-signals
+ */
+
+/**
+ * Outputs a greeting message in the admin footer.
+ *
+ * @return void
+ */
+function test_plugin_privacy_no_signals_greet() {
+	echo '<p>' . esc_html__( 'Hello from Test Plugin!', 'test-plugin-privacy-policy-no-signals' ) . '</p>';
+}
+
+add_action( 'admin_footer', 'test_plugin_privacy_no_signals_greet' );

--- a/tests/phpunit/testdata/plugins/test-plugin-privacy-policy-string-only/load.php
+++ b/tests/phpunit/testdata/plugins/test-plugin-privacy-policy-string-only/load.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * Plugin Name: Test Plugin Privacy Policy String Only
+ * Plugin URI: https://github.com/WordPress/plugin-check
+ * Description: A test plugin that mentions privacy-related function names only inside string literals, but has a real signal in code. Token check must ignore the string-only privacy call and still warn.
+ * Requires at least: 6.0
+ * Requires PHP: 7.4
+ * Version: 1.0.0
+ * Author: WordPress Performance Team
+ * Author URI: https://make.wordpress.org/performance/
+ * License: GPLv2 or later
+ * License URI: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+ * Text Domain: test-plugin-privacy-policy-string-only
+ *
+ * @package test-plugin-privacy-policy-string-only
+ */
+
+/**
+ * Sends data to an external service. Real signal must trigger warning.
+ *
+ * @return array|WP_Error
+ */
+function test_plugin_privacy_string_only_send_data() {
+	$placeholder = 'We may eventually call wp_add_privacy_policy_content() to register privacy text.';
+
+	return wp_remote_post(
+		'https://example-analytics.com/collect',
+		array(
+			'body' => array(
+				'email' => get_option( 'admin_email' ),
+			),
+		)
+	);
+}

--- a/tests/phpunit/testdata/plugins/test-plugin-privacy-policy-with-errors/load.php
+++ b/tests/phpunit/testdata/plugins/test-plugin-privacy-policy-with-errors/load.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Test Plugin Privacy Policy With Errors
  * Plugin URI: https://github.com/WordPress/plugin-check
- * Description: A test plugin that handles personal data but does not call wp_add_privacy_policy_content().
+ * Description: A test plugin that handles personal data but does not register privacy policy content.
  * Requires at least: 6.0
  * Requires PHP: 7.4
  * Version: 1.0.0

--- a/tests/phpunit/testdata/plugins/test-plugin-privacy-policy-with-errors/load.php
+++ b/tests/phpunit/testdata/plugins/test-plugin-privacy-policy-with-errors/load.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Plugin Name: Test Plugin Privacy Policy With Errors
+ * Plugin URI: https://github.com/WordPress/plugin-check
+ * Description: A test plugin that handles personal data but does not call wp_add_privacy_policy_content().
+ * Requires at least: 6.0
+ * Requires PHP: 7.4
+ * Version: 1.0.0
+ * Author: WordPress Performance Team
+ * Author URI: https://make.wordpress.org/performance/
+ * License: GPLv2 or later
+ * License URI: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+ * Text Domain: test-plugin-privacy-policy-with-errors
+ *
+ * @package test-plugin-privacy-policy-with-errors
+ */
+
+// Sends data to an external service — indicates potential personal data handling.
+function test_plugin_privacy_send_data() {
+	$response = wp_remote_post(
+		'https://example-analytics.com/collect',
+		array(
+			'body' => array(
+				'email' => get_option( 'admin_email' ),
+			),
+		)
+	);
+
+	return $response;
+}

--- a/tests/phpunit/testdata/plugins/test-plugin-privacy-policy-without-errors/load.php
+++ b/tests/phpunit/testdata/plugins/test-plugin-privacy-policy-without-errors/load.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Test Plugin Privacy Policy Without Errors
  * Plugin URI: https://github.com/WordPress/plugin-check
- * Description: A test plugin that handles personal data AND correctly calls wp_add_privacy_policy_content().
+ * Description: A test plugin that handles personal data AND correctly registers privacy policy content.
  * Requires at least: 6.0
  * Requires PHP: 7.4
  * Version: 1.0.0

--- a/tests/phpunit/testdata/plugins/test-plugin-privacy-policy-without-errors/load.php
+++ b/tests/phpunit/testdata/plugins/test-plugin-privacy-policy-without-errors/load.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Plugin Name: Test Plugin Privacy Policy Without Errors
+ * Plugin URI: https://github.com/WordPress/plugin-check
+ * Description: A test plugin that handles personal data AND correctly calls wp_add_privacy_policy_content().
+ * Requires at least: 6.0
+ * Requires PHP: 7.4
+ * Version: 1.0.0
+ * Author: WordPress Performance Team
+ * Author URI: https://make.wordpress.org/performance/
+ * License: GPLv2 or later
+ * License URI: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+ * Text Domain: test-plugin-privacy-policy-without-errors
+ *
+ * @package test-plugin-privacy-policy-without-errors
+ */
+
+// Registers suggested privacy policy content — satisfies the check.
+add_action(
+	'admin_init',
+	function () {
+		wp_add_privacy_policy_content(
+			'Test Plugin Privacy Policy Without Errors',
+			__( 'This plugin sends data to an external analytics service. No personally identifiable information is transmitted.', 'test-plugin-privacy-policy-without-errors' )
+		);
+	}
+);
+
+// Sends data to an external service.
+function test_plugin_privacy_no_errors_send_data() {
+	$response = wp_remote_post(
+		'https://example-analytics.com/collect',
+		array(
+			'body' => array(
+				'site_url' => get_site_url(),
+			),
+		)
+	);
+
+	return $response;
+}

--- a/tests/phpunit/tests/Checker/Checks/Privacy_Policy_Check_Tests.php
+++ b/tests/phpunit/tests/Checker/Checks/Privacy_Policy_Check_Tests.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * Tests for the Privacy_Policy_Check class.
+ *
+ * @package plugin-check
+ */
+
+use WordPress\Plugin_Check\Checker\Check_Context;
+use WordPress\Plugin_Check\Checker\Check_Result;
+use WordPress\Plugin_Check\Checker\Checks\Plugin_Repo\Privacy_Policy_Check;
+
+class Privacy_Policy_Check_Tests extends WP_UnitTestCase {
+
+	/**
+	 * Tests that a plugin using wp_remote_post() without wp_add_privacy_policy_content()
+	 * receives a warning.
+	 */
+	public function test_run_with_errors() {
+		$check         = new Privacy_Policy_Check();
+		$check_context = new Check_Context( UNIT_TESTS_PLUGIN_DIR . 'test-plugin-privacy-policy-with-errors/load.php' );
+		$check_result  = new Check_Result( $check_context );
+
+		$check->run( $check_result );
+
+		$warnings = $check_result->get_warnings();
+
+		$this->assertNotEmpty( $warnings );
+
+		// Warning must be on the plugin's main file.
+		$this->assertArrayHasKey( 'load.php', $warnings );
+
+		// Verify the expected warning code is present.
+		$this->assertCount( 1, wp_list_filter( $warnings['load.php'][0][0], array( 'code' => 'missing_privacy_policy_content' ) ) );
+	}
+
+	/**
+	 * Tests that a plugin using wp_remote_post() WITH wp_add_privacy_policy_content()
+	 * does not receive any warnings.
+	 */
+	public function test_run_without_errors() {
+		$check         = new Privacy_Policy_Check();
+		$check_context = new Check_Context( UNIT_TESTS_PLUGIN_DIR . 'test-plugin-privacy-policy-without-errors/load.php' );
+		$check_result  = new Check_Result( $check_context );
+
+		$check->run( $check_result );
+
+		$warnings = $check_result->get_warnings();
+		$errors   = $check_result->get_errors();
+
+		$this->assertEmpty( $warnings );
+		$this->assertEmpty( $errors );
+	}
+
+	/**
+	 * Tests that a plugin with no personal-data-handling patterns does not receive
+	 * any warnings, even if it does not call wp_add_privacy_policy_content().
+	 */
+	public function test_run_with_no_signals() {
+		$check         = new Privacy_Policy_Check();
+		$check_context = new Check_Context( UNIT_TESTS_PLUGIN_DIR . 'test-plugin-privacy-policy-no-signals/load.php' );
+		$check_result  = new Check_Result( $check_context );
+
+		$check->run( $check_result );
+
+		$warnings = $check_result->get_warnings();
+		$errors   = $check_result->get_errors();
+
+		$this->assertEmpty( $warnings );
+		$this->assertEmpty( $errors );
+	}
+}

--- a/tests/phpunit/tests/Checker/Checks/Privacy_Policy_Check_Tests.php
+++ b/tests/phpunit/tests/Checker/Checks/Privacy_Policy_Check_Tests.php
@@ -68,4 +68,46 @@ class Privacy_Policy_Check_Tests extends WP_UnitTestCase {
 		$this->assertEmpty( $warnings );
 		$this->assertEmpty( $errors );
 	}
+
+	/**
+	 * Tests that function names appearing only in comments do not satisfy the
+	 * wp_add_privacy_policy_content() check. The fixture contains a real
+	 * wp_remote_post() signal plus a comment-only mention of the privacy
+	 * function; the check must still emit a warning because the real code does
+	 * not register privacy policy content.
+	 */
+	public function test_run_with_comment_only_signals() {
+		$check         = new Privacy_Policy_Check();
+		$check_context = new Check_Context( UNIT_TESTS_PLUGIN_DIR . 'test-plugin-privacy-policy-comment-only/load.php' );
+		$check_result  = new Check_Result( $check_context );
+
+		$check->run( $check_result );
+
+		$warnings = $check_result->get_warnings();
+
+		$this->assertNotEmpty( $warnings );
+		$this->assertArrayHasKey( 'load.php', $warnings );
+		$this->assertCount( 1, wp_list_filter( $warnings['load.php'][0][0], array( 'code' => 'missing_privacy_policy_content' ) ) );
+	}
+
+	/**
+	 * Tests that function names and variable names appearing only inside
+	 * string literals do not satisfy the wp_add_privacy_policy_content() check.
+	 * The fixture contains a real wp_remote_post() signal plus a string-only
+	 * mention of the privacy function; the check must still emit a warning
+	 * because the real code does not register privacy policy content.
+	 */
+	public function test_run_with_string_only_signals() {
+		$check         = new Privacy_Policy_Check();
+		$check_context = new Check_Context( UNIT_TESTS_PLUGIN_DIR . 'test-plugin-privacy-policy-string-only/load.php' );
+		$check_result  = new Check_Result( $check_context );
+
+		$check->run( $check_result );
+
+		$warnings = $check_result->get_warnings();
+
+		$this->assertNotEmpty( $warnings );
+		$this->assertArrayHasKey( 'load.php', $warnings );
+		$this->assertCount( 1, wp_list_filter( $warnings['load.php'][0][0], array( 'code' => 'missing_privacy_policy_content' ) ) );
+	}
 }


### PR DESCRIPTION
## Summary

Implements the feature requested in #1249.

WordPress.org guidelines require that every plugin which collects, uses, stores, or passes personal data to a third party must suggest privacy policy text to site administrators using `wp_add_privacy_policy_content()`. In practice, the vast majority of plugins that handle personal data do not implement this.

This PR adds a new `Privacy_Policy_Check` (static file check) that detects common personal-data-handling signals and warns if `wp_add_privacy_policy_content()` is absent.

## How it works

The check scans all PHP files in the plugin for signals that indicate potential personal data handling:

| Signal | Rationale |
|--------|-----------|
| `wp_remote_post()` | Transmitting data to external services |
| `wp_remote_get()` | Fetching from external URLs (analytics, tracking) |
| `setcookie()` | Setting cookies that may track users |
| `$_COOKIE` | Reading cookie data |
| `wp_set_auth_cookie()` | Authentication cookie handling |

If any signal is found **and** `wp_add_privacy_policy_content()` is not called anywhere in the plugin, a **single warning** (severity 5) is emitted on the plugin's main file with a link to the [WordPress privacy developer docs](https://developer.wordpress.org/plugins/privacy/suggesting-text-for-the-site-privacy-policy/).

Plugins with no signals are completely unaffected — the check stays silent.

## Design decisions

- **Warning, not error** — the presence of these API calls doesn't guarantee personal data is being mishandled; it's a strong enough signal to inform authors but not block submission
- **One warning per plugin** — avoids noise by stopping after the first matched signal
- **Early exit** — checks for `wp_add_privacy_policy_content()` first; if present, skips all signal scanning
- **Conservative signals** — only high-confidence indicators (remote posts/gets, cookies) are included, not noisy ones like raw `$_POST`/`$_GET`

## Files changed

- `includes/Checker/Checks/Plugin_Repo/Privacy_Policy_Check.php` — new check class
- `includes/Checker/Default_Check_Repository.php` — register as `privacy_policy`
- `docs/checks.md` — add row to the checks table
- `tests/phpunit/tests/Checker/Checks/Privacy_Policy_Check_Tests.php` — 3 test cases
- `tests/phpunit/testdata/plugins/test-plugin-privacy-policy-with-errors/` — has signal, no privacy call → triggers warning
- `tests/phpunit/testdata/plugins/test-plugin-privacy-policy-without-errors/` — has signal + `wp_add_privacy_policy_content()` → clean
- `tests/phpunit/testdata/plugins/test-plugin-privacy-policy-no-signals/` — no signals → clean

## Testing

Manually verified against **Mailchimp for WordPress** (mc4wp) — correctly fires the `missing_privacy_policy_content` warning on `mailchimp-for-wp.php`.

Verified against **Akismet** (which properly calls `wp_add_privacy_policy_content()`) — no warning produced.

Closes #1249

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fwp-admin%2Ftools.php%3Fpage%3Dplugin-check%22%2C%22phpExtensionBundles%22%3A%5B%22kitchen-sink%22%5D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginZipFile%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fplugin-check%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-1291-d025f52cf90a19e18934ca4edf0dee82b9e62b80.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->