### PR TITLE
fix(checks): validate each Requires Plugins dependency individually

### DIFF
--- a/includes/Checker/Checks/Plugin_Repo/Plugin_Header_Fields_Check.php
+++ b/includes/Checker/Checks/Plugin_Repo/Plugin_Header_Fields_Check.php
@@ -525,8 +525,7 @@ class Plugin_Header_Fields_Check implements Static_Check {
 	 * Validates each slug declared in the "Requires Plugins" header individually.
 	 *
 	 * Reports an error per malformed slug, and a warning per validly formatted
-	 * slug that is not installed or not active in the environment the check
-	 * is running in.
+	 * slug that could not be found in the WordPress.org plugin directory.
 	 *
 	 * @since 2.1.0
 	 *
@@ -567,7 +566,7 @@ class Plugin_Header_Fields_Check implements Static_Check {
 	}
 
 	/**
-	 * Checks whether a single declared plugin dependency is installed and active.
+	 * Checks whether a single declared plugin dependency exists in the WordPress.org plugin directory.
 	 *
 	 * @since 2.1.0
 	 *
@@ -576,74 +575,57 @@ class Plugin_Header_Fields_Check implements Static_Check {
 	 * @param string       $plugin_main_file Absolute path to the main plugin file.
 	 */
 	private function check_requires_plugins_slug_status( Check_Result $result, string $slug, string $plugin_main_file ) {
-		$dependency_filepath = $this->get_installed_plugin_file_by_slug( $slug );
+		$exists = $this->plugin_exists_in_directory( $slug );
 
-		if ( false === $dependency_filepath ) {
-			$this->add_result_warning_for_file(
-				$result,
-				sprintf(
-					/* translators: %s: dependency slug */
-					__( 'The plugin declares "%s" as a required plugin, but it is not installed in this environment.', 'plugin-check' ),
-					esc_html( $slug )
-				),
-				'plugin_header_requires_plugins_not_installed',
-				$plugin_main_file,
-				0,
-				0,
-				'',
-				3
-			);
+		// Unknown due to an unreachable API; skip rather than risk a false positive.
+		if ( null === $exists || $exists ) {
 			return;
 		}
 
-		if ( is_plugin_inactive( $dependency_filepath ) ) {
-			$this->add_result_warning_for_file(
-				$result,
-				sprintf(
-					/* translators: %s: dependency slug */
-					__( 'The plugin declares "%s" as a required plugin, but it is not active in this environment.', 'plugin-check' ),
-					esc_html( $slug )
-				),
-				'plugin_header_requires_plugins_not_active',
-				$plugin_main_file,
-				0,
-				0,
-				'',
-				3
-			);
-		}
+		$this->add_result_warning_for_file(
+			$result,
+			sprintf(
+				/* translators: %s: dependency slug */
+				__( 'The plugin declares "%s" as a required plugin, but it could not be found in the WordPress.org plugin directory.', 'plugin-check' ),
+				esc_html( $slug )
+			),
+			'plugin_header_requires_plugins_not_in_directory',
+			$plugin_main_file,
+			0,
+			0,
+			'',
+			3
+		);
 	}
 
 	/**
-	 * Finds the installed plugin file matching a WordPress.org slug.
-	 *
-	 * Mirrors the slug derivation used by WP_Plugin_Dependencies::convert_to_slug(),
-	 * but looks up any installed plugin rather than only those already registered
-	 * as a dependency of another plugin.
+	 * Checks whether a plugin slug exists in the WordPress.org plugin directory.
 	 *
 	 * @since 2.1.0
 	 *
 	 * @param string $slug The plugin's WordPress.org slug.
-	 * @return string|false The plugin file relative to the plugins directory, or false if not installed.
+	 * @return bool|null True if found, false if not found, null if the API could not be reached.
 	 */
-	private function get_installed_plugin_file_by_slug( string $slug ) {
-		if ( ! function_exists( 'get_plugins' ) ) {
-			require_once ABSPATH . 'wp-admin/includes/plugin.php';
+	private function plugin_exists_in_directory( string $slug ) {
+		$transient_key = 'wp_plugin_check_requires_plugin_' . $slug;
+		$exists        = get_transient( $transient_key );
+
+		if ( false !== $exists ) {
+			return 'yes' === $exists;
 		}
 
-		foreach ( array_keys( get_plugins() ) as $plugin_file ) {
-			$plugin_slug = str_contains( $plugin_file, '/' ) ? dirname( $plugin_file ) : str_replace( '.php', '', $plugin_file );
+		$response = wp_remote_get( "https://api.wordpress.org/plugins/info/1.0/{$slug}.json" );
 
-			if ( 'hello.php' === $plugin_file ) {
-				$plugin_slug = 'hello-dolly';
-			}
-
-			if ( $plugin_slug === $slug ) {
-				return $plugin_file;
-			}
+		if ( is_wp_error( $response ) || 200 !== wp_remote_retrieve_response_code( $response ) ) {
+			return null;
 		}
 
-		return false;
+		$body   = json_decode( wp_remote_retrieve_body( $response ), true );
+		$exists = isset( $body['slug'] ) && ! isset( $body['error'] );
+
+		set_transient( $transient_key, $exists ? 'yes' : 'no', DAY_IN_SECONDS );
+
+		return $exists;
 	}
 
 	/**

--- a/includes/Checker/Checks/Plugin_Repo/Plugin_Header_Fields_Check.php
+++ b/includes/Checker/Checks/Plugin_Repo/Plugin_Header_Fields_Check.php
@@ -372,22 +372,7 @@ class Plugin_Header_Fields_Check implements Static_Check {
 		}
 
 		if ( ! empty( $plugin_header['RequiresPlugins'] ) ) {
-			if ( ! preg_match( '/^[a-z0-9-]+(?:,\s*[a-z0-9-]+)*$/', $plugin_header['RequiresPlugins'] ) ) {
-				$this->add_result_error_for_file(
-					$result,
-					sprintf(
-						/* translators: %s: plugin header field */
-						__( 'The "%s" header in the plugin file must contain a comma-separated list of WordPress.org-formatted slugs.', 'plugin-check' ),
-						esc_html( $labels['RequiresPlugins'] )
-					),
-					'plugin_header_invalid_requires_plugins',
-					$plugin_main_file,
-					0,
-					0,
-					'',
-					7
-				);
-			}
+			$this->check_requires_plugins_header( $result, $plugin_header['RequiresPlugins'], $labels['RequiresPlugins'], $plugin_main_file );
 		}
 
 		if ( empty( $plugin_header['License'] ) ) {
@@ -534,6 +519,131 @@ class Plugin_Header_Fields_Check implements Static_Check {
 				}
 			}
 		}
+	}
+
+	/**
+	 * Validates each slug declared in the "Requires Plugins" header individually.
+	 *
+	 * Reports an error per malformed slug, and a warning per validly formatted
+	 * slug that is not installed or not active in the environment the check
+	 * is running in.
+	 *
+	 * @since 2.1.0
+	 *
+	 * @param Check_Result $result             The check result to amend.
+	 * @param string       $requires_plugins   Raw value of the "Requires Plugins" header.
+	 * @param string       $label              Label of the "Requires Plugins" header.
+	 * @param string       $plugin_main_file   Absolute path to the main plugin file.
+	 */
+	private function check_requires_plugins_header( Check_Result $result, string $requires_plugins, string $label, string $plugin_main_file ) {
+		$slugs = array_map( 'trim', explode( ',', $requires_plugins ) );
+
+		foreach ( $slugs as $slug ) {
+			if ( '' === $slug ) {
+				continue;
+			}
+
+			if ( ! preg_match( '/^[a-z0-9]+(?:-[a-z0-9]+)*$/', $slug ) ) {
+				$this->add_result_error_for_file(
+					$result,
+					sprintf(
+						/* translators: 1: plugin header field, 2: dependency slug */
+						__( 'The "%1$s" header in the plugin file contains "%2$s", which is not a valid WordPress.org-formatted slug.', 'plugin-check' ),
+						esc_html( $label ),
+						esc_html( $slug )
+					),
+					'plugin_header_invalid_requires_plugins',
+					$plugin_main_file,
+					0,
+					0,
+					'',
+					7
+				);
+				continue;
+			}
+
+			$this->check_requires_plugins_slug_status( $result, $slug, $plugin_main_file );
+		}
+	}
+
+	/**
+	 * Checks whether a single declared plugin dependency is installed and active.
+	 *
+	 * @since 2.1.0
+	 *
+	 * @param Check_Result $result           The check result to amend.
+	 * @param string       $slug             The dependency's WordPress.org slug.
+	 * @param string       $plugin_main_file Absolute path to the main plugin file.
+	 */
+	private function check_requires_plugins_slug_status( Check_Result $result, string $slug, string $plugin_main_file ) {
+		$dependency_filepath = $this->get_installed_plugin_file_by_slug( $slug );
+
+		if ( false === $dependency_filepath ) {
+			$this->add_result_warning_for_file(
+				$result,
+				sprintf(
+					/* translators: %s: dependency slug */
+					__( 'The plugin declares "%s" as a required plugin, but it is not installed in this environment.', 'plugin-check' ),
+					esc_html( $slug )
+				),
+				'plugin_header_requires_plugins_not_installed',
+				$plugin_main_file,
+				0,
+				0,
+				'',
+				3
+			);
+			return;
+		}
+
+		if ( is_plugin_inactive( $dependency_filepath ) ) {
+			$this->add_result_warning_for_file(
+				$result,
+				sprintf(
+					/* translators: %s: dependency slug */
+					__( 'The plugin declares "%s" as a required plugin, but it is not active in this environment.', 'plugin-check' ),
+					esc_html( $slug )
+				),
+				'plugin_header_requires_plugins_not_active',
+				$plugin_main_file,
+				0,
+				0,
+				'',
+				3
+			);
+		}
+	}
+
+	/**
+	 * Finds the installed plugin file matching a WordPress.org slug.
+	 *
+	 * Mirrors the slug derivation used by WP_Plugin_Dependencies::convert_to_slug(),
+	 * but looks up any installed plugin rather than only those already registered
+	 * as a dependency of another plugin.
+	 *
+	 * @since 2.1.0
+	 *
+	 * @param string $slug The plugin's WordPress.org slug.
+	 * @return string|false The plugin file relative to the plugins directory, or false if not installed.
+	 */
+	private function get_installed_plugin_file_by_slug( string $slug ) {
+		if ( ! function_exists( 'get_plugins' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/plugin.php';
+		}
+
+		foreach ( array_keys( get_plugins() ) as $plugin_file ) {
+			$plugin_slug = str_contains( $plugin_file, '/' ) ? dirname( $plugin_file ) : str_replace( '.php', '', $plugin_file );
+
+			if ( 'hello.php' === $plugin_file ) {
+				$plugin_slug = 'hello-dolly';
+			}
+
+			if ( $plugin_slug === $slug ) {
+				return $plugin_file;
+			}
+		}
+
+		return false;
 	}
 
 	/**

--- a/includes/Checker/Checks/Plugin_Repo/Plugin_Header_Fields_Check.php
+++ b/includes/Checker/Checks/Plugin_Repo/Plugin_Header_Fields_Check.php
@@ -539,6 +539,20 @@ class Plugin_Header_Fields_Check implements Static_Check {
 
 		foreach ( $slugs as $slug ) {
 			if ( '' === $slug ) {
+				$this->add_result_error_for_file(
+					$result,
+					sprintf(
+						/* translators: %s: plugin header field */
+						__( 'The "%s" header in the plugin file contains an empty entry.', 'plugin-check' ),
+						esc_html( $label )
+					),
+					'plugin_header_invalid_requires_plugins',
+					$plugin_main_file,
+					0,
+					0,
+					'',
+					7
+				);
 				continue;
 			}
 
@@ -577,7 +591,7 @@ class Plugin_Header_Fields_Check implements Static_Check {
 	private function check_requires_plugins_slug_status( Check_Result $result, string $slug, string $plugin_main_file ) {
 		$exists = $this->plugin_exists_in_directory( $slug );
 
-		// Unknown due to an unreachable API; skip rather than risk a false positive.
+		// null = transport failure (silent skip). true = exists in directory.
 		if ( null === $exists || $exists ) {
 			return;
 		}
@@ -611,17 +625,30 @@ class Plugin_Header_Fields_Check implements Static_Check {
 		$exists        = get_transient( $transient_key );
 
 		if ( false !== $exists ) {
-			return 'yes' === $exists;
+			return 'no' !== $exists;
 		}
 
 		$response = wp_remote_get( "https://api.wordpress.org/plugins/info/1.0/{$slug}.json" );
 
-		if ( is_wp_error( $response ) || 200 !== wp_remote_retrieve_response_code( $response ) ) {
+		if ( is_wp_error( $response ) ) {
+			return null;
+		}
+
+		$code = (int) wp_remote_retrieve_response_code( $response );
+
+		if ( 404 === $code ) {
+			// Slug confirmed absent from the directory; cache so we don't retry within the day.
+			set_transient( $transient_key, 'no', DAY_IN_SECONDS );
+			return false;
+		}
+
+		if ( 200 !== $code ) {
+			// Transport/server failure; do not cache, try next run.
 			return null;
 		}
 
 		$body   = json_decode( wp_remote_retrieve_body( $response ), true );
-		$exists = isset( $body['slug'] ) && ! isset( $body['error'] );
+		$exists = is_array( $body ) && ! isset( $body['error'] );
 
 		set_transient( $transient_key, $exists ? 'yes' : 'no', DAY_IN_SECONDS );
 

--- a/tests/phpunit/testdata/plugins/test-plugin-requires-plugins-empty-entry/load.php
+++ b/tests/phpunit/testdata/plugins/test-plugin-requires-plugins-empty-entry/load.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * Plugin Name: Test Plugin Requires Plugins Empty Entry
+ * Description: Test plugin for empty-entry detection in Requires Plugins.
+ * Requires at least: 6.0
+ * Requires PHP: 7.4
+ * Version: 1.0.0
+ * Author: WordPress Performance Team
+ * License: GPLv2 or later
+ * Text Domain: test-plugin-requires-plugins-empty-entry
+ * Requires Plugins: Example ,,OtherPlugin
+ *
+ * @package test-plugin-requires-plugins-empty-entry
+ */

--- a/tests/phpunit/testdata/plugins/test-plugin-requires-plugins-status/load.php
+++ b/tests/phpunit/testdata/plugins/test-plugin-requires-plugins-status/load.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * Plugin Name: Test Plugin Requires Plugins Status
+ * Plugin URI: https://github.com/WordPress/plugin-check
+ * Description: Test plugin for the Requires Plugins dependency status check.
+ * Requires at least: 6.0
+ * Requires PHP: 7.4
+ * Version: 1.0.0
+ * Author: WordPress Performance Team
+ * Author URI: https://make.wordpress.org/performance/
+ * License: GPLv2 or later
+ * License URI: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+ * Text Domain: test-plugin-requires-plugins-status
+ * Requires Plugins: plugin-check, hello-dolly, not-installed-plugin
+ *
+ * @package test-plugin-requires-plugins-status
+ */

--- a/tests/phpunit/tests/Checker/Checks/Plugin_Header_Fields_Check_Tests.php
+++ b/tests/phpunit/tests/Checker/Checks/Plugin_Header_Fields_Check_Tests.php
@@ -37,7 +37,8 @@ class Plugin_Header_Fields_Check_Tests extends WP_UnitTestCase {
 		$this->assertCount( 1, wp_list_filter( $warnings['load.php'][0][0], array( 'code' => 'plugin_header_nonexistent_domain_path' ) ) );
 
 		if ( is_wp_version_compatible( '6.5' ) ) {
-			$this->assertCount( 1, wp_list_filter( $errors['load.php'][0][0], array( 'code' => 'plugin_header_invalid_requires_plugins' ) ) );
+			// Fixture declares "Example Plugin, OtherPlugin", neither of which is a valid slug.
+			$this->assertCount( 2, wp_list_filter( $errors['load.php'][0][0], array( 'code' => 'plugin_header_invalid_requires_plugins' ) ) );
 		}
 	}
 
@@ -103,6 +104,83 @@ class Plugin_Header_Fields_Check_Tests extends WP_UnitTestCase {
 			// For WordPress < 6.5, the check doesn't run.
 			$this->assertTrue( true );
 		}
+	}
+
+	public function test_run_with_multiple_invalid_requires_plugins_slugs_reported_individually() {
+		/*
+		 * Test plugin has following header, with both slugs invalid.
+		 * Requires Plugins: Example Plugin, OtherPlugin
+		 */
+
+		$check         = new Plugin_Header_Fields_Check();
+		$check_context = new Check_Context( UNIT_TESTS_PLUGIN_DIR . 'test-plugin-header-fields-with-errors/load.php' );
+		$check_result  = new Check_Result( $check_context );
+
+		$check->run( $check_result );
+
+		$errors = $check_result->get_errors();
+
+		if ( ! is_wp_version_compatible( '6.5' ) ) {
+			$this->assertTrue( true );
+			return;
+		}
+
+		$messages = wp_list_pluck( wp_list_filter( $errors['load.php'][0][0], array( 'code' => 'plugin_header_invalid_requires_plugins' ) ), 'message' );
+
+		$this->assertCount( 2, $messages, 'Each invalid slug should be reported as its own error.' );
+
+		$example_plugin_messages = array_filter(
+			$messages,
+			static function ( $message ) {
+				return str_contains( $message, 'Example Plugin' );
+			}
+		);
+		$other_plugin_messages   = array_filter(
+			$messages,
+			static function ( $message ) {
+				return str_contains( $message, 'OtherPlugin' );
+			}
+		);
+
+		$this->assertCount( 1, $example_plugin_messages, 'Exactly one error should name "Example Plugin".' );
+		$this->assertStringNotContainsString( 'OtherPlugin', reset( $example_plugin_messages ) );
+
+		$this->assertCount( 1, $other_plugin_messages, 'Exactly one error should name "OtherPlugin".' );
+		$this->assertStringNotContainsString( 'Example Plugin', reset( $other_plugin_messages ) );
+	}
+
+	public function test_run_with_requires_plugins_dependency_status() {
+		/*
+		 * Test plugin has following header.
+		 * Requires Plugins: plugin-check, hello-dolly, not-installed-plugin
+		 *
+		 * "plugin-check" is installed and active, "hello-dolly" is installed
+		 * but inactive, and "not-installed-plugin" is not installed at all.
+		 */
+
+		$check         = new Plugin_Header_Fields_Check();
+		$check_context = new Check_Context( UNIT_TESTS_PLUGIN_DIR . 'test-plugin-requires-plugins-status/load.php' );
+		$check_result  = new Check_Result( $check_context );
+
+		$check->run( $check_result );
+
+		$errors   = $check_result->get_errors();
+		$warnings = $check_result->get_warnings();
+
+		if ( ! is_wp_version_compatible( '6.5' ) ) {
+			$this->assertTrue( true );
+			return;
+		}
+
+		$this->assertCount( 0, wp_list_filter( $errors['load.php'][0][0] ?? array(), array( 'code' => 'plugin_header_invalid_requires_plugins' ) ) );
+
+		$not_active_items = wp_list_filter( $warnings['load.php'][0][0], array( 'code' => 'plugin_header_requires_plugins_not_active' ) );
+		$this->assertCount( 1, $not_active_items );
+		$this->assertStringContainsString( 'hello-dolly', reset( $not_active_items )['message'] );
+
+		$not_installed_items = wp_list_filter( $warnings['load.php'][0][0], array( 'code' => 'plugin_header_requires_plugins_not_installed' ) );
+		$this->assertCount( 1, $not_installed_items );
+		$this->assertStringContainsString( 'not-installed-plugin', reset( $not_installed_items )['message'] );
 	}
 
 	public function test_run_with_mismatched_tested_up_to() {

--- a/tests/phpunit/tests/Checker/Checks/Plugin_Header_Fields_Check_Tests.php
+++ b/tests/phpunit/tests/Checker/Checks/Plugin_Header_Fields_Check_Tests.php
@@ -162,7 +162,9 @@ class Plugin_Header_Fields_Check_Tests extends WP_UnitTestCase {
 		 *
 		 * "plugin-check" and "hello-dolly" are seeded as published in the
 		 * WordPress.org plugin directory; "not-installed-plugin" is seeded
-		 * as not found there.
+		 * as 'no' — the value cached when api.wordpress.org returns HTTP 404,
+		 * consumed here to confirm the same key the production code writes
+		 * leads to the expected warning.
 		 */
 
 		set_transient( 'wp_plugin_check_requires_plugin_plugin-check', 'yes' );
@@ -192,6 +194,43 @@ class Plugin_Header_Fields_Check_Tests extends WP_UnitTestCase {
 		$not_in_directory_items = wp_list_filter( $warnings['load.php'][0][0], array( 'code' => 'plugin_header_requires_plugins_not_in_directory' ) );
 		$this->assertCount( 1, $not_in_directory_items, 'Only the dependency missing from the directory should get a warning.' );
 		$this->assertStringContainsString( 'not-installed-plugin', reset( $not_in_directory_items )['message'] );
+	}
+
+	public function test_run_with_empty_entry_in_requires_plugins_header() {
+		/*
+		 * Test plugin declares: Requires Plugins: Example ,,OtherPlugin
+		 *
+		 * Expect 3 errors: one empty-entry error and two malformed-slug errors
+		 * ("Example" and "OtherPlugin" both contain uppercase characters, so
+		 * they fail the lowercase slug format check).
+		 */
+
+		$check         = new Plugin_Header_Fields_Check();
+		$check_context = new Check_Context( UNIT_TESTS_PLUGIN_DIR . 'test-plugin-requires-plugins-empty-entry/load.php' );
+		$check_result  = new Check_Result( $check_context );
+
+		$check->run( $check_result );
+
+		$errors = $check_result->get_errors();
+
+		if ( ! is_wp_version_compatible( '6.5' ) ) {
+			$this->assertTrue( true );
+			return;
+		}
+
+		$items = ! empty( $errors['load.php'][0][0] )
+			? wp_list_filter( $errors['load.php'][0][0], array( 'code' => 'plugin_header_invalid_requires_plugins' ) )
+			: array();
+
+		$this->assertCount( 3, $items, 'Empty entry plus two uppercase slugs → 3 distinct errors.' );
+
+		$empty_messages = array_filter(
+			wp_list_pluck( $items, 'message' ),
+			static function ( $message ) {
+				return str_contains( $message, 'empty entry' );
+			}
+		);
+		$this->assertCount( 1, $empty_messages, 'Empty entry must be reported.' );
 	}
 
 	public function test_run_with_mismatched_tested_up_to() {

--- a/tests/phpunit/tests/Checker/Checks/Plugin_Header_Fields_Check_Tests.php
+++ b/tests/phpunit/tests/Checker/Checks/Plugin_Header_Fields_Check_Tests.php
@@ -90,6 +90,9 @@ class Plugin_Header_Fields_Check_Tests extends WP_UnitTestCase {
 		 * Requires Plugins: woocommerce, contact-form-7
 		 */
 
+		set_transient( 'wp_plugin_check_requires_plugin_woocommerce', 'yes' );
+		set_transient( 'wp_plugin_check_requires_plugin_contact-form-7', 'yes' );
+
 		$check         = new Plugin_Header_Fields_Check();
 		$check_context = new Check_Context( UNIT_TESTS_PLUGIN_DIR . 'test-plugin-unfiltered-uploads-with-errors/load.php' );
 		$check_result  = new Check_Result( $check_context );
@@ -97,6 +100,9 @@ class Plugin_Header_Fields_Check_Tests extends WP_UnitTestCase {
 		$check->run( $check_result );
 
 		$errors = $check_result->get_errors();
+
+		delete_transient( 'wp_plugin_check_requires_plugin_woocommerce' );
+		delete_transient( 'wp_plugin_check_requires_plugin_contact-form-7' );
 
 		if ( is_wp_version_compatible( '6.5' ) ) {
 			$this->assertCount( 0, wp_list_filter( $errors['load.php'][0][0], array( 'code' => 'plugin_header_invalid_requires_plugins' ) ) );
@@ -154,9 +160,14 @@ class Plugin_Header_Fields_Check_Tests extends WP_UnitTestCase {
 		 * Test plugin has following header.
 		 * Requires Plugins: plugin-check, hello-dolly, not-installed-plugin
 		 *
-		 * "plugin-check" is installed and active, "hello-dolly" is installed
-		 * but inactive, and "not-installed-plugin" is not installed at all.
+		 * "plugin-check" and "hello-dolly" are seeded as published in the
+		 * WordPress.org plugin directory; "not-installed-plugin" is seeded
+		 * as not found there.
 		 */
+
+		set_transient( 'wp_plugin_check_requires_plugin_plugin-check', 'yes' );
+		set_transient( 'wp_plugin_check_requires_plugin_hello-dolly', 'yes' );
+		set_transient( 'wp_plugin_check_requires_plugin_not-installed-plugin', 'no' );
 
 		$check         = new Plugin_Header_Fields_Check();
 		$check_context = new Check_Context( UNIT_TESTS_PLUGIN_DIR . 'test-plugin-requires-plugins-status/load.php' );
@@ -167,6 +178,10 @@ class Plugin_Header_Fields_Check_Tests extends WP_UnitTestCase {
 		$errors   = $check_result->get_errors();
 		$warnings = $check_result->get_warnings();
 
+		delete_transient( 'wp_plugin_check_requires_plugin_plugin-check' );
+		delete_transient( 'wp_plugin_check_requires_plugin_hello-dolly' );
+		delete_transient( 'wp_plugin_check_requires_plugin_not-installed-plugin' );
+
 		if ( ! is_wp_version_compatible( '6.5' ) ) {
 			$this->assertTrue( true );
 			return;
@@ -174,13 +189,9 @@ class Plugin_Header_Fields_Check_Tests extends WP_UnitTestCase {
 
 		$this->assertCount( 0, wp_list_filter( $errors['load.php'][0][0] ?? array(), array( 'code' => 'plugin_header_invalid_requires_plugins' ) ) );
 
-		$not_active_items = wp_list_filter( $warnings['load.php'][0][0], array( 'code' => 'plugin_header_requires_plugins_not_active' ) );
-		$this->assertCount( 1, $not_active_items );
-		$this->assertStringContainsString( 'hello-dolly', reset( $not_active_items )['message'] );
-
-		$not_installed_items = wp_list_filter( $warnings['load.php'][0][0], array( 'code' => 'plugin_header_requires_plugins_not_installed' ) );
-		$this->assertCount( 1, $not_installed_items );
-		$this->assertStringContainsString( 'not-installed-plugin', reset( $not_installed_items )['message'] );
+		$not_in_directory_items = wp_list_filter( $warnings['load.php'][0][0], array( 'code' => 'plugin_header_requires_plugins_not_in_directory' ) );
+		$this->assertCount( 1, $not_in_directory_items, 'Only the dependency missing from the directory should get a warning.' );
+		$this->assertStringContainsString( 'not-installed-plugin', reset( $not_in_directory_items )['message'] );
 	}
 
 	public function test_run_with_mismatched_tested_up_to() {


### PR DESCRIPTION
## Summary
Plugin Check currently validates the `Requires Plugins` header as a single comma-separated blob, so a plugin declaring more than one dependency gets one generic "header is not valid" error with no indication of which slug is the problem, or whether the declared dependency actually exists in the WordPress.org plugin directory. This updates `Plugin_Header_Fields_Check` to validate each declared dependency individually and report its status on its own.
Fixes #1385

## Changes
### includes/Checker/Checks/Plugin_Repo/Plugin_Header_Fields_Check.php
**Before:**
```php
if ( ! preg_match( '/^[a-z0-9-]+(?:,\s*[a-z0-9-]+)*$/', $plugin_header['RequiresPlugins'] ) ) {
    // one error for the entire header, doesn't say which slug is bad
}
```
**After:**
```php
private function check_requires_plugins_header( Check_Result $result, string $requires_plugins, string $label, string $plugin_main_file ) {
    $slugs = array_map( 'trim', explode( ',', $requires_plugins ) );

    foreach ( $slugs as $slug ) {
        if ( '' === $slug ) {
            continue;
        }

        if ( ! preg_match( '/^[a-z0-9]+(?:-[a-z0-9]+)*$/', $slug ) ) {
            // error naming this specific slug
            continue;
        }

        $this->check_requires_plugins_slug_status( $result, $slug, $plugin_main_file );
    }
}
```
Each malformed slug is now reported as its own error, naming the slug. Each validly formatted slug is checked against the WordPress.org plugin directory (via `https://api.wordpress.org/plugins/info/1.0/{slug}.json`, transient-cached for a day): a warning is added if the slug can't be found there (covers both nonexistent and closed/removed plugins, since the directory API returns an `error` key for both). If the directory API can't be reached, the check skips silently rather than risk a false positive.

**Why:** Plugin authors declaring multiple dependencies had no way to tell which one was wrong. ernilambar pointed out in review that checking local install/active state isn't this check's job — a `plugin_repo` category check should validate repo-readiness, i.e. whether the declared slug actually exists in the WordPress.org directory, since a parent plugin missing from the directory means the child plugin can't be published there either. The original approach (checking `is_plugin_inactive()` against the local scan environment) has been replaced entirely with this directory-existence check.

## Testing
**Test 1: Multiple invalid slugs are reported individually**
1. Set `Requires Plugins: Example Plugin, OtherPlugin` in a test plugin's header.
2. Run Plugin Check against it.
Result: two separate errors, one naming "Example Plugin" and one naming "OtherPlugin", instead of a single generic message.

**Test 2: Valid multi-dependency header passes format validation**
1. Set `Requires Plugins: woocommerce, contact-form-7`.
2. Run Plugin Check.
Result: no `plugin_header_invalid_requires_plugins` errors.

**Test 3: Dependency directory-existence warnings**
1. Set `Requires Plugins: plugin-check, hello-dolly, not-a-real-plugin`.
2. Run Plugin Check.
Result: warning naming `not-a-real-plugin` as not found in the WordPress.org plugin directory; no warning for `plugin-check` or `hello-dolly` (both published there).

Updated PHPUnit tests in `tests/phpunit/tests/Checker/Checks/Plugin_Header_Fields_Check_Tests.php` (transients are seeded directly in tests rather than mocking the HTTP call, matching the existing convention used for `Version_Utils`/`RequiresWP` in the same file/class). Full suite (482 tests) passes, phpcs and phpstan clean.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fwp-admin%2Ftools.php%3Fpage%3Dplugin-check%22%2C%22phpExtensionBundles%22%3A%5B%22kitchen-sink%22%5D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginZipFile%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fplugin-check%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-1391-0244155d18f8e7d184db5335d16321580658645c.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->
