### PR TITLE
Clarify ignore-codes CLI documentation

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -17,7 +17,11 @@ Runs plugin check.
 Applies after evaluating `--checks`.
 
 [--ignore-codes=<codes>]
-: Ignore error codes provided as an argument in comma-separated values.
+: Ignore result codes provided as an argument in comma-separated values, e.g. missing_composer_json_file.
+Result codes are individual findings emitted by checks. They are different from check slugs used with
+`--checks` and `--exclude-checks`.
+Use an output format such as `--format=json` or `--format=csv` to inspect result codes.
+For example: `wp plugin check akismet --format=csv --fields=code,message`.
 
 [--format=<format>]
 : Format to display the results. Options are table, csv, json, ctrf, strict-table, strict-csv, strict-json, and strict-ctrf. The default will be a table.
@@ -52,9 +56,13 @@ options:
 [--exclude-directories=<directories>]
 : Additional directories to exclude from checks.
 By default, `.git`, `vendor`, `vendor_prefixed`, `vendor-prefixed` and `node_modules` directories are excluded.
+This only excludes files from file-based scans. It does not suppress plugin-level findings such as
+missing_composer_json_file; use `--ignore-codes` for specific result codes.
 
 [--exclude-files=<files>]
 : Additional files to exclude from checks.
+This only excludes files from file-based scans. It does not suppress plugin-level findings such as
+missing_composer_json_file; use `--ignore-codes` for specific result codes.
 
 [--severity=<severity>]
 : Severity level.
@@ -87,6 +95,8 @@ options:
 ```
 wp plugin check akismet
 wp plugin check akismet --checks=late_escaping
+wp plugin check akismet --format=csv --fields=code,message
+wp plugin check akismet --ignore-codes=missing_composer_json_file
 wp plugin check akismet --format=json
 wp plugin check akismet --format=ctrf
 wp plugin check akismet --mode=update

--- a/includes/CLI/Plugin_Check_Command.php
+++ b/includes/CLI/Plugin_Check_Command.php
@@ -77,7 +77,11 @@ final class Plugin_Check_Command {
 	 * Applies after evaluating `--checks`.
 	 *
 	 * [--ignore-codes=<codes>]
-	 * : Ignore error codes provided as an argument in comma-separated values.
+	 * : Ignore result codes provided as an argument in comma-separated values, e.g. missing_composer_json_file.
+	 * Result codes are individual findings emitted by checks. They are different from check slugs used with
+	 * `--checks` and `--exclude-checks`.
+	 * Use an output format such as `--format=json` or `--format=csv` to inspect result codes.
+	 * For example: `wp plugin check akismet --format=csv --fields=code,message`.
 	 *
 	 * [--format=<format>]
 	 * : Format to display the results. Options are table, csv, json, ctrf, strict-table, strict-csv, strict-json, and strict-ctrf. The default will be a table.
@@ -112,9 +116,13 @@ final class Plugin_Check_Command {
 	 * [--exclude-directories=<directories>]
 	 * : Additional directories to exclude from checks.
 	 * By default, `.git`, `vendor`, `vendor_prefixed`, `vendor-prefixed` and `node_modules` directories are excluded.
+	 * This only excludes files from file-based scans. It does not suppress plugin-level findings such as
+	 * missing_composer_json_file; use `--ignore-codes` for specific result codes.
 	 *
 	 * [--exclude-files=<files>]
 	 * : Additional files to exclude from checks.
+	 * This only excludes files from file-based scans. It does not suppress plugin-level findings such as
+	 * missing_composer_json_file; use `--ignore-codes` for specific result codes.
 	 *
 	 * [--severity=<severity>]
 	 * : Severity level.
@@ -153,6 +161,8 @@ final class Plugin_Check_Command {
 	 *
 	 *   wp plugin check akismet
 	 *   wp plugin check akismet --checks=late_escaping
+	 *   wp plugin check akismet --format=csv --fields=code,message
+	 *   wp plugin check akismet --ignore-codes=missing_composer_json_file
 	 *   wp plugin check akismet --format=json
 	 *   wp plugin check akismet --mode=update
 	 *   wp plugin check akismet --ai


### PR DESCRIPTION
## Summary

Clarifies how `--ignore-codes` works in the WP-CLI documentation.

## Changes

- Explains that result codes are different from check slugs.
- Adds an example for discovering result codes with `--format=csv --fields=code,message`.
- Adds an example for ignoring `missing_composer_json_file`.
- Clarifies that `--exclude-files` and `--exclude-directories` only apply to file-based scans and do not suppress plugin-level findings.

Fixes #1152.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fwp-admin%2Ftools.php%3Fpage%3Dplugin-check%22%2C%22phpExtensionBundles%22%3A%5B%22kitchen-sink%22%5D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginZipFile%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fplugin-check%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-1332-1c3c46ef74a177d005f3dcacda3f89997ad1faee.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->