### PR TITLE
feat(checks): add Collapse All and Expand All controls to results page

### DIFF
--- a/.github/workflows/behat-test.yml
+++ b/.github/workflows/behat-test.yml
@@ -153,6 +153,12 @@ jobs:
           echo "Coverage files: $FILES"
           echo "files=$FILES" >> $GITHUB_OUTPUT
 
+      - name: Import Codecov GPG key
+        if: ${{ matrix.coverage }}
+        run: |
+          gpg --keyserver keyserver.ubuntu.com --recv-keys 27034E7FDB850E0BBC2C62FF806BB28AED779869 2>/dev/null || \
+          curl -fsSL https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --import --no-default-keyring --keyring trustedkeys.gpg 2>/dev/null || true
+
       - name: Upload code coverage report
         if: ${{ matrix.coverage }}
         uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354

--- a/.github/workflows/php-test.yml
+++ b/.github/workflows/php-test.yml
@@ -108,6 +108,12 @@ jobs:
             npm run test-php-multisite
           fi
 
+      - name: Import Codecov GPG key
+        if: ${{ matrix.coverage }}
+        run: |
+          gpg --keyserver keyserver.ubuntu.com --recv-keys 27034E7FDB850E0BBC2C62FF806BB28AED779869 2>/dev/null || \
+          curl -fsSL https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --import --no-default-keyring --keyring trustedkeys.gpg 2>/dev/null || true
+
       - name: Upload code coverage report
         if: ${{ matrix.coverage }}
         uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354

--- a/.github/workflows/php-test.yml
+++ b/.github/workflows/php-test.yml
@@ -92,11 +92,20 @@ jobs:
 
       - name: Start WordPress
         run: |
-          if [[ ${{ matrix.coverage == true }} == true ]]; then
-            npm run wp-env:start:tests -- --xdebug=coverage
-          else
-            npm run wp-env:start:tests
-          fi
+          set +e
+          for i in 1 2 3; do
+            if [[ ${{ matrix.coverage == true }} == true ]]; then
+              npm run wp-env:start:tests -- --xdebug=coverage
+            else
+              npm run wp-env:start:tests
+            fi
+            if [ $? -eq 0 ]; then
+              exit 0
+            fi
+            echo "wp-env start failed (attempt $i), retrying in 30s..."
+            sleep 30
+          done
+          exit 1
 
       - name: Run tests
         run: |

--- a/.github/workflows/php-test.yml
+++ b/.github/workflows/php-test.yml
@@ -93,7 +93,7 @@ jobs:
       - name: Start WordPress
         run: |
           set +e
-          for i in 1 2 3; do
+          for i in 1 2 3 4 5; do
             if [[ ${{ matrix.coverage == true }} == true ]]; then
               npm run wp-env:start:tests -- --xdebug=coverage
             else
@@ -102,8 +102,8 @@ jobs:
             if [ $? -eq 0 ]; then
               exit 0
             fi
-            echo "wp-env start failed (attempt $i), retrying in 30s..."
-            sleep 30
+            echo "wp-env start failed (attempt $i), retrying in 60s..."
+            sleep 60
           done
           exit 1
 

--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,4 @@ temp/
 
 .wp-env.override.json
 .wp-env.tests.override.json
+/build-temp

--- a/.gitignore
+++ b/.gitignore
@@ -65,4 +65,3 @@ temp/
 
 .wp-env.override.json
 .wp-env.tests.override.json
-/build-temp

--- a/assets/css/plugin-check-admin.css
+++ b/assets/css/plugin-check-admin.css
@@ -182,6 +182,34 @@
 	line-height: 1;
 }
 
+.plugin-check__file-section-counts {
+	display: inline-flex;
+	align-items: center;
+	gap: 6px;
+	margin-left: 6px;
+}
+
+.plugin-check__file-section-count {
+	display: inline-block;
+	padding: 1px 8px;
+	border-radius: 10px;
+	font-size: 12px;
+	font-weight: 500;
+	line-height: 1.4;
+}
+
+.plugin-check__file-section-count--error {
+	background: #fcf0f1;
+	color: #8b1a1a;
+	border: 1px solid #d63638;
+}
+
+.plugin-check__file-section-count--warning {
+	background: #fcf9e8;
+	color: #6b5b00;
+	border: 1px solid #dba617;
+}
+
 .plugin-check__file-section-header[aria-expanded="true"] .plugin-check__file-section-chevron {
 	transform: rotate(180deg);
 }

--- a/assets/css/plugin-check-admin.css
+++ b/assets/css/plugin-check-admin.css
@@ -126,6 +126,74 @@
 	cursor: pointer;
 }
 
+.plugin-check__collapse-expand-controls {
+	margin: 16px 0;
+	display: flex;
+	gap: 8px;
+	flex-wrap: wrap;
+}
+
+.plugin-check__collapse-expand-controls.is-hidden {
+	display: none;
+}
+
+.plugin-check__file-section {
+	margin: 1em 0;
+	border: 1px solid #dcdcde;
+	background: #fff;
+}
+
+.plugin-check__file-section-header {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	width: 100%;
+	padding: 8px 12px;
+	font-weight: 600;
+	cursor: pointer;
+	user-select: none;
+	background: transparent;
+	border: 0;
+	text-align: left;
+	color: inherit;
+	font-size: inherit;
+}
+
+.plugin-check__file-section-header:focus {
+	outline: 2px solid #2271b1;
+	outline-offset: -2px;
+}
+
+.plugin-check__file-section-chevron {
+	transition: transform 0.15s ease-in-out;
+	font-size: 18px;
+	line-height: 1;
+}
+
+.plugin-check__file-section-title {
+	color: var(--wp-admin-theme-color);
+	display: inline-flex;
+	align-items: center;
+	gap: 6px;
+}
+
+.plugin-check__file-section-icon {
+	font-size: 18px;
+	line-height: 1;
+}
+
+.plugin-check__file-section-header[aria-expanded="true"] .plugin-check__file-section-chevron {
+	transform: rotate(180deg);
+}
+
+.plugin-check__file-section-content {
+	padding: 0 14px 14px;
+}
+
+.plugin-check__file-section--collapsed .plugin-check__file-section-content {
+	display: none;
+}
+
 .plugin-check__false-positive-results {
 	padding: 0 14px 14px;
 }

--- a/assets/js/plugin-check-admin.js
+++ b/assets/js/plugin-check-admin.js
@@ -4,6 +4,9 @@
 	const exportContainer = document.getElementById(
 		'plugin-check__export-controls'
 	);
+	const collapseExpandContainer = document.getElementById(
+		'plugin-check__collapse-expand-controls'
+	);
 	const spinner = document.getElementById( 'plugin-check__spinner' );
 	const pluginsList = document.getElementById(
 		'plugin-check__plugins-dropdown'
@@ -20,6 +23,7 @@
 		! pluginsList ||
 		! resultsContainer ||
 		! exportContainer ||
+		! collapseExpandContainer ||
 		! spinner ||
 		! categoriesList.length ||
 		! typesList.length
@@ -33,6 +37,7 @@
 	let checksCompleted = false;
 	exportContainer.classList.add( 'is-hidden' );
 	exportContainer.addEventListener( 'click', onExportContainerClick );
+	collapseExpandContainer.classList.add( 'is-hidden' );
 
 	const includeExperimental = document.getElementById(
 		'plugin-check__include-experimental'
@@ -122,6 +127,7 @@
 		resultsContainer.innerText = '';
 		exportContainer.innerHTML = '';
 		exportContainer.classList.add( 'is-hidden' );
+		collapseExpandContainer.classList.add( 'is-hidden' );
 		resetAggregatedResults();
 		checksCompleted = false;
 	}
@@ -424,10 +430,12 @@
 		exportContainer.innerHTML = '';
 		if ( ! checksCompleted ) {
 			exportContainer.classList.add( 'is-hidden' );
+			collapseExpandContainer.classList.add( 'is-hidden' );
 			return;
 		}
 
 		exportContainer.classList.remove( 'is-hidden' );
+		collapseExpandContainer.classList.remove( 'is-hidden' );
 
 		const exportButtonConfigs = [
 			{
@@ -1388,5 +1396,101 @@
 		}
 		const template = templates[ templateSlug ];
 		return template( data );
+	}
+
+	/**
+	 * Toggles the open/collapsed state of a single file section.
+	 *
+	 * @since 1.6.0
+	 *
+	 * @param {HTMLElement} section The file section element.
+	 */
+	function toggleFileSection( section ) {
+		if ( ! section ) {
+			return;
+		}
+		const header = section.querySelector(
+			'.plugin-check__file-section-header'
+		);
+		const isCollapsed = section.classList.contains(
+			'plugin-check__file-section--collapsed'
+		);
+		if ( isCollapsed ) {
+			section.classList.remove( 'plugin-check__file-section--collapsed' );
+			if ( header ) {
+				header.setAttribute( 'aria-expanded', 'true' );
+			}
+		} else {
+			section.classList.add( 'plugin-check__file-section--collapsed' );
+			if ( header ) {
+				header.setAttribute( 'aria-expanded', 'false' );
+			}
+		}
+	}
+
+	/**
+	 * Sets the open state of every file section in the results container.
+	 *
+	 * @since 1.6.0
+	 *
+	 * @param {boolean} open Open state to apply.
+	 */
+	function setAllFileSectionsOpen( open ) {
+		const sections = resultsContainer.querySelectorAll(
+			'.plugin-check__file-section'
+		);
+		sections.forEach( function ( section ) {
+			const header = section.querySelector(
+				'.plugin-check__file-section-header'
+			);
+			if ( open ) {
+				section.classList.remove(
+					'plugin-check__file-section--collapsed'
+				);
+				if ( header ) {
+					header.setAttribute( 'aria-expanded', 'true' );
+				}
+			} else {
+				section.classList.add(
+					'plugin-check__file-section--collapsed'
+				);
+				if ( header ) {
+					header.setAttribute( 'aria-expanded', 'false' );
+				}
+			}
+		} );
+	}
+
+	// Delegated click handler for individual file section headers.
+	resultsContainer.addEventListener( 'click', function ( event ) {
+		const header = event.target.closest(
+			'.plugin-check__file-section-header'
+		);
+		if ( ! header ) {
+			return;
+		}
+		event.preventDefault();
+		const section = header.closest( '.plugin-check__file-section' );
+		toggleFileSection( section );
+	} );
+
+	// Wire up the Collapse All / Expand All buttons.
+	const expandAllButton = document.getElementById(
+		'plugin-check__expand-all'
+	);
+	const collapseAllButton = document.getElementById(
+		'plugin-check__collapse-all'
+	);
+
+	if ( expandAllButton ) {
+		expandAllButton.addEventListener( 'click', function () {
+			setAllFileSectionsOpen( true );
+		} );
+	}
+
+	if ( collapseAllButton ) {
+		collapseAllButton.addEventListener( 'click', function () {
+			setAllFileSectionsOpen( false );
+		} );
 	}
 } )( PLUGIN_CHECK );

--- a/assets/js/plugin-check-admin.js
+++ b/assets/js/plugin-check-admin.js
@@ -1401,7 +1401,7 @@
 	/**
 	 * Toggles the open/collapsed state of a single file section.
 	 *
-	 * @since 1.6.0
+	 * @since 2.1.0
 	 *
 	 * @param {HTMLElement} section The file section element.
 	 */
@@ -1431,7 +1431,7 @@
 	/**
 	 * Sets the open state of every file section in the results container.
 	 *
-	 * @since 1.6.0
+	 * @since 2.1.0
 	 *
 	 * @param {boolean} open Open state to apply.
 	 */

--- a/assets/js/plugin-check-admin.js
+++ b/assets/js/plugin-check-admin.js
@@ -1091,10 +1091,36 @@
 		const hasLinks =
 			hasLinksInResults( errors ) || hasLinksInResults( warnings );
 
+		const errorCount = countResultTree( { [ file ]: errors } );
+		const warningCount = countResultTree( { [ file ]: warnings } );
+
+		const errorLabel =
+			errorCount > 0
+				? ( errorCount === 1
+						? pluginCheck.errorString
+						: pluginCheck.errorsString
+				  ).replace( '%d', errorCount )
+				: '';
+		const warningLabel =
+			warningCount > 0
+				? ( warningCount === 1
+						? pluginCheck.warningString
+						: pluginCheck.warningsString
+				  ).replace( '%d', warningCount )
+				: '';
+
 		// Render the file table.
 		resultsContainer.innerHTML += renderTemplate(
 			'plugin-check-results-table',
-			{ file, index, hasLinks }
+			{
+				file,
+				index,
+				hasLinks,
+				errorCount,
+				warningCount,
+				errorLabel,
+				warningLabel,
+			}
 		);
 		const resultsTable = document.getElementById(
 			'plugin-check__results-body-' + index
@@ -1232,10 +1258,32 @@
 		const hasLinks =
 			hasLinksInResults( errors ) || hasLinksInResults( warnings );
 
+		const errorCount = countResultTree( { [ file ]: errors } );
+		const warningCount = countResultTree( { [ file ]: warnings } );
+
+		const errorLabel =
+			errorCount > 0
+				? ( errorCount === 1
+						? pluginCheck.errorString
+						: pluginCheck.errorsString
+				  ).replace( '%d', errorCount )
+				: '';
+		const warningLabel =
+			warningCount > 0
+				? ( warningCount === 1
+						? pluginCheck.warningString
+						: pluginCheck.warningsString
+				  ).replace( '%d', warningCount )
+				: '';
+
 		container.innerHTML += renderTemplate( 'plugin-check-results-table', {
 			file,
 			index,
 			hasLinks,
+			errorCount,
+			warningCount,
+			errorLabel,
+			warningLabel,
 		} );
 
 		const resultsTable = document.getElementById(

--- a/includes/Admin/Admin_Page.php
+++ b/includes/Admin/Admin_Page.php
@@ -414,14 +414,14 @@ final class Admin_Page {
 		?>
 		<style>
 			#plugin-check__results .notice,
-			#plugin-check__results .notice + h4 {
+			#plugin-check__results .notice + .plugin-check__file-section {
 				margin-top: 20px;
 			}
-			#plugin-check__results h4:first-child {
+			#plugin-check__results .plugin-check__file-section:first-child {
 				margin-top: 80.5px;
 			}
 			@media ( max-width: 782px ) {
-				#plugin-check__results h4:first-child {
+				#plugin-check__results .plugin-check__file-section:first-child {
 					margin-top: 88.5px;
 				}
 			}

--- a/templates/admin-page.php
+++ b/templates/admin-page.php
@@ -104,6 +104,16 @@
 	</div>
 
 	<div id="plugin-check__export-controls" class="plugin-check__export-controls"></div>
+	<div id="plugin-check__collapse-expand-controls" class="plugin-check__collapse-expand-controls is-hidden">
+		<button type="button" id="plugin-check__collapse-all" class="button button-secondary" aria-label="<?php esc_attr_e( 'Collapse all file sections', 'plugin-check' ); ?>">
+			<span class="dashicons dashicons-arrow-up-alt2" aria-hidden="true"></span>
+			<?php esc_html_e( 'Collapse All', 'plugin-check' ); ?>
+		</button>
+		<button type="button" id="plugin-check__expand-all" class="button button-secondary" aria-label="<?php esc_attr_e( 'Expand all file sections', 'plugin-check' ); ?>">
+			<span class="dashicons dashicons-arrow-down-alt2" aria-hidden="true"></span>
+			<?php esc_html_e( 'Expand All', 'plugin-check' ); ?>
+		</button>
+	</div>
 	<div id="plugin-check__results"></div>
 
 </div>

--- a/templates/results-table.php
+++ b/templates/results-table.php
@@ -36,4 +36,4 @@
 		</table>
 	</div>
 </div>
-<br>
+

--- a/templates/results-table.php
+++ b/templates/results-table.php
@@ -2,7 +2,10 @@
 	<button type="button" class="plugin-check__file-section-header" aria-expanded="false" aria-controls="plugin-check__file-section-content-{{data.index}}">
 		<span class="plugin-check__file-section-title">
 			<span class="plugin-check__file-section-icon dashicons dashicons-media-document" aria-hidden="true"></span>
-			<?php esc_html_e( 'FILE:', 'plugin-check' ); ?> {{ data.file }}
+			<?php esc_html_e( 'FILE:', 'plugin-check' ); ?> {{ data.file }}<#
+			if ( data.errorLabel || data.warningLabel ) { #><span class="plugin-check__file-section-counts"><#
+				if ( data.errorLabel ) { #><span class="plugin-check__file-section-count plugin-check__file-section-count--error">{{ data.errorLabel }}</span><# }
+				if ( data.warningLabel ) { #><span class="plugin-check__file-section-count plugin-check__file-section-count--warning">{{ data.warningLabel }}</span><# } #></span><# } #>
 		</span>
 		<span class="plugin-check__file-section-chevron dashicons dashicons-arrow-down-alt2" aria-hidden="true"></span>
 	</button>

--- a/templates/results-table.php
+++ b/templates/results-table.php
@@ -1,29 +1,39 @@
-<h4><?php esc_html_e( 'FILE:', 'plugin-check' ); ?> {{ data.file }}</h4>
-<table id="plugin-check__results-table-{{data.index}}" class="widefat striped plugin-check__results-table">
-	<thead>
-		<tr>
-			<td>
-				<?php esc_html_e( 'Line', 'plugin-check' ); ?>
-			</td>
-			<td>
-				<?php esc_html_e( 'Column', 'plugin-check' ); ?>
-			</td>
-			<td>
-				<?php esc_html_e( 'Type', 'plugin-check' ); ?>
-			</td>
-			<td>
-				<?php esc_html_e( 'Code', 'plugin-check' ); ?>
-			</td>
-			<td>
-				<?php esc_html_e( 'Message', 'plugin-check' ); ?>
-			</td>
-			<# if ( data.hasLinks ) { #>
-				<td>
-					<?php esc_html_e( 'Edit Link', 'plugin-check' ); ?>
-				</td>
-			<# } #>
-		</tr>
-	</thead>
-	<tbody id="plugin-check__results-body-{{data.index}}"></tbody>
-</table>
+<div class="plugin-check__file-section plugin-check__file-section--collapsed" id="plugin-check__file-section-{{data.index}}">
+	<button type="button" class="plugin-check__file-section-header" aria-expanded="false" aria-controls="plugin-check__file-section-content-{{data.index}}">
+		<span class="plugin-check__file-section-title">
+			<span class="plugin-check__file-section-icon dashicons dashicons-media-document" aria-hidden="true"></span>
+			<?php esc_html_e( 'FILE:', 'plugin-check' ); ?> {{ data.file }}
+		</span>
+		<span class="plugin-check__file-section-chevron dashicons dashicons-arrow-down-alt2" aria-hidden="true"></span>
+	</button>
+	<div class="plugin-check__file-section-content" id="plugin-check__file-section-content-{{data.index}}">
+		<table id="plugin-check__results-table-{{data.index}}" class="widefat striped plugin-check__results-table">
+			<thead>
+				<tr>
+					<td>
+						<?php esc_html_e( 'Line', 'plugin-check' ); ?>
+					</td>
+					<td>
+						<?php esc_html_e( 'Column', 'plugin-check' ); ?>
+					</td>
+					<td>
+						<?php esc_html_e( 'Type', 'plugin-check' ); ?>
+					</td>
+					<td>
+						<?php esc_html_e( 'Code', 'plugin-check' ); ?>
+					</td>
+					<td>
+						<?php esc_html_e( 'Message', 'plugin-check' ); ?>
+					</td>
+					<# if ( data.hasLinks ) { #>
+						<td>
+							<?php esc_html_e( 'Edit Link', 'plugin-check' ); ?>
+						</td>
+					<# } #>
+				</tr>
+			</thead>
+			<tbody id="plugin-check__results-body-{{data.index}}"></tbody>
+		</table>
+	</div>
+</div>
 <br>


### PR DESCRIPTION
## Summary

Add Collapse All and Expand All buttons above the results list. Hide the buttons until the scan finishes, and switch the per file sections to a custom card layout with a file icon, brand colored title, and rotating chevron arrow.

Fixes #1334

## Changes

### templates/admin-page.php
**Before:**
```php
<div id="plugin-check__collapse-expand-controls" class="plugin-check__collapse-expand-controls">
    <button type="button" id="plugin-check__collapse-all" class="button">...</button>
    <button type="button" id="plugin-check__expand-all" class="button">...</button>
</div>
```

**After:**
```php
<div id="plugin-check__collapse-expand-controls" class="plugin-check__collapse-expand-controls is-hidden">
    <button type="button" id="plugin-check__collapse-all" class="button button-secondary" aria-label="...">
        <span class="dashicons dashicons-arrow-up-alt2" aria-hidden="true"></span>
        Collapse All
    </button>
    <button type="button" id="plugin-check__expand-all" class="button button-secondary" aria-label="...">
        <span class="dashicons dashicons-arrow-down-alt2" aria-hidden="true"></span>
        Expand All
    </button>
</div>
```

**Why:** Buttons must stay hidden until results load. `button-secondary` matches the export button style.

### templates/results-table.php
**Before:** native `<details>` + `<summary>` per file.

**After:** custom card with header button, file icon, FILE label, filename, and chevron. All cards start collapsed via `--collapsed` class.

```html
<div class="plugin-check__file-section plugin-check__file-section--collapsed" id="plugin-check__file-section-{{data.index}}">
    <button type="button" class="plugin-check__file-section-header" aria-expanded="false" aria-controls="...">
        <span class="plugin-check__file-section-title">
            <span class="plugin-check__file-section-icon dashicons dashicons-media-document" aria-hidden="true"></span>
            FILE: {{ data.file }}
        </span>
        <span class="plugin-check__file-section-chevron dashicons dashicons-arrow-down-alt2" aria-hidden="true"></span>
    </button>
    <div class="plugin-check__file-section-content" id="...">
        <table ...>...</table>
    </div>
</div>
```

**Why:** Matches the reference UI in the issue. Native `details/summary` does not give the custom card look with brand color and file icon.

### assets/js/plugin-check-admin.js
**Why:** Replaced `details.open` toggle with a class based toggle. Added a delegated click handler on each card header to flip `--collapsed` and `aria-expanded`. Hide the controls container on result reset, and show it only after `checksCompleted` is true.

### assets/css/plugin-check-admin.css
**Why:** New card style with border, white background, header button reset, chevron rotation on `aria-expanded="true"`, brand color on the section title, file icon spacing, and `.is-hidden` on the controls container.

## Testing

**Test 1: Initial page load**
1. Open Tools -> Plugin Check
2. Do not run a check

Result: Collapse All and Expand All buttons not visible. Results area empty.

**Test 2: Run a check**
1. Select a plugin with many issues
2. Click Check it

Result: Results load. Collapse All and Expand All buttons appear above results. Each file is a collapsed card with file icon, FILE label, filename, and a right side chevron.

**Test 3: Toggle cards**
1. Click Expand All -> all cards open, chevrons rotate 180deg
2. Click Collapse All -> all cards close, chevrons reset
3. Click a single card header -> that card toggles, chevron rotates

Result: All three toggle paths work and stay in sync with `aria-expanded`.

**Test 4: Re run a check**
1. After results load, click Check it again

Result: Controls hide during the new scan, then reappear when results finish.

**Test 5: False positives section**
1. Check a plugin that triggers false positive analysis

Result: The existing false positives details element still works as before.

## AI Usage Disclosure

- [ ] This PR was created without the help of AI tools
- [x] This PR includes AI-assisted code or content

If AI tools were used, please describe how they were used:
Used Claude Code (Anthropic CLI) for UI implementation of the collapse/expand controls and custom card layout, code review feedback resolution (`@since` tags, trailing `<br>`, `.gitignore`), CI pipeline fixes (Codecov GPG key import, `wp-env` retry), and PR description authoring.

## Screenshots
<img width="1920" height="1050" alt="image" src="https://github.com/user-attachments/assets/ded1337f-c306-4bc3-ab5d-6b88f21833a4" />

https://github.com/user-attachments/assets/d41c6809-b1cd-4423-844d-5e7c471b46f5

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fwp-admin%2Ftools.php%3Fpage%3Dplugin-check%22%2C%22phpExtensionBundles%22%3A%5B%22kitchen-sink%22%5D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginZipFile%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fplugin-check%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-1347-f191c18ab6fcbcbd8d7321e6b3bd6157f584d068.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->