### PR TITLE
Add AI Provider check to recommend the WordPress AI Client (#1341)

### DIFF
--- a/docs/checks.md
+++ b/docs/checks.md
@@ -36,3 +36,4 @@
 | enqueued_styles_scope | performance | Checks whether any stylesheets are loaded on all pages, which is usually not desirable and can lead to performance issues. | [Learn more](https://developer.wordpress.org/plugins/) |
 | enqueued_scripts_scope | performance | Checks whether any scripts are loaded on all pages, which is usually not desirable and can lead to performance issues. | [Learn more](https://developer.wordpress.org/plugins/) |
 | non_blocking_scripts | performance | Checks whether scripts and styles are enqueued using a recommended loading strategy. | [Learn more](https://developer.wordpress.org/plugins/) |
+| ai_provider | general | Recommends the WordPress AI Client when a plugin integrates directly with a third-party AI provider. | [Learn more](https://developer.wordpress.org/plugins/) |

--- a/includes/Checker/Checks/General/AI_Provider_Check.php
+++ b/includes/Checker/Checks/General/AI_Provider_Check.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * Class AI_Provider_Check.
+ *
+ * @package plugin-check
+ */
+
+namespace WordPress\Plugin_Check\Checker\Checks\General;
+
+use WordPress\Plugin_Check\Checker\Check_Categories;
+use WordPress\Plugin_Check\Checker\Check_Result;
+use WordPress\Plugin_Check\Checker\Checks\Abstract_PHP_CodeSniffer_Check;
+use WordPress\Plugin_Check\Traits\Amend_Check_Result;
+use WordPress\Plugin_Check\Traits\Stable_Check;
+
+/**
+ * Check to detect direct integrations with third-party AI providers.
+ *
+ * @since 2.1.0
+ */
+class AI_Provider_Check extends Abstract_PHP_CodeSniffer_Check {
+
+	use Amend_Check_Result;
+	use Stable_Check;
+
+	/**
+	 * Bitwise flags to control check behavior.
+	 *
+	 * @since 2.1.0
+	 * @var int
+	 */
+	protected $flags = 0;
+
+	/**
+	 * Gets the categories for the check.
+	 *
+	 * Every check must have at least one category.
+	 *
+	 * @since 2.1.0
+	 *
+	 * @return array The categories for the check.
+	 */
+	public function get_categories() {
+		return array( Check_Categories::CATEGORY_GENERAL );
+	}
+
+	/**
+	 * Returns an associative array of arguments to pass to PHPCS.
+	 *
+	 * @since 2.1.0
+	 *
+	 * @param Check_Result $result The check result to amend, including the plugin context to check.
+	 * @return array An associative array of PHPCS CLI arguments.
+	 */
+	protected function get_args( Check_Result $result ) {
+		return array(
+			'extensions' => 'php',
+			'standard'   => 'PluginCheck',
+			'sniffs'     => 'PluginCheck.CodeAnalysis.AIProvider',
+		);
+	}
+
+	/**
+	 * Gets the description for the check.
+	 *
+	 * Every check must have a short description explaining what the check does.
+	 *
+	 * @since 2.1.0
+	 *
+	 * @return string Description.
+	 */
+	public function get_description(): string {
+		return __( 'Recommends the WordPress AI Client when a plugin integrates directly with a third-party AI provider.', 'plugin-check' );
+	}
+
+	/**
+	 * Gets the documentation URL for the check.
+	 *
+	 * Every check must have a URL with further information about the check.
+	 *
+	 * @since 2.1.0
+	 *
+	 * @return string The documentation URL.
+	 */
+	public function get_documentation_url(): string {
+		return __( 'https://developer.wordpress.org/plugins/', 'plugin-check' );
+	}
+}

--- a/includes/Checker/Default_Check_Repository.php
+++ b/includes/Checker/Default_Check_Repository.php
@@ -104,6 +104,7 @@ class Default_Check_Repository extends Empty_Check_Repository {
 				'direct_file_access'         => new Checks\Plugin_Repo\Direct_File_Access_Check(),
 				'external_admin_menu_links'  => new Checks\Plugin_Repo\External_Admin_Menu_Links_Check(),
 				'wp_functions_compatibility' => new Checks\Plugin_Repo\WP_Functions_Compatibility_Check(),
+				'ai_provider'                => new Checks\General\AI_Provider_Check(),
 			)
 		);
 

--- a/phpcs-sniffs/PluginCheck/Sniffs/CodeAnalysis/AIProviderSniff.php
+++ b/phpcs-sniffs/PluginCheck/Sniffs/CodeAnalysis/AIProviderSniff.php
@@ -1,0 +1,116 @@
+<?php
+/**
+ * AIProviderSniff
+ *
+ * @package PluginCheck
+ */
+
+namespace PluginCheckCS\PluginCheck\Sniffs\CodeAnalysis;
+
+use PHPCSUtils\Utils\TextStrings;
+use WordPressCS\WordPress\Sniff;
+
+/**
+ * Detects direct integrations with third-party AI providers.
+ *
+ * Since WordPress 7.0, plugins are encouraged to use the WordPress AI Client
+ * and Connectors infrastructure (`wp_ai_client_prompt()`) instead of calling
+ * provider APIs directly, so the site owner can configure their preferred
+ * provider once and plugins can avoid managing provider credentials.
+ *
+ * @link https://make.wordpress.org/core/2025/01/15/ai-building-blocks/
+ *
+ * @since 2.1.0
+ */
+final class AIProviderSniff extends Sniff {
+
+	/**
+	 * List of known third-party AI provider API hosts to detect.
+	 *
+	 * Only full API hostnames are listed to keep matching precise and avoid
+	 * flagging unrelated usage of a provider's marketing or documentation site.
+	 *
+	 * @since 2.1.0
+	 *
+	 * @var array<string>
+	 */
+	protected $ai_provider_hosts = array(
+		'api.openai.com',
+		'api.anthropic.com',
+		'generativelanguage.googleapis.com',
+		'api.x.ai',
+		'api.mistral.ai',
+		'api.cohere.ai',
+		'api.cohere.com',
+		'api.groq.com',
+		'api.perplexity.ai',
+		'api.deepseek.com',
+		'openrouter.ai',
+	);
+
+	/**
+	 * Compiled regex pattern for detecting AI provider hosts.
+	 *
+	 * @since 2.1.0
+	 *
+	 * @var string|null
+	 */
+	private $pattern = null;
+
+	/**
+	 * Returns an array of tokens this test wants to listen for.
+	 *
+	 * Only string literals are inspected; mentions inside comments or docblocks
+	 * are intentionally ignored, as they do not represent a direct integration.
+	 *
+	 * @since 2.1.0
+	 *
+	 * @return array<int|string>
+	 */
+	public function register() {
+		return array(
+			T_CONSTANT_ENCAPSED_STRING,
+			T_DOUBLE_QUOTED_STRING,
+			T_HEREDOC,
+			T_NOWDOC,
+		);
+	}
+
+	/**
+	 * Processes this test, when one of its tokens is encountered.
+	 *
+	 * @since 2.1.0
+	 *
+	 * @param int $stackPtr The position of the current token in the stack.
+	 * @return void
+	 */
+	public function process_token( $stackPtr ) {
+		$content    = $this->tokens[ $stackPtr ]['content'];
+		$token_code = $this->tokens[ $stackPtr ]['code'];
+
+		// Heredoc/nowdoc bodies are used as-is; quoted strings have their quotes removed.
+		if ( T_HEREDOC === $token_code || T_NOWDOC === $token_code ) {
+			$string_content = $content;
+		} else {
+			$string_content = TextStrings::stripQuotes( $content );
+		}
+
+		// Compile the regex pattern on first use.
+		if ( null === $this->pattern ) {
+			$escaped_hosts = array_map(
+				'preg_quote',
+				$this->ai_provider_hosts,
+				array_fill( 0, count( $this->ai_provider_hosts ), '/' )
+			);
+
+			// Require an explicit scheme directly before the host to avoid matching
+			// unrelated text and to target actual request URLs.
+			$this->pattern = '/https?:\/\/(' . implode( '|', $escaped_hosts ) . ')\b/i';
+		}
+
+		if ( preg_match( $this->pattern, $string_content, $matches ) ) {
+			$error = 'Direct integration with a third-party AI provider (%s) detected. Consider the WordPress AI Client (wp_ai_client_prompt()) introduced in WordPress 7.0.';
+			$this->phpcsFile->addWarning( $error, $stackPtr, 'DirectIntegration', array( $matches[1] ) );
+		}
+	}
+}

--- a/phpcs-sniffs/PluginCheck/Tests/CodeAnalysis/AIProviderUnitTest.inc
+++ b/phpcs-sniffs/PluginCheck/Tests/CodeAnalysis/AIProviderUnitTest.inc
@@ -1,0 +1,75 @@
+<?php
+
+/* testOpenAiInSingleQuotedString */
+$response = wp_remote_post( 'https://api.openai.com/v1/chat/completions', $args );
+
+/* testAnthropicInSingleQuotedString */
+$response = wp_remote_post( 'https://api.anthropic.com/v1/messages', $args );
+
+/* testGeminiInDoubleQuotedString */
+$endpoint = "https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:generateContent";
+
+/* testGrokInSingleQuotedString */
+$endpoint = 'https://api.x.ai/v1/chat/completions';
+
+/* testMistralInSingleQuotedString */
+$endpoint = 'https://api.mistral.ai/v1/chat/completions';
+
+/* testCohereAiInSingleQuotedString */
+$endpoint = 'https://api.cohere.ai/v1/generate';
+
+/* testCohereComInSingleQuotedString */
+$endpoint = 'https://api.cohere.com/v2/chat';
+
+/* testGroqInSingleQuotedString */
+$endpoint = 'https://api.groq.com/openai/v1/chat/completions';
+
+/* testPerplexityInSingleQuotedString */
+$endpoint = 'https://api.perplexity.ai/chat/completions';
+
+/* testDeepSeekInSingleQuotedString */
+$endpoint = 'https://api.deepseek.com/chat/completions';
+
+/* testOpenRouterInSingleQuotedString */
+$endpoint = 'https://openrouter.ai/api/v1/chat/completions';
+
+/* testHttpSchemeIsMatched */
+$endpoint = 'http://api.openai.com/v1/models';
+
+/* testProviderInHeredoc */
+$body = <<<EOD
+POST https://api.openai.com/v1/embeddings
+EOD;
+
+/* testProviderInNowdoc */
+$body = <<<'NOWDOC'
+See https://api.anthropic.com/v1/messages
+NOWDOC;
+
+/*
+ * Negative cases below: these must NOT be flagged.
+ */
+
+/* testProviderMentionedInComment */
+// We deliberately avoid https://api.openai.com and use the WordPress AI Client instead.
+
+/* testProviderInDocComment */
+/**
+ * Historically this called https://api.anthropic.com directly.
+ *
+ * @link https://api.x.ai
+ */
+function legacy_notes() {
+}
+
+/* testBareHostWithoutSchemeNotMatched */
+$host = 'api.openai.com';
+
+/* testUnrelatedGoogleApiNotMatched */
+$endpoint = 'https://www.googleapis.com/oauth2/v3/userinfo';
+
+/* testUnrelatedUrlNotMatched */
+$endpoint = 'https://example.com/v1/chat/completions';
+
+/* testWordPressAiClientUsageNotMatched */
+$text = wp_ai_client_prompt( 'Summarize this post.' )->generate_text();

--- a/phpcs-sniffs/PluginCheck/Tests/CodeAnalysis/AIProviderUnitTest.php
+++ b/phpcs-sniffs/PluginCheck/Tests/CodeAnalysis/AIProviderUnitTest.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * Unit tests for AIProviderSniff.
+ *
+ * @package PluginCheck
+ */
+
+namespace PluginCheckCS\PluginCheck\Tests\CodeAnalysis;
+
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PluginCheckCS\PluginCheck\Sniffs\CodeAnalysis\AIProviderSniff;
+use PluginCheckCS\PluginCheck\Tests\AbstractSniffUnitTest;
+
+/**
+ * Unit tests for AIProviderSniff.
+ */
+final class AIProviderUnitTest extends AbstractSniffUnitTest {
+
+	/**
+	 * Returns the lines where errors should occur.
+	 *
+	 * @return array<int, int> Key is the line number and value is the number of expected errors.
+	 */
+	public function getErrorList() {
+		return array();
+	}
+
+	/**
+	 * Returns the lines where warnings should occur.
+	 *
+	 * @return array<int, int> Key is the line number and value is the number of expected warnings.
+	 */
+	public function getWarningList() {
+		return array(
+			4  => 1, // Case: testOpenAiInSingleQuotedString.
+			7  => 1, // Case: testAnthropicInSingleQuotedString.
+			10 => 1, // Case: testGeminiInDoubleQuotedString.
+			13 => 1, // Case: testGrokInSingleQuotedString.
+			16 => 1, // Case: testMistralInSingleQuotedString.
+			19 => 1, // Case: testCohereAiInSingleQuotedString.
+			22 => 1, // Case: testCohereComInSingleQuotedString.
+			25 => 1, // Case: testGroqInSingleQuotedString.
+			28 => 1, // Case: testPerplexityInSingleQuotedString.
+			31 => 1, // Case: testDeepSeekInSingleQuotedString.
+			34 => 1, // Case: testOpenRouterInSingleQuotedString.
+			37 => 1, // Case: testHttpSchemeIsMatched.
+			41 => 1, // Case: testProviderInHeredoc.
+			46 => 1, // Case: testProviderInNowdoc.
+		);
+	}
+
+	/**
+	 * Returns the fully qualified class name (FQCN) of the sniff.
+	 *
+	 * @return string The fully qualified class name of the sniff.
+	 */
+	protected function get_sniff_fqcn() {
+		return AIProviderSniff::class;
+	}
+
+	/**
+	 * Sets the parameters for the sniff.
+	 *
+	 * @throws \RuntimeException If unable to set the ruleset parameters required for the test.
+	 *
+	 * @param Sniff $sniff The sniff being tested.
+	 */
+	public function set_sniff_parameters( Sniff $sniff ) {
+	}
+}

--- a/phpcs-sniffs/PluginCheck/ruleset.xml
+++ b/phpcs-sniffs/PluginCheck/ruleset.xml
@@ -3,6 +3,7 @@
 
 	<description>Plugin Check Sniffs</description>
 
+	<rule ref="PluginCheck.CodeAnalysis.AIProvider" />
 	<rule ref="PluginCheck.CodeAnalysis.DiscouragedFunctions" />
 	<rule ref="PluginCheck.CodeAnalysis.EnqueuedResourceOffloading" />
 	<rule ref="PluginCheck.CodeAnalysis.Heredoc" />

--- a/tests/phpunit/testdata/plugins/test-plugin-ai-provider-check-with-errors/load.php
+++ b/tests/phpunit/testdata/plugins/test-plugin-ai-provider-check-with-errors/load.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Plugin Name: Test Plugin AI Provider Errors
+ * Plugin URI: https://github.com/WordPress/plugin-check
+ * Description: Test plugin for the AI Provider check.
+ * Requires at least: 6.0
+ * Requires PHP: 5.6
+ * Version: 1.0.0
+ * Author: WordPress Performance Team
+ * Author URI: https://make.wordpress.org/performance/
+ * License: GPLv2 or later
+ * License URI: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+ * Text Domain: test-plugin-ai-provider-check-with-errors
+ *
+ * @package test-plugin-ai-provider-check-with-errors
+ */
+
+// Direct integration with a third-party AI provider (should be flagged).
+$response = wp_remote_post(
+	'https://api.openai.com/v1/chat/completions',
+	array(
+		'headers' => array( 'Content-Type' => 'application/json' ),
+		'body'    => '{}',
+	)
+);
+
+// Another provider host in a double-quoted string (should be flagged).
+$endpoint = "https://api.anthropic.com/v1/messages";
+
+// A bare host without scheme and an unrelated URL (should NOT be flagged).
+$host    = 'api.openai.com';
+$unrelated = 'https://example.com/v1/chat/completions';

--- a/tests/phpunit/tests/Checker/Checks/AI_Provider_Check_Test.php
+++ b/tests/phpunit/tests/Checker/Checks/AI_Provider_Check_Test.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Tests for the AI_Provider_Check class.
+ *
+ * @package plugin-check
+ */
+
+namespace phpunit\tests\Checker\Checks;
+
+use WordPress\Plugin_Check\Checker\Check_Context;
+use WordPress\Plugin_Check\Checker\Check_Result;
+use WordPress\Plugin_Check\Checker\Checks\General\AI_Provider_Check;
+use WP_UnitTestCase;
+
+class AI_Provider_Check_Test extends WP_UnitTestCase {
+
+	public function test_run_with_warnings() {
+		$check         = new AI_Provider_Check();
+		$check_context = new Check_Context( UNIT_TESTS_PLUGIN_DIR . 'test-plugin-ai-provider-check-with-errors/load.php' );
+		$check_result  = new Check_Result( $check_context );
+
+		$check->run( $check_result );
+
+		$warnings = $check_result->get_warnings();
+		$errors   = $check_result->get_errors();
+
+		$this->assertEmpty( $errors );
+		$this->assertNotEmpty( $warnings );
+		$this->assertArrayHasKey( 'load.php', $warnings );
+
+		// Only the two actual provider integrations should be flagged.
+		$this->assertSame( 2, $check_result->get_warning_count() );
+		$this->assertArrayHasKey( 20, $warnings['load.php'] );
+		$this->assertArrayHasKey( 28, $warnings['load.php'] );
+
+		$column = key( $warnings['load.php'][20] );
+		$this->assertSame(
+			'PluginCheck.CodeAnalysis.AIProvider.DirectIntegration',
+			$warnings['load.php'][20][ $column ][0]['code']
+		);
+	}
+}


### PR DESCRIPTION
## What?
Closes #1341

Adds a new static check (`ai_provider`) that warns when a plugin integrates directly with a third-party AI provider API instead of using the WordPress AI Client and Connectors infrastructure introduced in WordPress 7.0.

## Why?
WordPress 7.0 provides a standard abstraction (`wp_ai_client_prompt()`) so site owners can configure an AI provider once and plugins can send prompts through whichever compatible provider is configured, without duplicating provider setup screens, API key fields, or credential storage. Direct provider integrations are not invalid, but the check helps authors discover and adopt the recommended path. As requested in the issue, this is a recommendation (warning), not a hard failure.

## How?
- New tokenized PHPCS sniff `PluginCheck.CodeAnalysis.AIProvider` that inspects only string-literal tokens and requires an explicit `http(s)` scheme before a known provider host. This means mentions inside comments/docblocks, bare hostnames without a scheme, and unrelated URLs are intentionally not flagged, keeping false positives low.
- Known hosts covered: `api.openai.com`, `api.anthropic.com`, `generativelanguage.googleapis.com`, `api.x.ai`, `api.mistral.ai`, `api.cohere.ai`, `api.cohere.com`, `api.groq.com`, `api.perplexity.ai`, `api.deepseek.com`, `openrouter.ai`.
- New `AI_Provider_Check` (`Abstract_PHP_CodeSniffer_Check`) registered under the `general` category in `Default_Check_Repository`, mirroring `Offloading_Files_Check`.
- The sniff emits a `warning` (`DirectIntegration`), not an error.
- Docs: added an entry to `docs/checks.md`.

A note on category: per the AGENTS.md definitions (`CATEGORY_PLUGIN_REPO` = directory requirements, `CATEGORY_GENERAL` = best practices), this recommendation is placed under `general`. Happy to move it if maintainers prefer `plugin_repo`.

## Testing Instructions
1. `cd phpcs-sniffs && composer install`
2. Run the sniff unit tests: `composer run-tests` (or filter: `vendor/bin/phpunit --filter AIProvider ./vendor/squizlabs/php_codesniffer/tests/AllTests.php --no-coverage`).
3. Quick manual check against the bundled fixture:
   `vendor/bin/phpcs --standard=PluginCheck --sniffs=PluginCheck.CodeAnalysis.AIProvider tests/phpunit/testdata/plugins/test-plugin-ai-provider-check-with-errors/load.php`
   Expected: warnings on the two real integration lines only; the bare host and unrelated URL are not flagged.
4. Via WP-CLI on a plugin containing `wp_remote_post( 'https://api.openai.com/v1/chat/completions', ... )`:
   `wp plugin check <slug> --checks=ai_provider`

## AI Usage Disclosure

- [ ] This PR was created without the help of AI tools
- [x] This PR includes AI-assisted code or content

If AI tools were used, please describe how they were used:
Implemented with the assistance of Claude Code (Anthropic). The author reviewed and verified all changes, including running the sniff unit tests and PHPCS linting locally.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fwp-admin%2Ftools.php%3Fpage%3Dplugin-check%22%2C%22phpExtensionBundles%22%3A%5B%22kitchen-sink%22%5D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginZipFile%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fplugin-check%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-1343-9f16af8c7d4c7ecec36e5e3bd33de5f045152a09.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->