### PR TITLE
Refactor i18n number functions to use _n() for pluralization.

### DIFF
--- a/includes/CLI/Plugin_Check_Command.php
+++ b/includes/CLI/Plugin_Check_Command.php
@@ -795,7 +795,7 @@ final class Plugin_Check_Command {
 			WP_CLI::line(
 				sprintf(
 					/* translators: %d: Number of possible false positives detected. */
-					_n( 'Possible false positive detected: %d','Possible false positives detected: %d', $false_positives, 'plugin-check' ),
+					_n( 'Possible false positive detected: %d', 'Possible false positives detected: %d', $false_positives, 'plugin-check' ),
 					$false_positives
 				)
 			);

--- a/includes/CLI/Plugin_Check_Command.php
+++ b/includes/CLI/Plugin_Check_Command.php
@@ -788,14 +788,14 @@ final class Plugin_Check_Command {
 			WP_CLI::line(
 				sprintf(
 					/* translators: %d: Number of issues analyzed. */
-					__( 'Issues analyzed: %d', 'plugin-check' ),
+					_n( 'Issue analyzed: %d', 'Issues analyzed: %d', $issues_analyzed, 'plugin-check' ),
 					$issues_analyzed
 				)
 			);
 			WP_CLI::line(
 				sprintf(
 					/* translators: %d: Number of possible false positives detected. */
-					__( 'Possible false positives detected: %d', 'plugin-check' ),
+					_n( 'Possible false positive detected: %d','Possible false positives detected: %d', $false_positives, 'plugin-check' ),
 					$false_positives
 				)
 			);
@@ -804,7 +804,7 @@ final class Plugin_Check_Command {
 				WP_CLI::line(
 					sprintf(
 						/* translators: %s: Number of tokens spent. */
-						__( 'Tokens spent: %s', 'plugin-check' ),
+						_n( 'Token spent: %s', 'Tokens spent: %s', $tokens_spent, 'plugin-check' ),
 						number_format_i18n( $tokens_spent )
 					)
 				);

--- a/includes/Checker/Checks/Plugin_Repo/Plugin_Readme_Check.php
+++ b/includes/Checker/Checks/Plugin_Repo/Plugin_Readme_Check.php
@@ -613,7 +613,12 @@ class Plugin_Readme_Check extends Abstract_File_Check {
 			'too_many_tags'                => array(
 				'message' => sprintf(
 					/* translators: %d: maximum tags limit */
-					__( 'One or more tags were ignored. Please limit your plugin to %d tags.', 'plugin-check' ),
+					_n(
+						'One or more tags were ignored. Please limit your plugin to %d tag.',
+						'One or more tags were ignored. Please limit your plugin to %d tags.',
+						5,
+						'plugin-check'
+					),
 					5
 				),
 			),


### PR DESCRIPTION
## What?
<!-- Link this PR to its associated issue. -->
Closes [<!-- #ISSUE-NUMBER or URL -->](https://github.com/iworks/plugin-check/issues/1)

Convert the i18n function with numbers to use _n() for handling plural/singular forms.

## Why?
In pl_PL we have 3 forms, even is a different between numbers ending with "2-5" and "6-9".

## How?
Just use `_n()`.

## AI Usage Disclosure
<!-- See the WordPress AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/ -->

- [x] This PR was created without the help of AI tools
- [ ] This PR includes AI-assisted code or content

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fwp-admin%2Ftools.php%3Fpage%3Dplugin-check%22%2C%22phpExtensionBundles%22%3A%5B%22kitchen-sink%22%5D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginZipFile%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fplugin-check%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-1365-e16cfb0a03067b3775015d19a5f58155e99332b8.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->