### PR TITLE
Clarify widget output escaping guidance

### DIFF
--- a/docs/checks.md
+++ b/docs/checks.md
@@ -37,3 +37,19 @@
 | enqueued_scripts_scope | performance | Checks whether any scripts are loaded on all pages, which is usually not desirable and can lead to performance issues. | [Learn more](https://developer.wordpress.org/plugins/) |
 | non_blocking_scripts | performance | Checks whether scripts and styles are enqueued using a recommended loading strategy. | [Learn more](https://developer.wordpress.org/plugins/) |
 | ai_provider | general | Recommends the WordPress AI Client when a plugin integrates directly with a third-party AI provider. | [Learn more](https://developer.wordpress.org/plugins/) |
+
+## Notes
+
+### Escaping widget wrapper output
+
+The `late_escaping` check expects all output to be escaped before it is sent to the browser. This also applies to widget display arguments such as `before_widget`, `after_widget`, `before_title`, and `after_title`.
+
+Classic widget examples often echo these values directly because themes provide the wrapper markup. When a plugin outputs them, use an escaping function that allows expected HTML, such as `wp_kses_post()`. Escape widget text according to the content it allows, such as `esc_html()` for plain text titles or `wp_kses_post()` for titles that intentionally allow limited markup:
+
+```php
+echo wp_kses_post( $args['before_widget'] );
+echo wp_kses_post( $args['before_title'] );
+echo esc_html( $title );
+echo wp_kses_post( $args['after_title'] );
+echo wp_kses_post( $args['after_widget'] );
+```

--- a/tests/phpunit/testdata/plugins/test-plugin-late-escaping-without-errors/load.php
+++ b/tests/phpunit/testdata/plugins/test-plugin-late-escaping-without-errors/load.php
@@ -20,3 +20,24 @@
  */
 
 esc_html_e( 'Hello World!', 'test-plugin-check' );
+
+/**
+ * Outputs widget markup with escaped wrapper arguments.
+ *
+ * @param array $args     Widget display arguments.
+ * @param array $instance Widget instance settings.
+ */
+function test_plugin_check_widget_output( $args, $instance ) {
+	$title = isset( $instance['title'] ) ? $instance['title'] : '';
+
+	echo wp_kses_post( $args['before_widget'] );
+
+	if ( '' !== $title ) {
+		echo wp_kses_post( $args['before_title'] );
+		echo esc_html( $title );
+		echo wp_kses_post( $args['after_title'] );
+	}
+
+	echo '<p>' . esc_html__( 'Widget content.', 'test-plugin-check' ) . '</p>';
+	echo wp_kses_post( $args['after_widget'] );
+}


### PR DESCRIPTION
## Summary
- Adds guidance for escaping classic widget wrapper arguments in the `late_escaping` check documentation.
- Recommends `wp_kses_post()` for wrapper HTML such as `before_widget`, `after_widget`, `before_title`, and `after_title`.
- Adds a fixture case showing the recommended widget output pattern passes the late escaping check.

## Testing
- `vendor/bin/phpcs --standard=WordPress --sniffs=WordPress.Security.EscapeOutput tests/phpunit/testdata/plugins/test-plugin-late-escaping-without-errors/load.php`
- `vendor/bin/phpcs --standard=phpcs.xml.dist tests/phpunit/testdata/plugins/test-plugin-late-escaping-without-errors/load.php`
- `npm run test-php -- --filter Late_Escaping_Check_Tests`
- `git diff --check`

Fixes #946

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fwp-admin%2Ftools.php%3Fpage%3Dplugin-check%22%2C%22phpExtensionBundles%22%3A%5B%22kitchen-sink%22%5D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginZipFile%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fplugin-check%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-1335-55d2a3c212dfa8328e9993a0f4947f7fc8b3861d.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->