### PR TITLE
Enhancement: Use distinct visual styles for different issue types #1384

### DIFF
--- a/assets/css/plugin-check-admin.css
+++ b/assets/css/plugin-check-admin.css
@@ -225,12 +225,13 @@
 /** Plugin Check Report Error/Warning Badge **/
 .plugin-check__results-row-type--ERROR span,
 .plugin-check__results-row-type--WARNING span {
-	background: #dc3545;
-	color: #fff;
+	background: rgb(235, 163, 163);
+	color: #570000;
 	padding: 4px 8px;
 	border-radius: 2px;
 }
 
 .plugin-check__results-row-type--WARNING span {
-	background: #ffc107;
+	background: rgb(248, 221, 167);
+	color: rgb(87, 59, 0);
 }

--- a/assets/css/plugin-check-admin.css
+++ b/assets/css/plugin-check-admin.css
@@ -221,3 +221,16 @@
 	color: #646970;
 	font-size: 0.9em;
 }
+
+/** Plugin Check Report Error/Warning Badge **/
+.plugin-check__results-row-type--ERROR span,
+.plugin-check__results-row-type--WARNING span {
+	background: #dc3545;
+	color: #fff;
+	padding: 4px 8px;
+	border-radius: 2px;
+}
+
+.plugin-check__results-row-type--WARNING span {
+	background: #ffc107;
+}

--- a/assets/css/plugin-check-admin.css
+++ b/assets/css/plugin-check-admin.css
@@ -223,15 +223,15 @@
 }
 
 /** Plugin Check Report Error/Warning Badge **/
-.plugin-check__results-row-type--ERROR span,
-.plugin-check__results-row-type--WARNING span {
+.plugin-check__results-row-type--error span,
+.plugin-check__results-row-type--warning span {
 	background: rgb(235, 163, 163);
 	color: #570000;
 	padding: 4px 8px;
 	border-radius: 2px;
 }
 
-.plugin-check__results-row-type--WARNING span {
+.plugin-check__results-row-type--warning span {
 	background: rgb(248, 221, 167);
 	color: rgb(87, 59, 0);
 }

--- a/templates/results-row.php
+++ b/templates/results-row.php
@@ -5,7 +5,7 @@
 	<td data-label="<?php esc_attr_e( 'Column', 'plugin-check' ); ?>">
 		{{data.column}}
 	</td>
-	<td data-label="<?php esc_attr_e( 'Type', 'plugin-check' ); ?>" class="plugin-check__results-row-type plugin-check__results-row-type--{{data.type}}">
+	<td data-label="<?php esc_attr_e( 'Type', 'plugin-check' ); ?>" class="plugin-check__results-row-type plugin-check__results-row-type--{{data.type.toLowerCase()}}">
 		<span>{{data.type}}</span>
 	</td>
 	<td data-label="<?php esc_attr_e( 'Code', 'plugin-check' ); ?>">

--- a/templates/results-row.php
+++ b/templates/results-row.php
@@ -5,8 +5,8 @@
 	<td data-label="<?php esc_attr_e( 'Column', 'plugin-check' ); ?>">
 		{{data.column}}
 	</td>
-	<td data-label="<?php esc_attr_e( 'Type', 'plugin-check' ); ?>">
-		{{data.type}}
+	<td data-label="<?php esc_attr_e( 'Type', 'plugin-check' ); ?>" class="plugin-check__results-row-type plugin-check__results-row-type--{{data.type}}">
+		<span>{{data.type}}</span>
 	</td>
 	<td data-label="<?php esc_attr_e( 'Code', 'plugin-check' ); ?>">
 		{{data.code}}


### PR DESCRIPTION
## What?

Closes #1384

Using badges instead of raw ERROR/WARNING text to improve the user experience.

## Why?

As a Plugin Check user, I always use it before pushing any version of my plugin. I noticed that it's hard to visually distinguish errors and warnings. Even though I can turn warnings/errors off, using badges makes it easier for our brains to quickly identify whether something is an error or a warning, making it slightly more effective. I noticed someone had already created an issue, and I thought I would try to implement it myself since it's not a huge change.

## How?

As a fix, I added custom classes `plugin-check__results-row-type` and `plugin-check__results-row-type--{{error_type}}`, and wrapped the ERROR/WARNING text inside a `<span>`. I also added custom CSS to the `assets/css/plugin-check-admin.css` file with a proper comment. I used `#dc3545` as the ERROR badge background color and `#ffc107` as the WARNING badge background color.

## Testing Instructions

1. Open the Plugin Check menu from WordPress Admin -> Tools.
2. Select any plugin and click Check.
3. If the plugin has any warnings or errors, the results will show the ERROR/WARNING text as a badge instead of raw text.

## AI Usage Disclosure

- [x] This PR includes AI-assisted code or content

It's a tiny change. I did it myself, but I used AI to fix typos and grammatical mistakes in the PR message.

## Screenshots

<img width="1912" height="777" alt="after my change" src="https://github.com/user-attachments/assets/2b0621ec-0fac-49f8-a2d7-e1cf1ecd1726" />

| Before | After |
| - | - |
| <img width="1912" height="777" alt="before my change" src="https://github.com/user-attachments/assets/896c99a4-2174-41ba-9853-bbc3187663ad" /> | <img width="1912" height="777" alt="after my change" src="https://github.com/user-attachments/assets/2b0621ec-0fac-49f8-a2d7-e1cf1ecd1726" /> |

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fwp-admin%2Ftools.php%3Fpage%3Dplugin-check%22%2C%22phpExtensionBundles%22%3A%5B%22kitchen-sink%22%5D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginZipFile%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fplugin-check%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-1388-e80d2d6244d90f5283dae7ee92a944c2b2b59f88.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->

Co-authored-by: kmfoysal06 <kmfoysal06@git.wordpress.org>
Co-authored-by: tushar-addweb <tusharaddweb@git.wordpress.org>