### PR TITLE
feat(1314): add unclosed ob_start check

### DIFF
--- a/docs/checks.md
+++ b/docs/checks.md
@@ -36,4 +36,5 @@
 | enqueued_styles_scope | performance | Checks whether any stylesheets are loaded on all pages, which is usually not desirable and can lead to performance issues. | [Learn more](https://developer.wordpress.org/plugins/) |
 | enqueued_scripts_scope | performance | Checks whether any scripts are loaded on all pages, which is usually not desirable and can lead to performance issues. | [Learn more](https://developer.wordpress.org/plugins/) |
 | non_blocking_scripts | performance | Checks whether scripts and styles are enqueued using a recommended loading strategy. | [Learn more](https://developer.wordpress.org/plugins/) |
+| unclosed_ob_start | performance, plugin_repo | Detects calls to ob_start() that are not paired with a corresponding buffer-closing function within the same logical scope. | [Learn more](https://make.wordpress.org/core/2025/11/18/wordpress-6-9-frontend-performance-field-guide/#introduce-the-template-enhancement-output-buffer) |
 | ai_provider | general | Recommends the WordPress AI Client when a plugin integrates directly with a third-party AI provider. | [Learn more](https://developer.wordpress.org/plugins/) |

--- a/includes/Checker/Checks/Performance/Unclosed_Ob_Start_Check.php
+++ b/includes/Checker/Checks/Performance/Unclosed_Ob_Start_Check.php
@@ -9,8 +9,7 @@ namespace WordPress\Plugin_Check\Checker\Checks\Performance;
 
 use WordPress\Plugin_Check\Checker\Check_Categories;
 use WordPress\Plugin_Check\Checker\Check_Result;
-use WordPress\Plugin_Check\Checker\Checks\Abstract_File_Check;
-use WordPress\Plugin_Check\Traits\Amend_Check_Result;
+use WordPress\Plugin_Check\Checker\Checks\Abstract_PHP_CodeSniffer_Check;
 use WordPress\Plugin_Check\Traits\Stable_Check;
 
 /**
@@ -18,9 +17,8 @@ use WordPress\Plugin_Check\Traits\Stable_Check;
  *
  * @since 1.4.0
  */
-class Unclosed_Ob_Start_Check extends Abstract_File_Check {
+class Unclosed_Ob_Start_Check extends Abstract_PHP_CodeSniffer_Check {
 
-	use Amend_Check_Result;
 	use Stable_Check;
 
 	/**
@@ -37,254 +35,19 @@ class Unclosed_Ob_Start_Check extends Abstract_File_Check {
 	}
 
 	/**
-	 * Amends the given result by running the check on the given list of files.
+	 * Returns an associative array of arguments to pass to PHPCS.
 	 *
 	 * @since 1.4.0
 	 *
-	 * @param Check_Result $result The Check Result to amend.
-	 * @param array        $files  Array of plugin files.
+	 * @param Check_Result $result The check result to amend, including the plugin context to check.
+	 * @return array An associative array of PHPCS CLI arguments.
 	 */
-	protected function check_files( Check_Result $result, array $files ) {
-		$php_files = self::filter_files_by_extension( $files, 'php' );
-
-		foreach ( $php_files as $file ) {
-			$this->check_file_for_unclosed_ob_start( $result, $file );
-		}
-	}
-
-	/**
-	 * Checks a single PHP file for unclosed ob_start calls.
-	 *
-	 * @since 1.4.0
-	 *
-	 * @param Check_Result $result The check result.
-	 * @param string       $file   Absolute path to the file.
-	 */
-	private function check_file_for_unclosed_ob_start( Check_Result $result, string $file ) {
-		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
-		$source = file_get_contents( $file );
-		if ( false === $source || '' === $source ) {
-			return;
-		}
-
-		$tokens = token_get_all( $source );
-
-		$brace_depth             = 0;
-		$awaiting_function_brace = false;
-
-		$scope_stack = array(
-			array(
-				'type'        => 'file',
-				'start_depth' => 0,
-				'ob_starts'   => array(),
-				'ob_closes'   => array(),
-			),
+	protected function get_args( Check_Result $result ) {
+		return array(
+			'extensions' => 'php',
+			'standard'   => 'PluginCheck',
+			'sniffs'     => 'PluginCheck.CodeAnalysis.UnclosedObStart',
 		);
-
-		foreach ( $tokens as $index => $token ) {
-			if ( is_array( $token ) ) {
-				$this->process_array_token( $token, $index, $tokens, $brace_depth, $scope_stack, $awaiting_function_brace );
-				continue;
-			}
-
-			if ( '{' === $token ) {
-				if ( $awaiting_function_brace ) {
-					$scope_stack[]           = array(
-						'type'        => 'function',
-						'start_depth' => $brace_depth,
-						'ob_starts'   => array(),
-						'ob_closes'   => array(),
-					);
-					$awaiting_function_brace = false;
-				}
-				++$brace_depth;
-			} elseif ( '}' === $token ) {
-				--$brace_depth;
-				$current_scope = end( $scope_stack );
-				if ( 'function' === $current_scope['type'] && $current_scope['start_depth'] === $brace_depth ) {
-					$this->process_scope( $result, $file, $current_scope );
-					array_pop( $scope_stack );
-				}
-			}
-		}
-
-		// Process any remaining scopes in case of unbalanced braces or top-level file scope.
-		while ( count( $scope_stack ) > 0 ) {
-			$current_scope = array_pop( $scope_stack );
-			$this->process_scope( $result, $file, $current_scope );
-		}
-	}
-
-	/**
-	 * Processes an array token to update function detection state and track ob_start/close calls.
-	 *
-	 * @since 1.4.0
-	 *
-	 * @param array $token                   The array token.
-	 * @param int   $index                   Token index.
-	 * @param array $tokens                  All tokens.
-	 * @param int   $brace_depth             Current brace depth.
-	 * @param array $scope_stack             The scope stack.
-	 * @param bool  $awaiting_function_brace Whether awaiting a function's opening brace.
-	 */
-	private function process_array_token( array $token, int $index, array &$tokens, int $brace_depth, array &$scope_stack, bool &$awaiting_function_brace ) {
-		$token_type = $token[0];
-
-		if ( T_FUNCTION === $token_type ) {
-			$awaiting_function_brace = true;
-			return;
-		}
-
-		if ( T_STRING !== $token_type ) {
-			return;
-		}
-
-		$next_index = $this->get_next_significant_token_index( $tokens, $index );
-		if ( null === $next_index || '(' !== $tokens[ $next_index ] ) {
-			return;
-		}
-
-		if ( ! $this->is_global_function_call( $tokens, $index ) ) {
-			return;
-		}
-
-		$name = strtolower( $token[1] );
-		$line = (int) $token[2];
-
-		if ( 'ob_start' === $name ) {
-			$scope_stack[ count( $scope_stack ) - 1 ]['ob_starts'][] = array(
-				'line'  => $line,
-				'depth' => $brace_depth,
-			);
-		} elseif ( in_array( $name, array( 'ob_get_clean', 'ob_end_clean', 'ob_get_flush', 'ob_end_flush' ), true ) ) {
-			$scope_stack[ count( $scope_stack ) - 1 ]['ob_closes'][] = array(
-				'line'  => $line,
-				'depth' => $brace_depth,
-			);
-		}
-	}
-
-	/**
-	 * Processes a completed scope to find unpaired ob_start calls.
-	 *
-	 * @since 1.4.0
-	 *
-	 * @param Check_Result $result The check result.
-	 * @param string       $file   Absolute path to the file.
-	 * @param array        $scope  The scope data.
-	 */
-	private function process_scope( Check_Result $result, string $file, array $scope ) {
-		if ( empty( $scope['ob_starts'] ) ) {
-			return;
-		}
-
-		$unpaired_ob_starts = $scope['ob_starts'];
-
-		foreach ( $scope['ob_closes'] as $close ) {
-			// Find the most recent ob_start that is on or before this close's depth.
-			for ( $i = count( $unpaired_ob_starts ) - 1; $i >= 0; $i-- ) {
-				if ( $close['depth'] <= $unpaired_ob_starts[ $i ]['depth'] ) {
-					array_splice( $unpaired_ob_starts, $i, 1 );
-					break; // Found the match for this close, move to the next close.
-				}
-			}
-		}
-
-		foreach ( $unpaired_ob_starts as $ob_start ) {
-			$this->add_result_warning_for_file(
-				$result,
-				__( '<code>ob_start()</code> was found without a corresponding closing call (<code>ob_get_clean()</code>, <code>ob_end_clean()</code>, <code>ob_get_flush()</code> or <code>ob_end_flush()</code>) in the same scope. Output buffering is a valid technique, but a buffer must not be left open. WordPress is a shared environment where core, themes and other plugins may also open or close buffers, and a misaligned buffer stack causes unpredictable behaviour (headers already sent, lost output, broken redirects, etc.). Please ensure every <code>ob_start()</code> is paired with a closing function within the same function scope, and that nothing (including hooks or early returns) can bypass that closing logic. If you need to modify the full response output, use the new template enhancement output buffer available since WordPress 6.9.', 'plugin-check' ),
-				'unclosed_ob_start',
-				$file,
-				$ob_start['line'],
-				0,
-				'https://make.wordpress.org/core/2021/02/10/introducing-template-road-map-and-enhancements-in-wordpress-5-7/'
-			);
-		}
-	}
-
-	/**
-	 * Checks whether a tokenized T_STRING is a global function call.
-	 *
-	 * @since 1.4.0
-	 *
-	 * @param array $tokens Token stream.
-	 * @param int   $index  Current token index.
-	 * @return bool
-	 */
-	private function is_global_function_call( array $tokens, int $index ): bool {
-		$previous_index = $this->get_previous_significant_token_index( $tokens, $index );
-		if ( null === $previous_index ) {
-			return true;
-		}
-
-		$previous_token = $tokens[ $previous_index ];
-
-		if ( is_array( $previous_token ) ) {
-			if ( in_array( $previous_token[0], array( T_FUNCTION, T_NEW, T_OBJECT_OPERATOR, T_DOUBLE_COLON ), true ) ) {
-				return false;
-			}
-
-			if ( T_NS_SEPARATOR === $previous_token[0] ) {
-				$before_namespace_index = $this->get_previous_significant_token_index( $tokens, $previous_index );
-				if ( null === $before_namespace_index ) {
-					return true;
-				}
-
-				$before_namespace_token = $tokens[ $before_namespace_index ];
-				if ( is_array( $before_namespace_token ) && in_array( $before_namespace_token[0], array( T_STRING, T_NAMESPACE ), true ) ) {
-					return false;
-				}
-			}
-		}
-
-		return true;
-	}
-
-	/**
-	 * Finds the next significant token index.
-	 *
-	 * @since 1.4.0
-	 *
-	 * @param array $tokens Token stream.
-	 * @param int   $index  Current token index.
-	 * @return int|null
-	 */
-	private function get_next_significant_token_index( array $tokens, int $index ): ?int {
-		$count = count( $tokens );
-		for ( $i = $index + 1; $i < $count; $i++ ) {
-			$token = $tokens[ $i ];
-			if ( is_array( $token ) && T_WHITESPACE === $token[0] ) {
-				continue;
-			}
-
-			return $i;
-		}
-
-		return null;
-	}
-
-	/**
-	 * Finds the previous significant token index.
-	 *
-	 * @since 1.4.0
-	 *
-	 * @param array $tokens Token stream.
-	 * @param int   $index  Current token index.
-	 * @return int|null
-	 */
-	private function get_previous_significant_token_index( array $tokens, int $index ): ?int {
-		for ( $i = $index - 1; $i >= 0; $i-- ) {
-			$token = $tokens[ $i ];
-
-			if ( is_array( $token ) && in_array( $token[0], array( T_WHITESPACE, T_COMMENT, T_DOC_COMMENT ), true ) ) {
-				continue;
-			}
-
-			return $i;
-		}
-
-		return null;
 	}
 
 	/**
@@ -310,6 +73,28 @@ class Unclosed_Ob_Start_Check extends Abstract_File_Check {
 	 * @return string The documentation URL.
 	 */
 	public function get_documentation_url(): string {
-		return __( 'https://developer.wordpress.org/plugins/', 'plugin-check' );
+		return __( 'https://make.wordpress.org/core/2025/11/18/wordpress-6-9-frontend-performance-field-guide/#introduce-the-template-enhancement-output-buffer', 'plugin-check' );
+	}
+
+	/**
+	 * Amends the given result with a message for the specified file, including the
+	 * documentation URL for this check.
+	 *
+	 * @since 1.4.0
+	 *
+	 * @param Check_Result $result   The check result to amend, including the plugin context to check.
+	 * @param bool         $error    Whether it is an error or notice.
+	 * @param string       $message  Error message.
+	 * @param string       $code     Error code.
+	 * @param string       $file     Absolute path to the file where the issue was found.
+	 * @param int          $line     The line on which the message occurred. Default is 0 (unknown line).
+	 * @param int          $column   The column on which the message occurred. Default is 0 (unknown column).
+	 * @param string       $docs     URL for further information about the message.
+	 * @param int          $severity Severity level. Default is 5.
+	 */
+	protected function add_result_message_for_file( Check_Result $result, $error, $message, $code, $file, $line = 0, $column = 0, string $docs = '', $severity = 5 ) {
+		$docs = __( 'https://make.wordpress.org/core/2025/11/18/wordpress-6-9-frontend-performance-field-guide/#introduce-the-template-enhancement-output-buffer', 'plugin-check' );
+
+		parent::add_result_message_for_file( $result, $error, $message, $code, $file, $line, $column, $docs, $severity );
 	}
 }

--- a/includes/Checker/Checks/Performance/Unclosed_Ob_Start_Check.php
+++ b/includes/Checker/Checks/Performance/Unclosed_Ob_Start_Check.php
@@ -121,9 +121,9 @@ class Unclosed_Ob_Start_Check extends Abstract_File_Check {
 					);
 					$awaiting_function_brace = false;
 				}
-				$brace_depth++;
+				++$brace_depth;
 			} elseif ( '}' === $token ) {
-				$brace_depth--;
+				--$brace_depth;
 				$current_scope = end( $scope_stack );
 				if ( 'function' === $current_scope['type'] && $current_scope['start_depth'] === $brace_depth ) {
 					$this->process_scope( $result, $file, $current_scope );

--- a/includes/Checker/Checks/Performance/Unclosed_Ob_Start_Check.php
+++ b/includes/Checker/Checks/Performance/Unclosed_Ob_Start_Check.php
@@ -83,31 +83,7 @@ class Unclosed_Ob_Start_Check extends Abstract_File_Check {
 
 		foreach ( $tokens as $index => $token ) {
 			if ( is_array( $token ) ) {
-				$token_type = $token[0];
-
-				if ( T_FUNCTION === $token_type ) {
-					$awaiting_function_brace = true;
-				} elseif ( T_STRING === $token_type ) {
-					$next_index = $this->get_next_significant_token_index( $tokens, $index );
-					if ( null !== $next_index && '(' === $tokens[ $next_index ] ) {
-						if ( $this->is_global_function_call( $tokens, $index ) ) {
-							$name = strtolower( $token[1] );
-							$line = (int) $token[2];
-
-							if ( 'ob_start' === $name ) {
-								$scope_stack[ count( $scope_stack ) - 1 ]['ob_starts'][] = array(
-									'line'  => $line,
-									'depth' => $brace_depth,
-								);
-							} elseif ( in_array( $name, array( 'ob_get_clean', 'ob_end_clean', 'ob_get_flush', 'ob_end_flush' ), true ) ) {
-								$scope_stack[ count( $scope_stack ) - 1 ]['ob_closes'][] = array(
-									'line'  => $line,
-									'depth' => $brace_depth,
-								);
-							}
-						}
-					}
-				}
+				$this->process_array_token( $token, $index, $tokens, $brace_depth, $scope_stack, $awaiting_function_brace );
 				continue;
 			}
 
@@ -136,6 +112,55 @@ class Unclosed_Ob_Start_Check extends Abstract_File_Check {
 		while ( count( $scope_stack ) > 0 ) {
 			$current_scope = array_pop( $scope_stack );
 			$this->process_scope( $result, $file, $current_scope );
+		}
+	}
+
+	/**
+	 * Processes an array token to update function detection state and track ob_start/close calls.
+	 *
+	 * @since 1.4.0
+	 *
+	 * @param array $token                   The array token.
+	 * @param int   $index                   Token index.
+	 * @param array $tokens                  All tokens.
+	 * @param int   $brace_depth             Current brace depth.
+	 * @param array $scope_stack             The scope stack.
+	 * @param bool  $awaiting_function_brace Whether awaiting a function's opening brace.
+	 */
+	private function process_array_token( array $token, int $index, array &$tokens, int $brace_depth, array &$scope_stack, bool &$awaiting_function_brace ) {
+		$token_type = $token[0];
+
+		if ( T_FUNCTION === $token_type ) {
+			$awaiting_function_brace = true;
+			return;
+		}
+
+		if ( T_STRING !== $token_type ) {
+			return;
+		}
+
+		$next_index = $this->get_next_significant_token_index( $tokens, $index );
+		if ( null === $next_index || '(' !== $tokens[ $next_index ] ) {
+			return;
+		}
+
+		if ( ! $this->is_global_function_call( $tokens, $index ) ) {
+			return;
+		}
+
+		$name = strtolower( $token[1] );
+		$line = (int) $token[2];
+
+		if ( 'ob_start' === $name ) {
+			$scope_stack[ count( $scope_stack ) - 1 ]['ob_starts'][] = array(
+				'line'  => $line,
+				'depth' => $brace_depth,
+			);
+		} elseif ( in_array( $name, array( 'ob_get_clean', 'ob_end_clean', 'ob_get_flush', 'ob_end_flush' ), true ) ) {
+			$scope_stack[ count( $scope_stack ) - 1 ]['ob_closes'][] = array(
+				'line'  => $line,
+				'depth' => $brace_depth,
+			);
 		}
 	}
 

--- a/includes/Checker/Checks/Performance/Unclosed_Ob_Start_Check.php
+++ b/includes/Checker/Checks/Performance/Unclosed_Ob_Start_Check.php
@@ -1,0 +1,290 @@
+<?php
+/**
+ * Class Unclosed_Ob_Start_Check.
+ *
+ * @package plugin-check
+ */
+
+namespace WordPress\Plugin_Check\Checker\Checks\Performance;
+
+use WordPress\Plugin_Check\Checker\Check_Categories;
+use WordPress\Plugin_Check\Checker\Check_Result;
+use WordPress\Plugin_Check\Checker\Checks\Abstract_File_Check;
+use WordPress\Plugin_Check\Traits\Amend_Check_Result;
+use WordPress\Plugin_Check\Traits\Stable_Check;
+
+/**
+ * Check for unclosed ob_start() calls.
+ *
+ * @since 1.4.0
+ */
+class Unclosed_Ob_Start_Check extends Abstract_File_Check {
+
+	use Amend_Check_Result;
+	use Stable_Check;
+
+	/**
+	 * Gets the categories for the check.
+	 *
+	 * Every check must have at least one category.
+	 *
+	 * @since 1.4.0
+	 *
+	 * @return array The categories for the check.
+	 */
+	public function get_categories() {
+		return array( Check_Categories::CATEGORY_PERFORMANCE );
+	}
+
+	/**
+	 * Amends the given result by running the check on the given list of files.
+	 *
+	 * @since 1.4.0
+	 *
+	 * @param Check_Result $result The Check Result to amend.
+	 * @param array        $files  Array of plugin files.
+	 */
+	protected function check_files( Check_Result $result, array $files ) {
+		$php_files = self::filter_files_by_extension( $files, 'php' );
+
+		foreach ( $php_files as $file ) {
+			$this->check_file_for_unclosed_ob_start( $result, $file );
+		}
+	}
+
+	/**
+	 * Checks a single PHP file for unclosed ob_start calls.
+	 *
+	 * @since 1.4.0
+	 *
+	 * @param Check_Result $result The check result.
+	 * @param string       $file   Absolute path to the file.
+	 */
+	private function check_file_for_unclosed_ob_start( Check_Result $result, string $file ) {
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+		$source = file_get_contents( $file );
+		if ( false === $source || '' === $source ) {
+			return;
+		}
+
+		$tokens = token_get_all( $source );
+
+		$brace_depth             = 0;
+		$awaiting_function_brace = false;
+
+		$scope_stack = array(
+			array(
+				'type'        => 'file',
+				'start_depth' => 0,
+				'ob_starts'   => array(),
+				'ob_closes'   => array(),
+			),
+		);
+
+		foreach ( $tokens as $index => $token ) {
+			if ( is_array( $token ) ) {
+				$token_type = $token[0];
+
+				if ( T_FUNCTION === $token_type ) {
+					$awaiting_function_brace = true;
+				} elseif ( T_STRING === $token_type ) {
+					$next_index = $this->get_next_significant_token_index( $tokens, $index );
+					if ( null !== $next_index && '(' === $tokens[ $next_index ] ) {
+						if ( $this->is_global_function_call( $tokens, $index ) ) {
+							$name = strtolower( $token[1] );
+							$line = (int) $token[2];
+
+							if ( 'ob_start' === $name ) {
+								$scope_stack[ count( $scope_stack ) - 1 ]['ob_starts'][] = array(
+									'line'  => $line,
+									'depth' => $brace_depth,
+								);
+							} elseif ( in_array( $name, array( 'ob_get_clean', 'ob_end_clean', 'ob_get_flush', 'ob_end_flush' ), true ) ) {
+								$scope_stack[ count( $scope_stack ) - 1 ]['ob_closes'][] = array(
+									'line'  => $line,
+									'depth' => $brace_depth,
+								);
+							}
+						}
+					}
+				}
+				continue;
+			}
+
+			if ( '{' === $token ) {
+				if ( $awaiting_function_brace ) {
+					$scope_stack[]           = array(
+						'type'        => 'function',
+						'start_depth' => $brace_depth,
+						'ob_starts'   => array(),
+						'ob_closes'   => array(),
+					);
+					$awaiting_function_brace = false;
+				}
+				$brace_depth++;
+			} elseif ( '}' === $token ) {
+				$brace_depth--;
+				$current_scope = end( $scope_stack );
+				if ( 'function' === $current_scope['type'] && $current_scope['start_depth'] === $brace_depth ) {
+					$this->process_scope( $result, $file, $current_scope );
+					array_pop( $scope_stack );
+				}
+			}
+		}
+
+		// Process any remaining scopes in case of unbalanced braces or top-level file scope.
+		while ( count( $scope_stack ) > 0 ) {
+			$current_scope = array_pop( $scope_stack );
+			$this->process_scope( $result, $file, $current_scope );
+		}
+	}
+
+	/**
+	 * Processes a completed scope to find unpaired ob_start calls.
+	 *
+	 * @since 1.4.0
+	 *
+	 * @param Check_Result $result The check result.
+	 * @param string       $file   Absolute path to the file.
+	 * @param array        $scope  The scope data.
+	 */
+	private function process_scope( Check_Result $result, string $file, array $scope ) {
+		if ( empty( $scope['ob_starts'] ) ) {
+			return;
+		}
+
+		$unpaired_ob_starts = $scope['ob_starts'];
+
+		foreach ( $scope['ob_closes'] as $close ) {
+			// Find the most recent ob_start that is on or before this close's depth.
+			for ( $i = count( $unpaired_ob_starts ) - 1; $i >= 0; $i-- ) {
+				if ( $close['depth'] <= $unpaired_ob_starts[ $i ]['depth'] ) {
+					array_splice( $unpaired_ob_starts, $i, 1 );
+					break; // Found the match for this close, move to the next close.
+				}
+			}
+		}
+
+		foreach ( $unpaired_ob_starts as $ob_start ) {
+			$this->add_result_warning_for_file(
+				$result,
+				__( '<code>ob_start()</code> was found without a corresponding closing call (<code>ob_get_clean()</code>, <code>ob_end_clean()</code>, <code>ob_get_flush()</code> or <code>ob_end_flush()</code>) in the same scope. Output buffering is a valid technique, but a buffer must not be left open. WordPress is a shared environment where core, themes and other plugins may also open or close buffers, and a misaligned buffer stack causes unpredictable behaviour (headers already sent, lost output, broken redirects, etc.). Please ensure every <code>ob_start()</code> is paired with a closing function within the same function scope, and that nothing (including hooks or early returns) can bypass that closing logic. If you need to modify the full response output, use the new template enhancement output buffer available since WordPress 6.9.', 'plugin-check' ),
+				'unclosed_ob_start',
+				$file,
+				$ob_start['line'],
+				0,
+				'https://make.wordpress.org/core/2021/02/10/introducing-template-road-map-and-enhancements-in-wordpress-5-7/'
+			);
+		}
+	}
+
+	/**
+	 * Checks whether a tokenized T_STRING is a global function call.
+	 *
+	 * @since 1.4.0
+	 *
+	 * @param array $tokens Token stream.
+	 * @param int   $index  Current token index.
+	 * @return bool
+	 */
+	private function is_global_function_call( array $tokens, int $index ): bool {
+		$previous_index = $this->get_previous_significant_token_index( $tokens, $index );
+		if ( null === $previous_index ) {
+			return true;
+		}
+
+		$previous_token = $tokens[ $previous_index ];
+
+		if ( is_array( $previous_token ) ) {
+			if ( in_array( $previous_token[0], array( T_FUNCTION, T_NEW, T_OBJECT_OPERATOR, T_DOUBLE_COLON ), true ) ) {
+				return false;
+			}
+
+			if ( T_NS_SEPARATOR === $previous_token[0] ) {
+				$before_namespace_index = $this->get_previous_significant_token_index( $tokens, $previous_index );
+				if ( null === $before_namespace_index ) {
+					return true;
+				}
+
+				$before_namespace_token = $tokens[ $before_namespace_index ];
+				if ( is_array( $before_namespace_token ) && in_array( $before_namespace_token[0], array( T_STRING, T_NAMESPACE ), true ) ) {
+					return false;
+				}
+			}
+		}
+
+		return true;
+	}
+
+	/**
+	 * Finds the next significant token index.
+	 *
+	 * @since 1.4.0
+	 *
+	 * @param array $tokens Token stream.
+	 * @param int   $index  Current token index.
+	 * @return int|null
+	 */
+	private function get_next_significant_token_index( array $tokens, int $index ): ?int {
+		$count = count( $tokens );
+		for ( $i = $index + 1; $i < $count; $i++ ) {
+			$token = $tokens[ $i ];
+			if ( is_array( $token ) && T_WHITESPACE === $token[0] ) {
+				continue;
+			}
+
+			return $i;
+		}
+
+		return null;
+	}
+
+	/**
+	 * Finds the previous significant token index.
+	 *
+	 * @since 1.4.0
+	 *
+	 * @param array $tokens Token stream.
+	 * @param int   $index  Current token index.
+	 * @return int|null
+	 */
+	private function get_previous_significant_token_index( array $tokens, int $index ): ?int {
+		for ( $i = $index - 1; $i >= 0; $i-- ) {
+			$token = $tokens[ $i ];
+
+			if ( is_array( $token ) && in_array( $token[0], array( T_WHITESPACE, T_COMMENT, T_DOC_COMMENT ), true ) ) {
+				continue;
+			}
+
+			return $i;
+		}
+
+		return null;
+	}
+
+	/**
+	 * Gets the description for the check.
+	 *
+	 * Every check must have a short description explaining what the check does.
+	 *
+	 * @since 1.4.0
+	 *
+	 * @return string Description.
+	 */
+	public function get_description(): string {
+		return __( 'Detects calls to ob_start() that are not paired with a corresponding buffer-closing function within the same logical scope.', 'plugin-check' );
+	}
+
+	/**
+	 * Gets the documentation URL for the check.
+	 *
+	 * Every check must have a URL with further information about the check.
+	 *
+	 * @since 1.4.0
+	 *
+	 * @return string The documentation URL.
+	 */
+	public function get_documentation_url(): string {
+		return __( 'https://developer.wordpress.org/plugins/', 'plugin-check' );
+	}
+}

--- a/includes/Checker/Checks/Performance/Unclosed_Ob_Start_Check.php
+++ b/includes/Checker/Checks/Performance/Unclosed_Ob_Start_Check.php
@@ -15,7 +15,7 @@ use WordPress\Plugin_Check\Traits\Stable_Check;
 /**
  * Check for unclosed ob_start() calls.
  *
- * @since 1.4.0
+ * @since 2.1.0
  */
 class Unclosed_Ob_Start_Check extends Abstract_PHP_CodeSniffer_Check {
 
@@ -26,18 +26,21 @@ class Unclosed_Ob_Start_Check extends Abstract_PHP_CodeSniffer_Check {
 	 *
 	 * Every check must have at least one category.
 	 *
-	 * @since 1.4.0
+	 * @since 2.1.0
 	 *
 	 * @return array The categories for the check.
 	 */
 	public function get_categories() {
-		return array( Check_Categories::CATEGORY_PERFORMANCE );
+		return array(
+			Check_Categories::CATEGORY_PERFORMANCE,
+			Check_Categories::CATEGORY_PLUGIN_REPO,
+		);
 	}
 
 	/**
 	 * Returns an associative array of arguments to pass to PHPCS.
 	 *
-	 * @since 1.4.0
+	 * @since 2.1.0
 	 *
 	 * @param Check_Result $result The check result to amend, including the plugin context to check.
 	 * @return array An associative array of PHPCS CLI arguments.
@@ -55,7 +58,7 @@ class Unclosed_Ob_Start_Check extends Abstract_PHP_CodeSniffer_Check {
 	 *
 	 * Every check must have a short description explaining what the check does.
 	 *
-	 * @since 1.4.0
+	 * @since 2.1.0
 	 *
 	 * @return string Description.
 	 */
@@ -68,7 +71,7 @@ class Unclosed_Ob_Start_Check extends Abstract_PHP_CodeSniffer_Check {
 	 *
 	 * Every check must have a URL with further information about the check.
 	 *
-	 * @since 1.4.0
+	 * @since 2.1.0
 	 *
 	 * @return string The documentation URL.
 	 */
@@ -80,7 +83,7 @@ class Unclosed_Ob_Start_Check extends Abstract_PHP_CodeSniffer_Check {
 	 * Amends the given result with a message for the specified file, including the
 	 * documentation URL for this check.
 	 *
-	 * @since 1.4.0
+	 * @since 2.1.0
 	 *
 	 * @param Check_Result $result   The check result to amend, including the plugin context to check.
 	 * @param bool         $error    Whether it is an error or notice.
@@ -93,7 +96,9 @@ class Unclosed_Ob_Start_Check extends Abstract_PHP_CodeSniffer_Check {
 	 * @param int          $severity Severity level. Default is 5.
 	 */
 	protected function add_result_message_for_file( Check_Result $result, $error, $message, $code, $file, $line = 0, $column = 0, string $docs = '', $severity = 5 ) {
-		$docs = __( 'https://make.wordpress.org/core/2025/11/18/wordpress-6-9-frontend-performance-field-guide/#introduce-the-template-enhancement-output-buffer', 'plugin-check' );
+		if ( '' === $docs ) {
+			$docs = $this->get_documentation_url();
+		}
 
 		parent::add_result_message_for_file( $result, $error, $message, $code, $file, $line, $column, $docs, $severity );
 	}

--- a/includes/Checker/Default_Check_Repository.php
+++ b/includes/Checker/Default_Check_Repository.php
@@ -103,6 +103,7 @@ class Default_Check_Repository extends Empty_Check_Repository {
 				'direct_file_access'         => new Checks\Plugin_Repo\Direct_File_Access_Check(),
 				'external_admin_menu_links'  => new Checks\Plugin_Repo\External_Admin_Menu_Links_Check(),
 				'wp_functions_compatibility' => new Checks\Plugin_Repo\WP_Functions_Compatibility_Check(),
+				'unclosed_ob_start'          => new Checks\Performance\Unclosed_Ob_Start_Check(),
 			)
 		);
 

--- a/phpcs-sniffs/PluginCheck/Sniffs/CodeAnalysis/UnclosedObStartSniff.php
+++ b/phpcs-sniffs/PluginCheck/Sniffs/CodeAnalysis/UnclosedObStartSniff.php
@@ -257,7 +257,10 @@ final class UnclosedObStartSniff extends Sniff {
 
 		$conditions = array_reverse( $this->tokens[ $stackPtr ]['conditions'], true );
 		foreach ( $conditions as $condition_ptr => $condition_code ) {
-			if ( in_array( $condition_code, array( T_FUNCTION, T_CLOSURE ), true ) ) {
+			// T_FN (arrow functions, PHP 7.4+) creates its own scope in the PHPCS
+			// conditions stack and must be treated like a function/closure for the
+			// purposes of pairing ob_start() with its closing call.
+			if ( in_array( $condition_code, array( T_FUNCTION, T_CLOSURE, T_FN ), true ) ) {
 				return $condition_ptr;
 			}
 		}

--- a/phpcs-sniffs/PluginCheck/Sniffs/CodeAnalysis/UnclosedObStartSniff.php
+++ b/phpcs-sniffs/PluginCheck/Sniffs/CodeAnalysis/UnclosedObStartSniff.php
@@ -138,9 +138,9 @@ final class UnclosedObStartSniff extends Sniff {
 		// Cache the last registered token pointer on first call to avoid
 		// scanning the entire token stack on every matching token visit.
 		if ( null === $this->last_registered_ptr ) {
-			$tokens                   = $this->register();
+			$tokens                    = $this->register();
 			$this->last_registered_ptr = $this->phpcsFile->findNext( $tokens, 0 );
-			$next_ptr                 = $this->last_registered_ptr;
+			$next_ptr                  = $this->last_registered_ptr;
 			while ( false !== $next_ptr ) {
 				$this->last_registered_ptr = $next_ptr;
 				$next_ptr                  = $this->phpcsFile->findNext( $tokens, ( $next_ptr + 1 ) );

--- a/phpcs-sniffs/PluginCheck/Sniffs/CodeAnalysis/UnclosedObStartSniff.php
+++ b/phpcs-sniffs/PluginCheck/Sniffs/CodeAnalysis/UnclosedObStartSniff.php
@@ -1,0 +1,402 @@
+<?php
+/**
+ * UnclosedObStartSniff
+ *
+ * @package PluginCheck
+ */
+
+namespace PluginCheckCS\PluginCheck\Sniffs\CodeAnalysis;
+
+use PHP_CodeSniffer\Util\Tokens;
+use WordPressCS\WordPress\Sniff;
+
+/**
+ * Detects calls to ob_start() that are not paired with a corresponding buffer-closing
+ * function within the same logical scope.
+ *
+ * @since 1.4.0
+ */
+final class UnclosedObStartSniff extends Sniff {
+
+	/**
+	 * Buffer-closing functions that pair with ob_start().
+	 *
+	 * @since 1.4.0
+	 *
+	 * @var array<string, true>
+	 */
+	private $closing_functions = array(
+		'ob_get_clean' => true,
+		'ob_end_clean' => true,
+		'ob_get_flush' => true,
+		'ob_end_flush' => true,
+	);
+
+	/**
+	 * Scope-keyed collection of ob_start() and closing calls for the current file.
+	 *
+	 * Populated during the token walk and evaluated once the file has been
+	 * fully processed.
+	 *
+	 * @since 1.4.0
+	 *
+	 * @var array<int, array{starts: array<int, array{ptr: int, line: int, conditions: array}>, closes: array<int, array{ptr: int, line: int, conditions: array}>}>
+	 */
+	private $scopes = array();
+
+	/**
+	 * Ordered list of scope start pointers, used to process scopes in source order.
+	 *
+	 * @since 1.4.0
+	 *
+	 * @var array<int, int>
+	 */
+	private $scope_order = array();
+
+	/**
+	 * Whether the current file has been finalized (scopes evaluated).
+	 *
+	 * @since 1.4.0
+	 *
+	 * @var bool
+	 */
+	private $finalized = false;
+
+	/**
+	 * Returns an array of tokens this test wants to listen for.
+	 *
+	 * @since 1.4.0
+	 *
+	 * @return array<int>
+	 */
+	public function register() {
+		$tokens = array( T_STRING );
+
+		// T_NAME_FULLY_QUALIFIED was introduced in PHP 8.0 for namespaced names like \ob_start().
+		if ( defined( 'T_NAME_FULLY_QUALIFIED' ) ) {
+			$tokens[] = constant( 'T_NAME_FULLY_QUALIFIED' );
+		}
+
+		return $tokens;
+	}
+
+	/**
+	 * Processes this test, when one of its tokens is encountered.
+	 *
+	 * @since 1.4.0
+	 *
+	 * @param int $stackPtr The position of the current token in the stack.
+	 * @return int|void Integer stack pointer to skip forward or void to continue normal file processing.
+	 */
+	public function process_token( $stackPtr ) {
+		$name = $this->get_global_function_name( $stackPtr );
+		if ( null === $name ) {
+			$this->maybe_finalize( $stackPtr );
+			return;
+		}
+
+		$lower_name = strtolower( $name );
+
+		if ( 'ob_start' === $lower_name ) {
+			$this->record_call( $stackPtr, true );
+		} elseif ( isset( $this->closing_functions[ $lower_name ] ) ) {
+			$this->record_call( $stackPtr, false );
+		}
+
+		$this->maybe_finalize( $stackPtr );
+	}
+
+	/**
+	 * Finalizes the file once the last registered token has been processed.
+	 *
+	 * PHPCS only invokes process_token() for tokens returned by register(), so the
+	 * final file token (often trailing whitespace) is never visited. This finalizes as
+	 * soon as no further registered tokens remain ahead, ensuring all collected calls
+	 * are available before pairing.
+	 *
+	 * @since 1.4.0
+	 *
+	 * @param int $stackPtr The position of the current token in the stack.
+	 */
+	private function maybe_finalize( $stackPtr ) {
+		if ( $this->finalized ) {
+			return;
+		}
+
+		$next = $this->phpcsFile->findNext( $this->register(), ( $stackPtr + 1 ) );
+		if ( false !== $next ) {
+			return;
+		}
+
+		$this->finalize_file();
+	}
+
+	/**
+	 * Resolves the global function name being called at the given pointer, or null if
+	 * the token is not a global call to a tracked function.
+	 *
+	 * Handles both the legacy T_STRING + T_NS_SEPARATOR sequence (PHP < 8.0) and the
+	 * single T_NAME_FULLY_QUALIFIED token (PHP >= 8.0) so that \ob_start() in namespaced
+	 * code is detected consistently.
+	 *
+	 * @since 1.4.0
+	 *
+	 * @param int $stackPtr The position of the current token in the stack.
+	 * @return string|null The lowercased function name, or null when not a global call.
+	 */
+	private function get_global_function_name( $stackPtr ) {
+		$token_code = $this->tokens[ $stackPtr ]['code'];
+
+		$name = null;
+
+		if ( T_STRING === $token_code ) {
+			$previous = $this->phpcsFile->findPrevious( Tokens::$emptyTokens, ( $stackPtr - 1 ), null, true );
+			if ( false === $previous ) {
+				return null;
+			}
+
+			$previous_code = $this->tokens[ $previous ]['code'];
+
+			$disallowed_previous = array( T_FUNCTION, T_NEW, T_OBJECT_OPERATOR, T_DOUBLE_COLON );
+
+			// T_NULLSAFE_OBJECT_OPERATOR (?->) was introduced in PHP 8.0.
+			if ( defined( 'T_NULLSAFE_OBJECT_OPERATOR' ) ) {
+				$disallowed_previous[] = constant( 'T_NULLSAFE_OBJECT_OPERATOR' );
+			}
+
+			// Skip method calls, constructors and function declarations.
+			if ( in_array( $previous_code, $disallowed_previous, true ) ) {
+				return null;
+			}
+
+			// Handle the legacy \Namespace\func() two-token form.
+			if ( T_NS_SEPARATOR === $previous_code ) {
+				$before_ns = $this->phpcsFile->findPrevious( Tokens::$emptyTokens, ( $previous - 1 ), null, true );
+				if ( false !== $before_ns ) {
+					$before_code = $this->tokens[ $before_ns ]['code'];
+					if ( in_array( $before_code, array( T_STRING, T_NAMESPACE ), true ) ) {
+						return null; // Namespaced call, not a global one.
+					}
+				}
+			}
+
+			$name = $this->tokens[ $stackPtr ]['content'];
+		} elseif ( defined( 'T_NAME_FULLY_QUALIFIED' ) && constant( 'T_NAME_FULLY_QUALIFIED' ) === $token_code ) {
+			// PHP >= 8.0: \ob_start() tokenizes as a single T_NAME_FULLY_QUALIFIED token.
+			$name = ltrim( $this->tokens[ $stackPtr ]['content'], '\\' );
+		}
+
+		if ( null === $name ) {
+			return null;
+		}
+
+		// Must be followed by an opening parenthesis to be a function call.
+		$next = $this->phpcsFile->findNext( Tokens::$emptyTokens, ( $stackPtr + 1 ), null, true );
+		if ( false === $next || T_OPEN_PARENTHESIS !== $this->tokens[ $next ]['code'] ) {
+			return null;
+		}
+
+		return $name;
+	}
+
+	/**
+	 * Records an ob_start() or closing call against its enclosing scope.
+	 *
+	 * The file scope is represented by a pointer of -1. Function, method and closure
+	 * scopes use the pointer of their opening condition token.
+	 *
+	 * @since 1.4.0
+	 *
+	 * @param int  $stackPtr The position of the call.
+	 * @param bool $is_start Whether this is an ob_start() (true) or a closing call (false).
+	 */
+	private function record_call( $stackPtr, $is_start ) {
+		$scope_ptr = $this->get_scope_pointer( $stackPtr );
+
+		if ( ! isset( $this->scopes[ $scope_ptr ] ) ) {
+			$this->scopes[ $scope_ptr ] = array(
+				'starts' => array(),
+				'closes' => array(),
+			);
+			$this->scope_order[]        = $scope_ptr;
+		}
+
+		$line       = $this->tokens[ $stackPtr ]['line'];
+		$conditions = isset( $this->tokens[ $stackPtr ]['conditions'] ) ? $this->tokens[ $stackPtr ]['conditions'] : array();
+
+		if ( $is_start ) {
+			$this->scopes[ $scope_ptr ]['starts'][] = array(
+				'ptr'        => $stackPtr,
+				'line'       => $line,
+				'conditions' => $conditions,
+			);
+		} else {
+			$this->scopes[ $scope_ptr ]['closes'][] = array(
+				'ptr'        => $stackPtr,
+				'line'       => $line,
+				'conditions' => $conditions,
+			);
+		}
+	}
+
+	/**
+	 * Gets the scope pointer that owns the token at the given position.
+	 *
+	 * Returns the pointer of the nearest enclosing function, method or closure, or -1
+	 * for the file (top-level) scope.
+	 *
+	 * @since 1.4.0
+	 *
+	 * @param int $stackPtr The position of the token.
+	 * @return int The scope pointer, or -1 for the file scope.
+	 */
+	private function get_scope_pointer( $stackPtr ) {
+		if ( empty( $this->tokens[ $stackPtr ]['conditions'] ) ) {
+			return -1;
+		}
+
+		$conditions = array_reverse( $this->tokens[ $stackPtr ]['conditions'], true );
+		foreach ( $conditions as $condition_ptr => $condition_code ) {
+			if ( in_array( $condition_code, array( T_FUNCTION, T_CLOSURE ), true ) ) {
+				return $condition_ptr;
+			}
+		}
+
+		return -1;
+	}
+
+	/**
+	 * Evaluates collected scopes and reports unpaired ob_start() calls.
+	 *
+	 * Called once when the end of the file is reached so that the full scope contents
+	 * are available for pairing.
+	 *
+	 * @since 1.4.0
+	 */
+	private function finalize_file() {
+		$this->finalized = true;
+
+		foreach ( $this->scope_order as $scope_ptr ) {
+			$scope = $this->scopes[ $scope_ptr ];
+			if ( empty( $scope['starts'] ) ) {
+				continue;
+			}
+
+			$unpaired = $this->pair_starts_and_closes( $scope['starts'], $scope['closes'] );
+
+			foreach ( $unpaired as $start ) {
+				if ( $this->is_hook_paired( $start['ptr'] ) ) {
+					continue;
+				}
+
+				$this->phpcsFile->addWarning(
+					'ob_start() was found without a corresponding closing call (ob_get_clean(), ob_end_clean(), ob_get_flush() or ob_end_flush()) in the same scope. Output buffering is a valid technique, but a buffer must not be left open. WordPress is a shared environment where core, themes and other plugins may also open or close buffers, and a misaligned buffer stack causes unpredictable behaviour (headers already sent, lost output, broken redirects, etc.). Please ensure every ob_start() is paired with a closing function within the same function scope, and that nothing (including hooks or early returns) can bypass that closing logic. If you need to modify the full response output, use the new template enhancement output buffer available since WordPress 6.9.',
+					$start['ptr'],
+					'UnclosedObStart'
+				);
+			}
+		}
+
+		// Reset state so the sniff can be reused across multiple files.
+		$this->scopes      = array();
+		$this->scope_order = array();
+		$this->finalized   = false;
+	}
+
+	/**
+	 * Pairs ob_start() calls with closing calls within the same scope.
+	 *
+	 * A closing call pairs with the most recent unpaired ob_start() that appears before
+	 * it in source order and that sits at the same nesting level (identical set of
+	 * enclosing conditions). This ensures a buffer that is only closed conditionally,
+	 * for example inside an if block that may not execute, is treated as unpaired and
+	 * flagged.
+	 *
+	 * ob_start() calls that remain after all closes have been consumed are returned as
+	 * unpaired.
+	 *
+	 * @since 1.4.0
+	 *
+	 * @param array<int, array{ptr: int, line: int, conditions: array}> $starts The ob_start() calls.
+	 * @param array<int, array{ptr: int, line: int, conditions: array}> $closes The closing calls.
+	 * @return array<int, array{ptr: int, line: int, conditions: array}> The unpaired ob_start() calls.
+	 */
+	private function pair_starts_and_closes( array $starts, array $closes ) {
+		$unpaired = $starts;
+
+		foreach ( $closes as $close ) {
+			for ( $i = ( count( $unpaired ) - 1 ); $i >= 0; $i-- ) {
+				$start = $unpaired[ $i ];
+
+				if ( $close['ptr'] <= $start['ptr'] ) {
+					continue;
+				}
+
+				// Only pair when both calls share the exact same nesting context, so a
+				// close inside a conditional block does not silently pair with a start
+				// at the enclosing level.
+				if ( $this->same_nesting( $start['conditions'], $close['conditions'] ) ) {
+					array_splice( $unpaired, $i, 1 );
+					break;
+				}
+			}
+		}
+
+		return $unpaired;
+	}
+
+	/**
+	 * Determines whether two condition sets represent the same nesting level.
+	 *
+	 * Compares the full set of enclosing condition pointers and their token codes, so
+	 * that two calls in different conditional branches (same depth, different blocks)
+	 * are not treated as nested identically.
+	 *
+	 * @since 1.4.0
+	 *
+	 * @param array $a The first set of conditions (token pointer => token code).
+	 * @param array $b The second set of conditions (token pointer => token code).
+	 * @return bool True when both calls sit at the same nesting level.
+	 */
+	private function same_nesting( array $a, array $b ) {
+		return $a === $b;
+	}
+
+	/**
+	 * Best-effort heuristic for hook-paired buffers that should not be flagged.
+	 *
+	 * Per issue #1314, an ob_start() that is intentionally closed via a hook callback
+	 * registered immediately next to it, in a way that is statically obvious, should
+	 * not be considered an issue. This checks whether the statement immediately
+	 * following the ob_start() is a call to add_action() or add_filter(), which is the
+	 * statically obvious signal that the buffer is managed by a hooked callback.
+	 *
+	 * This is intentionally conservative: it only suppresses the warning when the hook
+	 * registration directly follows the ob_start() call, to avoid masking genuinely
+	 * unclosed buffers. Resolving the registered callback and verifying it closes the
+	 * buffer is out of scope for static analysis.
+	 *
+	 * @since 1.4.0
+	 *
+	 * @param int $start_ptr The position of the ob_start() call.
+	 * @return bool True when the buffer appears to be closed via an adjacent hook callback.
+	 */
+	private function is_hook_paired( $start_ptr ) {
+		$next_statement = $this->phpcsFile->findEndOfStatement( $start_ptr );
+		if ( false === $next_statement ) {
+			return false;
+		}
+
+		$hook_ptr = $this->phpcsFile->findNext( Tokens::$emptyTokens, ( $next_statement + 1 ), null, true );
+		if ( false === $hook_ptr ) {
+			return false;
+		}
+
+		$name = $this->get_global_function_name( $hook_ptr );
+		if ( null === $name ) {
+			return false;
+		}
+
+		return in_array( strtolower( $name ), array( 'add_action', 'add_filter' ), true );
+	}
+}

--- a/phpcs-sniffs/PluginCheck/Sniffs/CodeAnalysis/UnclosedObStartSniff.php
+++ b/phpcs-sniffs/PluginCheck/Sniffs/CodeAnalysis/UnclosedObStartSniff.php
@@ -54,6 +54,18 @@ final class UnclosedObStartSniff extends Sniff {
 	private $scope_order = array();
 
 	/**
+	 * Cached last registered token pointer for the current file.
+	 *
+	 * Populated on the first maybe_finalize() call so subsequent calls can
+	 * avoid repeated findNext() scans over the full token stack.
+	 *
+	 * @since 2.1.0
+	 *
+	 * @var int|null
+	 */
+	private $last_registered_ptr = null;
+
+	/**
 	 * Whether the current file has been finalized (scopes evaluated).
 	 *
 	 * @since 2.1.0
@@ -123,8 +135,19 @@ final class UnclosedObStartSniff extends Sniff {
 			return;
 		}
 
-		$next = $this->phpcsFile->findNext( $this->register(), ( $stackPtr + 1 ) );
-		if ( false !== $next ) {
+		// Cache the last registered token pointer on first call to avoid
+		// scanning the entire token stack on every matching token visit.
+		if ( null === $this->last_registered_ptr ) {
+			$tokens                   = $this->register();
+			$this->last_registered_ptr = $this->phpcsFile->findNext( $tokens, 0 );
+			$next_ptr                 = $this->last_registered_ptr;
+			while ( false !== $next_ptr ) {
+				$this->last_registered_ptr = $next_ptr;
+				$next_ptr                  = $this->phpcsFile->findNext( $tokens, ( $next_ptr + 1 ) );
+			}
+		}
+
+		if ( $stackPtr < $this->last_registered_ptr ) {
 			return;
 		}
 
@@ -142,7 +165,7 @@ final class UnclosedObStartSniff extends Sniff {
 	 * @since 2.1.0
 	 *
 	 * @param int $stackPtr The position of the current token in the stack.
-	 * @return string|null The lowercased function name, or null when not a global call.
+	 * @return string|null The function name, or null when not a global call.
 	 */
 	private function get_global_function_name( $stackPtr ) {
 		$token_code = $this->tokens[ $stackPtr ]['code'];
@@ -293,7 +316,7 @@ final class UnclosedObStartSniff extends Sniff {
 				}
 
 				$this->phpcsFile->addWarning(
-					'ob_start() was found without a corresponding closing call (ob_get_clean(), ob_end_clean(), ob_get_flush() or ob_end_flush()) in the same scope. Output buffering is a valid technique, but a buffer must not be left open. WordPress is a shared environment where core, themes and other plugins may also open or close buffers, and a misaligned buffer stack causes unpredictable behaviour (headers already sent, lost output, broken redirects, etc.). Please ensure every ob_start() is paired with a closing function within the same function scope, and that nothing (including hooks or early returns) can bypass that closing logic. If you need to modify the full response output, use the new template enhancement output buffer available since WordPress 6.9.',
+					'ob_start() was found without a reliably-executed corresponding closing call (ob_get_clean(), ob_end_clean(), ob_get_flush() or ob_end_flush()) in the same scope. Output buffering is a valid technique, but a buffer must not be left open. WordPress is a shared environment where core, themes and other plugins may also open or close buffers, and a misaligned buffer stack causes unpredictable behaviour (headers already sent, lost output, broken redirects, etc.). Please ensure every ob_start() is paired with a closing function within the same function scope, and that nothing (including hooks or early returns) can bypass that closing logic. If you need to modify the full response output, use the new template enhancement output buffer available since WordPress 6.9.',
 					$start['ptr'],
 					'UnclosedObStart'
 				);
@@ -301,9 +324,10 @@ final class UnclosedObStartSniff extends Sniff {
 		}
 
 		// Reset state so the sniff can be reused across multiple files.
-		$this->scopes      = array();
-		$this->scope_order = array();
-		$this->finalized   = false;
+		$this->scopes              = array();
+		$this->scope_order         = array();
+		$this->last_registered_ptr = null;
+		$this->finalized           = false;
 	}
 
 	/**

--- a/phpcs-sniffs/PluginCheck/Sniffs/CodeAnalysis/UnclosedObStartSniff.php
+++ b/phpcs-sniffs/PluginCheck/Sniffs/CodeAnalysis/UnclosedObStartSniff.php
@@ -14,14 +14,14 @@ use WordPressCS\WordPress\Sniff;
  * Detects calls to ob_start() that are not paired with a corresponding buffer-closing
  * function within the same logical scope.
  *
- * @since 1.4.0
+ * @since 2.1.0
  */
 final class UnclosedObStartSniff extends Sniff {
 
 	/**
 	 * Buffer-closing functions that pair with ob_start().
 	 *
-	 * @since 1.4.0
+	 * @since 2.1.0
 	 *
 	 * @var array<string, true>
 	 */
@@ -38,7 +38,7 @@ final class UnclosedObStartSniff extends Sniff {
 	 * Populated during the token walk and evaluated once the file has been
 	 * fully processed.
 	 *
-	 * @since 1.4.0
+	 * @since 2.1.0
 	 *
 	 * @var array<int, array{starts: array<int, array{ptr: int, line: int, conditions: array}>, closes: array<int, array{ptr: int, line: int, conditions: array}>}>
 	 */
@@ -47,7 +47,7 @@ final class UnclosedObStartSniff extends Sniff {
 	/**
 	 * Ordered list of scope start pointers, used to process scopes in source order.
 	 *
-	 * @since 1.4.0
+	 * @since 2.1.0
 	 *
 	 * @var array<int, int>
 	 */
@@ -56,7 +56,7 @@ final class UnclosedObStartSniff extends Sniff {
 	/**
 	 * Whether the current file has been finalized (scopes evaluated).
 	 *
-	 * @since 1.4.0
+	 * @since 2.1.0
 	 *
 	 * @var bool
 	 */
@@ -65,7 +65,7 @@ final class UnclosedObStartSniff extends Sniff {
 	/**
 	 * Returns an array of tokens this test wants to listen for.
 	 *
-	 * @since 1.4.0
+	 * @since 2.1.0
 	 *
 	 * @return array<int>
 	 */
@@ -83,7 +83,7 @@ final class UnclosedObStartSniff extends Sniff {
 	/**
 	 * Processes this test, when one of its tokens is encountered.
 	 *
-	 * @since 1.4.0
+	 * @since 2.1.0
 	 *
 	 * @param int $stackPtr The position of the current token in the stack.
 	 * @return int|void Integer stack pointer to skip forward or void to continue normal file processing.
@@ -114,7 +114,7 @@ final class UnclosedObStartSniff extends Sniff {
 	 * soon as no further registered tokens remain ahead, ensuring all collected calls
 	 * are available before pairing.
 	 *
-	 * @since 1.4.0
+	 * @since 2.1.0
 	 *
 	 * @param int $stackPtr The position of the current token in the stack.
 	 */
@@ -139,7 +139,7 @@ final class UnclosedObStartSniff extends Sniff {
 	 * single T_NAME_FULLY_QUALIFIED token (PHP >= 8.0) so that \ob_start() in namespaced
 	 * code is detected consistently.
 	 *
-	 * @since 1.4.0
+	 * @since 2.1.0
 	 *
 	 * @param int $stackPtr The position of the current token in the stack.
 	 * @return string|null The lowercased function name, or null when not a global call.
@@ -205,7 +205,7 @@ final class UnclosedObStartSniff extends Sniff {
 	 * The file scope is represented by a pointer of -1. Function, method and closure
 	 * scopes use the pointer of their opening condition token.
 	 *
-	 * @since 1.4.0
+	 * @since 2.1.0
 	 *
 	 * @param int  $stackPtr The position of the call.
 	 * @param bool $is_start Whether this is an ob_start() (true) or a closing call (false).
@@ -245,7 +245,7 @@ final class UnclosedObStartSniff extends Sniff {
 	 * Returns the pointer of the nearest enclosing function, method or closure, or -1
 	 * for the file (top-level) scope.
 	 *
-	 * @since 1.4.0
+	 * @since 2.1.0
 	 *
 	 * @param int $stackPtr The position of the token.
 	 * @return int The scope pointer, or -1 for the file scope.
@@ -271,7 +271,7 @@ final class UnclosedObStartSniff extends Sniff {
 	 * Called once when the end of the file is reached so that the full scope contents
 	 * are available for pairing.
 	 *
-	 * @since 1.4.0
+	 * @since 2.1.0
 	 */
 	private function finalize_file() {
 		$this->finalized = true;
@@ -315,7 +315,7 @@ final class UnclosedObStartSniff extends Sniff {
 	 * ob_start() calls that remain after all closes have been consumed are returned as
 	 * unpaired.
 	 *
-	 * @since 1.4.0
+	 * @since 2.1.0
 	 *
 	 * @param array<int, array{ptr: int, line: int, conditions: array}> $starts The ob_start() calls.
 	 * @param array<int, array{ptr: int, line: int, conditions: array}> $closes The closing calls.
@@ -352,7 +352,7 @@ final class UnclosedObStartSniff extends Sniff {
 	 * that two calls in different conditional branches (same depth, different blocks)
 	 * are not treated as nested identically.
 	 *
-	 * @since 1.4.0
+	 * @since 2.1.0
 	 *
 	 * @param array $a The first set of conditions (token pointer => token code).
 	 * @param array $b The second set of conditions (token pointer => token code).
@@ -376,7 +376,7 @@ final class UnclosedObStartSniff extends Sniff {
 	 * unclosed buffers. Resolving the registered callback and verifying it closes the
 	 * buffer is out of scope for static analysis.
 	 *
-	 * @since 1.4.0
+	 * @since 2.1.0
 	 *
 	 * @param int $start_ptr The position of the ob_start() call.
 	 * @return bool True when the buffer appears to be closed via an adjacent hook callback.

--- a/phpcs-sniffs/PluginCheck/Sniffs/CodeAnalysis/UnclosedObStartSniff.php
+++ b/phpcs-sniffs/PluginCheck/Sniffs/CodeAnalysis/UnclosedObStartSniff.php
@@ -316,7 +316,7 @@ final class UnclosedObStartSniff extends Sniff {
 				}
 
 				$this->phpcsFile->addWarning(
-					'ob_start() was found without a reliably-executed corresponding closing call (ob_get_clean(), ob_end_clean(), ob_get_flush() or ob_end_flush()) in the same scope. Output buffering is a valid technique, but a buffer must not be left open. WordPress is a shared environment where core, themes and other plugins may also open or close buffers, and a misaligned buffer stack causes unpredictable behaviour (headers already sent, lost output, broken redirects, etc.). Please ensure every ob_start() is paired with a closing function within the same function scope, and that nothing (including hooks or early returns) can bypass that closing logic. If you need to modify the full response output, use the new template enhancement output buffer available since WordPress 6.9.',
+					'ob_start() has no corresponding closing call (ob_get_clean, ob_end_clean, ob_get_flush, or ob_end_flush) in the same scope. Pair every ob_start() with a closing function to prevent open buffer issues.',
 					$start['ptr'],
 					'UnclosedObStart'
 				);

--- a/phpcs-sniffs/PluginCheck/Tests/CodeAnalysis/UnclosedObStartUnitTest.inc
+++ b/phpcs-sniffs/PluginCheck/Tests/CodeAnalysis/UnclosedObStartUnitTest.inc
@@ -40,3 +40,9 @@ function hook_paired() {
 function hook_paired_callback() {
 	ob_end_clean();
 }
+
+// 8. Arrow function with unpaired ob_start() — T_FN must form its own scope.
+$arrow_unpaired = fn() => ob_start();
+
+// 9. Arrow function with paired ob_start()/ob_get_clean() — T_FN scope, no warning.
+$arrow_paired = static fn() => ob_start() && ob_get_clean();

--- a/phpcs-sniffs/PluginCheck/Tests/CodeAnalysis/UnclosedObStartUnitTest.inc
+++ b/phpcs-sniffs/PluginCheck/Tests/CodeAnalysis/UnclosedObStartUnitTest.inc
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Fixture for UnclosedObStartSniff.
+ *
+ * @package PluginCheck
+ */
+
+function paired_in_same_function() {
+	ob_start();
+	echo 'hello';
+	ob_end_clean();
+}
+
+ob_start();
+
+function multiple_ob_start() {
+	ob_start(); // Unpaired.
+	ob_start();
+	ob_end_clean();
+}
+
+$closure = function() {
+	ob_start();
+	echo 'hello';
+	ob_get_clean();
+};
+
+function conditional_close() {
+	ob_start();
+	if ( true ) {
+		ob_end_clean();
+	}
+}
+
+function hook_paired() {
+	ob_start();
+	add_action( 'template_redirect', 'hook_paired_callback' );
+}
+
+function hook_paired_callback() {
+	ob_end_clean();
+}

--- a/phpcs-sniffs/PluginCheck/Tests/CodeAnalysis/UnclosedObStartUnitTest.inc
+++ b/phpcs-sniffs/PluginCheck/Tests/CodeAnalysis/UnclosedObStartUnitTest.inc
@@ -19,7 +19,7 @@ function multiple_ob_start() {
 	ob_end_clean();
 }
 
-$closure = function() {
+$closure = static function() {
 	ob_start();
 	echo 'hello';
 	ob_get_clean();

--- a/phpcs-sniffs/PluginCheck/Tests/CodeAnalysis/UnclosedObStartUnitTest.php
+++ b/phpcs-sniffs/PluginCheck/Tests/CodeAnalysis/UnclosedObStartUnitTest.php
@@ -35,6 +35,7 @@ final class UnclosedObStartUnitTest extends AbstractSniffUnitTest {
 			14 => 1, // Case: ob_start() at file scope with no closing call.
 			17 => 1, // Case: multiple ob_start() in the same scope, only one closed.
 			29 => 1, // Case: ob_start() closed only conditionally via an if block.
+			45 => 1, // Case: arrow function (T_FN) with unpaired ob_start().
 		);
 	}
 

--- a/phpcs-sniffs/PluginCheck/Tests/CodeAnalysis/UnclosedObStartUnitTest.php
+++ b/phpcs-sniffs/PluginCheck/Tests/CodeAnalysis/UnclosedObStartUnitTest.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * Unit tests for UnclosedObStartSniff.
+ *
+ * @package PluginCheck
+ */
+
+namespace PluginCheckCS\PluginCheck\Tests\CodeAnalysis;
+
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PluginCheckCS\PluginCheck\Sniffs\CodeAnalysis\UnclosedObStartSniff;
+use PluginCheckCS\PluginCheck\Tests\AbstractSniffUnitTest;
+
+/**
+ * Unit tests for UnclosedObStartSniff.
+ */
+final class UnclosedObStartUnitTest extends AbstractSniffUnitTest {
+
+	/**
+	 * Returns the lines where errors should occur.
+	 *
+	 * @return array<int, int> Key is the line number and value is the number of expected errors.
+	 */
+	public function getErrorList() {
+		return array();
+	}
+
+	/**
+	 * Returns the lines where warnings should occur.
+	 *
+	 * @return array<int, int> Key is the line number and value is the number of expected warnings.
+	 */
+	public function getWarningList() {
+		return array(
+			14 => 1, // Case: ob_start() at file scope with no closing call.
+			17 => 1, // Case: multiple ob_start() in the same scope, only one closed.
+			29 => 1, // Case: ob_start() closed only conditionally via an if block.
+		);
+	}
+
+	/**
+	 * Returns the fully qualified class name (FQCN) of the sniff.
+	 *
+	 * @return string The fully qualified class name of the sniff.
+	 */
+	protected function get_sniff_fqcn() {
+		return UnclosedObStartSniff::class;
+	}
+
+	/**
+	 * Sets the parameters for the sniff.
+	 *
+	 * @throws \RuntimeException If unable to set the ruleset parameters required for the test.
+	 *
+	 * @param Sniff $sniff The sniff being tested.
+	 */
+	public function set_sniff_parameters( Sniff $sniff ) {
+	}
+}

--- a/phpcs-sniffs/PluginCheck/ruleset.xml
+++ b/phpcs-sniffs/PluginCheck/ruleset.xml
@@ -10,6 +10,7 @@
 	<rule ref="PluginCheck.CodeAnalysis.Offloading" />
 	<rule ref="PluginCheck.CodeAnalysis.RequiredFunctionParameters" />
 	<rule ref="PluginCheck.CodeAnalysis.SettingSanitization" />
+	<rule ref="PluginCheck.CodeAnalysis.UnclosedObStart" />
 	<rule ref="PluginCheck.CodeAnalysis.WriteFile" />
 	<rule ref="PluginCheck.Security.VerifyNonce" />
 	<rule ref="PluginCheck.Security.DirectDB" />

--- a/tests/phpunit/testdata/plugins/test-plugin-unclosed-ob-start/load.php
+++ b/tests/phpunit/testdata/plugins/test-plugin-unclosed-ob-start/load.php
@@ -34,3 +34,20 @@ function conditional_close() {
 		ob_end_clean();
 	}
 }
+
+// 6. Fully-qualified \ob_start() paired in the same function → no issue (PHP 8 FQN handling).
+function fqn_paired() {
+	\ob_start();
+	echo 'hello';
+	\ob_end_clean();
+}
+
+// 7. ob_start() closed via an immediately adjacent hook callback → no issue (statically obvious).
+function hook_paired() {
+	ob_start();
+	add_action( 'template_redirect', 'test_plugin_unclosed_ob_start_close' );
+}
+
+function test_plugin_unclosed_ob_start_close() {
+	ob_end_clean();
+}

--- a/tests/phpunit/testdata/plugins/test-plugin-unclosed-ob-start/load.php
+++ b/tests/phpunit/testdata/plugins/test-plugin-unclosed-ob-start/load.php
@@ -51,3 +51,9 @@ function hook_paired() {
 function test_plugin_unclosed_ob_start_close() {
 	ob_end_clean();
 }
+
+// 8. Arrow function (T_FN) with unpaired ob_start() → issue (T_FN must form its own scope).
+$arrow_unpaired = fn() => ob_start();
+
+// 9. Arrow function (T_FN) with paired ob_start()/ob_get_clean() → no issue.
+$arrow_paired = static fn() => ob_start() && ob_get_clean();

--- a/tests/phpunit/testdata/plugins/test-plugin-unclosed-ob-start/load.php
+++ b/tests/phpunit/testdata/plugins/test-plugin-unclosed-ob-start/load.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Plugin Name: Test Plugin Unclosed Ob Start
+ */
+
+// 1. Paired in the same function → no issue.
+function paired_in_same_function() {
+	ob_start();
+	echo 'hello';
+	ob_end_clean();
+}
+
+// 2. ob_start() at the top of the file with no closing call → issue.
+ob_start();
+
+// 3. Multiple ob_start() in the same scope, only one closed → issue on the unpaired one (line 18).
+function multiple_ob_start() {
+	ob_start(); // this one is unpaired
+	ob_start();
+	ob_end_clean();
+}
+
+// 4. ob_start() inside a closure, closed inside the same closure → no issue.
+$closure = function() {
+	ob_start();
+	echo 'hello';
+	ob_get_clean();
+};
+
+// 5. ob_start() inside a function, closed only conditionally (if) → flagged as warning (line 33).
+function conditional_close() {
+	ob_start();
+	if ( true ) {
+		ob_end_clean();
+	}
+}

--- a/tests/phpunit/testdata/plugins/test-plugin-unclosed-ob-start/load.php
+++ b/tests/phpunit/testdata/plugins/test-plugin-unclosed-ob-start/load.php
@@ -27,7 +27,7 @@ $closure = function() {
 	ob_get_clean();
 };
 
-// 5. ob_start() inside a function, closed only conditionally (if) → flagged as warning (line 33).
+// 5. ob_start() inside a function, closed only conditionally (if) → flagged as warning (line 32).
 function conditional_close() {
 	ob_start();
 	if ( true ) {

--- a/tests/phpunit/tests/Checker/Checks/Unclosed_Ob_Start_Check_Tests.php
+++ b/tests/phpunit/tests/Checker/Checks/Unclosed_Ob_Start_Check_Tests.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * Tests for the Unclosed_Ob_Start_Check class.
+ *
+ * @package plugin-check
+ */
+
+use WordPress\Plugin_Check\Checker\Check_Context;
+use WordPress\Plugin_Check\Checker\Check_Result;
+use WordPress\Plugin_Check\Checker\Checks\Performance\Unclosed_Ob_Start_Check;
+
+class Unclosed_Ob_Start_Check_Tests extends WP_UnitTestCase {
+
+	public function test_run() {
+		$check_context = new Check_Context( UNIT_TESTS_PLUGIN_DIR . 'test-plugin-unclosed-ob-start/load.php' );
+		$check_result  = new Check_Result( $check_context );
+
+		$check = new Unclosed_Ob_Start_Check();
+		$check->run( $check_result );
+
+		$warnings = $check_result->get_warnings();
+
+		$this->assertArrayHasKey( 'load.php', $warnings );
+		$this->assertCount( 3, $warnings['load.php'] );
+
+		// 14: ob_start() at the top of the file with no closing call.
+		$this->assertEquals( 'unclosed_ob_start', $warnings['load.php'][0][0][0]['code'] );
+		$this->assertEquals( 14, $warnings['load.php'][0][0][0]['line'] );
+		
+		// 18: Multiple ob_start() in the same scope, only one closed.
+		$this->assertEquals( 'unclosed_ob_start', $warnings['load.php'][1][0][0]['code'] );
+		$this->assertEquals( 18, $warnings['load.php'][1][0][0]['line'] );
+		
+		// 33: ob_start() inside a function, closed only conditionally (if).
+		$this->assertEquals( 'unclosed_ob_start', $warnings['load.php'][2][0][0]['code'] );
+		$this->assertEquals( 33, $warnings['load.php'][2][0][0]['line'] );
+	}
+}

--- a/tests/phpunit/tests/Checker/Checks/Unclosed_Ob_Start_Check_Tests.php
+++ b/tests/phpunit/tests/Checker/Checks/Unclosed_Ob_Start_Check_Tests.php
@@ -5,11 +5,22 @@
  * @package plugin-check
  */
 
+use WordPress\Plugin_Check\Checker\Check_Categories;
 use WordPress\Plugin_Check\Checker\Check_Context;
 use WordPress\Plugin_Check\Checker\Check_Result;
 use WordPress\Plugin_Check\Checker\Checks\Performance\Unclosed_Ob_Start_Check;
 
 class Unclosed_Ob_Start_Check_Tests extends WP_UnitTestCase {
+
+	public function test_get_categories() {
+		$check      = new Unclosed_Ob_Start_Check();
+		$categories = $check->get_categories();
+
+		$this->assertIsArray( $categories );
+		$this->assertContains( Check_Categories::CATEGORY_PERFORMANCE, $categories );
+		$this->assertContains( Check_Categories::CATEGORY_PLUGIN_REPO, $categories );
+		$this->assertCount( 2, $categories );
+	}
 
 	public function test_run_with_errors() {
 		$check         = new Unclosed_Ob_Start_Check();

--- a/tests/phpunit/tests/Checker/Checks/Unclosed_Ob_Start_Check_Tests.php
+++ b/tests/phpunit/tests/Checker/Checks/Unclosed_Ob_Start_Check_Tests.php
@@ -24,15 +24,18 @@ class Unclosed_Ob_Start_Check_Tests extends WP_UnitTestCase {
 		$this->assertCount( 3, $warnings['load.php'] );
 
 		// 14: ob_start() at the top of the file with no closing call.
-		$this->assertEquals( 'unclosed_ob_start', $warnings['load.php'][0][0][0]['code'] );
-		$this->assertEquals( 14, $warnings['load.php'][0][0][0]['line'] );
-		
+		$this->assertArrayHasKey( 14, $warnings['load.php'] );
+		$this->assertEquals( 'unclosed_ob_start', $warnings['load.php'][14][0][0]['code'] );
+		$this->assertEquals( 14, $warnings['load.php'][14][0][0]['line'] );
+
 		// 18: Multiple ob_start() in the same scope, only one closed.
-		$this->assertEquals( 'unclosed_ob_start', $warnings['load.php'][1][0][0]['code'] );
-		$this->assertEquals( 18, $warnings['load.php'][1][0][0]['line'] );
-		
-		// 33: ob_start() inside a function, closed only conditionally (if).
-		$this->assertEquals( 'unclosed_ob_start', $warnings['load.php'][2][0][0]['code'] );
-		$this->assertEquals( 33, $warnings['load.php'][2][0][0]['line'] );
+		$this->assertArrayHasKey( 18, $warnings['load.php'] );
+		$this->assertEquals( 'unclosed_ob_start', $warnings['load.php'][18][0][0]['code'] );
+		$this->assertEquals( 18, $warnings['load.php'][18][0][0]['line'] );
+
+		// 32: ob_start() inside a function, closed only conditionally (if).
+		$this->assertArrayHasKey( 32, $warnings['load.php'] );
+		$this->assertEquals( 'unclosed_ob_start', $warnings['load.php'][32][0][0]['code'] );
+		$this->assertEquals( 32, $warnings['load.php'][32][0][0]['line'] );
 	}
 }

--- a/tests/phpunit/tests/Checker/Checks/Unclosed_Ob_Start_Check_Tests.php
+++ b/tests/phpunit/tests/Checker/Checks/Unclosed_Ob_Start_Check_Tests.php
@@ -26,16 +26,13 @@ class Unclosed_Ob_Start_Check_Tests extends WP_UnitTestCase {
 		// 14: ob_start() at the top of the file with no closing call.
 		$this->assertArrayHasKey( 14, $warnings['load.php'] );
 		$this->assertEquals( 'unclosed_ob_start', $warnings['load.php'][14][0][0]['code'] );
-		$this->assertEquals( 14, $warnings['load.php'][14][0][0]['line'] );
 
 		// 18: Multiple ob_start() in the same scope, only one closed.
 		$this->assertArrayHasKey( 18, $warnings['load.php'] );
 		$this->assertEquals( 'unclosed_ob_start', $warnings['load.php'][18][0][0]['code'] );
-		$this->assertEquals( 18, $warnings['load.php'][18][0][0]['line'] );
 
 		// 32: ob_start() inside a function, closed only conditionally (if).
 		$this->assertArrayHasKey( 32, $warnings['load.php'] );
 		$this->assertEquals( 'unclosed_ob_start', $warnings['load.php'][32][0][0]['code'] );
-		$this->assertEquals( 32, $warnings['load.php'][32][0][0]['line'] );
 	}
 }

--- a/tests/phpunit/tests/Checker/Checks/Unclosed_Ob_Start_Check_Tests.php
+++ b/tests/phpunit/tests/Checker/Checks/Unclosed_Ob_Start_Check_Tests.php
@@ -11,28 +11,29 @@ use WordPress\Plugin_Check\Checker\Checks\Performance\Unclosed_Ob_Start_Check;
 
 class Unclosed_Ob_Start_Check_Tests extends WP_UnitTestCase {
 
-	public function test_run() {
+	public function test_run_with_errors() {
+		$check         = new Unclosed_Ob_Start_Check();
 		$check_context = new Check_Context( UNIT_TESTS_PLUGIN_DIR . 'test-plugin-unclosed-ob-start/load.php' );
 		$check_result  = new Check_Result( $check_context );
 
-		$check = new Unclosed_Ob_Start_Check();
 		$check->run( $check_result );
 
 		$warnings = $check_result->get_warnings();
 
+		$this->assertNotEmpty( $warnings );
 		$this->assertArrayHasKey( 'load.php', $warnings );
-		$this->assertCount( 3, $warnings['load.php'] );
+		$this->assertEquals( 3, $check_result->get_warning_count() );
 
 		// 14: ob_start() at the top of the file with no closing call.
 		$this->assertArrayHasKey( 14, $warnings['load.php'] );
-		$this->assertEquals( 'unclosed_ob_start', $warnings['load.php'][14][0][0]['code'] );
+		$this->assertEquals( 'PluginCheck.CodeAnalysis.UnclosedObStart.UnclosedObStart', $warnings['load.php'][14][1][0]['code'] );
 
 		// 18: Multiple ob_start() in the same scope, only one closed.
 		$this->assertArrayHasKey( 18, $warnings['load.php'] );
-		$this->assertEquals( 'unclosed_ob_start', $warnings['load.php'][18][0][0]['code'] );
+		$this->assertEquals( 'PluginCheck.CodeAnalysis.UnclosedObStart.UnclosedObStart', $warnings['load.php'][18][2][0]['code'] );
 
 		// 32: ob_start() inside a function, closed only conditionally (if).
 		$this->assertArrayHasKey( 32, $warnings['load.php'] );
-		$this->assertEquals( 'unclosed_ob_start', $warnings['load.php'][32][0][0]['code'] );
+		$this->assertEquals( 'PluginCheck.CodeAnalysis.UnclosedObStart.UnclosedObStart', $warnings['load.php'][32][2][0]['code'] );
 	}
 }

--- a/tests/phpunit/tests/Checker/Checks/Unclosed_Ob_Start_Check_Tests.php
+++ b/tests/phpunit/tests/Checker/Checks/Unclosed_Ob_Start_Check_Tests.php
@@ -33,18 +33,41 @@ class Unclosed_Ob_Start_Check_Tests extends WP_UnitTestCase {
 
 		$this->assertNotEmpty( $warnings );
 		$this->assertArrayHasKey( 'load.php', $warnings );
-		$this->assertEquals( 3, $check_result->get_warning_count() );
+		$this->assertEquals( 4, $check_result->get_warning_count() );
+
+		$expected_code = 'PluginCheck.CodeAnalysis.UnclosedObStart.UnclosedObStart';
 
 		// 14: ob_start() at the top of the file with no closing call.
 		$this->assertArrayHasKey( 14, $warnings['load.php'] );
-		$this->assertEquals( 'PluginCheck.CodeAnalysis.UnclosedObStart.UnclosedObStart', $warnings['load.php'][14][1][0]['code'] );
+		$this->assertWarningCodeOnLine( $warnings['load.php'][14], $expected_code );
 
 		// 18: Multiple ob_start() in the same scope, only one closed.
 		$this->assertArrayHasKey( 18, $warnings['load.php'] );
-		$this->assertEquals( 'PluginCheck.CodeAnalysis.UnclosedObStart.UnclosedObStart', $warnings['load.php'][18][2][0]['code'] );
+		$this->assertWarningCodeOnLine( $warnings['load.php'][18], $expected_code );
 
 		// 32: ob_start() inside a function, closed only conditionally (if).
 		$this->assertArrayHasKey( 32, $warnings['load.php'] );
-		$this->assertEquals( 'PluginCheck.CodeAnalysis.UnclosedObStart.UnclosedObStart', $warnings['load.php'][32][2][0]['code'] );
+		$this->assertWarningCodeOnLine( $warnings['load.php'][32], $expected_code );
+
+		// 56: Arrow function (T_FN) with unpaired ob_start().
+		$this->assertArrayHasKey( 56, $warnings['load.php'] );
+		$this->assertWarningCodeOnLine( $warnings['load.php'][56], $expected_code );
+	}
+
+	/**
+	 * Asserts that the line's first warning carries the expected error code.
+	 *
+	 * Avoids brittle direct access into deeply nested array offsets whose indices
+	 * shift when other warnings are added on the same line.
+	 *
+	 * @param array<int, array<int, array<string, mixed>>> $line_warnings Warnings recorded for a single source line, keyed by column.
+	 * @param string                                       $expected_code The expected error code.
+	 */
+	private function assertWarningCodeOnLine( $line_warnings, $expected_code ) {
+		$first_column = reset( $line_warnings );
+		$this->assertIsArray( $first_column );
+		$this->assertArrayHasKey( 0, $first_column );
+		$this->assertArrayHasKey( 'code', $first_column[0] );
+		$this->assertEquals( $expected_code, $first_column[0]['code'] );
 	}
 }


### PR DESCRIPTION
## What?

Closes #1314

Adds a new performance check to detect `ob_start()` calls that are not paired with a corresponding buffer-closing function within the same scope. Prevents unpredictable behaviour caused by misaligned output buffers in shared WordPress environments.

## Why?

Every `ob_start()` must be paired with a closing call (`ob_get_clean()`, `ob_end_clean()`, `ob_get_flush()`, or `ob_end_flush()`) in the same scope. Unclosed buffers break headers, lose output, and cause redirect issues in shared hosting. WordPress core, themes, and other plugins all share the buffer stack.

## How?

Implemented as a PHPCS sniff (`PluginCheck.CodeAnalysis.UnclosedObStart`) following @westonruter's suggestion:

- Extends `Abstract_PHP_CodeSniffer_Check` like other sniff-based checks
- Uses PHPCS `conditions` data for scope tracking instead of hand-rolled brace-depth
- Resolves fully-qualified `\ob_start()` calls (PHP 7.4 two-token form + PHP 8+ `T_NAME_FULLY_QUALIFIED`)
- Flags conditional closes (e.g. `ob_end_clean()` only inside an `if`) as warnings
- Conservative hook-paired heuristic: suppresses warning when `ob_start()` is immediately followed by `add_action()`/`add_filter()`
- Registered in `Default_Check_Repository` under both `CATEGORY_PERFORMANCE` and `CATEGORY_PLUGIN_REPO`

## Testing Instructions

1. Install the plugin from this branch
2. Run `wp plugin check <plugin-slug>` or use the Plugin Check admin UI
3. Verify the "unclosed_ob_start" check runs by default in the Plugin Directory view (CATEGORY_PLUGIN_REPO ensures it is selected automatically)
4. Test with a plugin that has an unpaired `ob_start()` — confirm a warning is reported on the exact line
5. Test with a plugin that has paired `ob_start()` / `ob_end_clean()` in the same function — confirm no warning
6. Test with `\ob_start()` in namespaced code — confirm detection works
7. Test the hook-paired case (`ob_start()` + `add_action()`) — confirm no warning

<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fwp-admin%2Ftools.php%3Fpage%3Dplugin-check%22%2C%22phpExtensionBundles%22%3A%5B%22kitchen-sink%22%5D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginZipFile%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fplugin-check%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-1318-ff7ff7227e2f7fee61c8447e99c50d71d6db2af8.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>

## AI Usage Disclosure

- [ ] This PR was created without the help of AI tools
- [x] This PR includes AI-assisted code or content

If AI tools were used, please describe how they were used:

- Claude Code assisted with PHPCS sniff architecture research (reviewing existing `AbstractFunctionParameterSniff` / `AbstractFunctionRestrictionsSniff` patterns in `phpcs-sniffs/PluginCheck/Sniffs/CodeAnalysis/`)
- Drafted the scope-tracking logic (function/closure walk via `$tokens[ $stackPtr ]['conditions']`)
- Generated the PHP 7.4 vs 8.0 fully-qualified name handling (`T_STRING` + `T_NS_SEPARATOR` vs `T_NAME_FULLY_QUALIFIED`)
- Generated the PHPUnit fixture scenarios (paired, multiple, closure, conditional, FQN, hook-paired)
- Drafted the PR body and testing instructions

## Screenshots or screencast 

|Before|After|
|-|-|
|CLI / no UI change|CLI / no UI change|

<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fwp-admin%2Ftools.php%3Fpage%3Dplugin-check%22%2C%22phpExtensionBundles%22%3A%5B%22kitchen-sink%22%5D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginZipFile%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fplugin-check%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-1318-d218081a2aee01f9e38f3dc3dde8196de91758b8.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fwp-admin%2Ftools.php%3Fpage%3Dplugin-check%22%2C%22phpExtensionBundles%22%3A%5B%22kitchen-sink%22%5D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginZipFile%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fplugin-check%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-1318-eb5a8e62ba5e67ff3973479196d7d78f62274922.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->
