### PR TITLE
Fix silently dropped WordPress core functions in since-data generator

### DIFF
--- a/tools/generate-wp-function-since-data.php
+++ b/tools/generate-wp-function-since-data.php
@@ -43,19 +43,32 @@ foreach ( $scan_dirs as $scan_dir ) {
 	);
 }
 
-// Root-level core entrypoints (e.g. wp-signup.php, wp-cron.php, xmlrpc.php).
-// Restricted to core file names and scanned non-recursively so site-specific
-// files (wp-config.php, custom root scripts, wp-content) do not pollute the dataset.
-$root_files = array_merge(
-	glob( $wordpress_dir . '/wp-*.php' ) ?: array(),
-	glob( $wordpress_dir . '/xmlrpc.php' ) ?: array()
+// Root-level core entrypoints. An explicit allowlist keeps site-specific root
+// files (wp-config.php, custom wp-*.php scripts) out of the core dataset.
+$root_entrypoints = array(
+	'index.php',
+	'wp-activate.php',
+	'wp-blog-header.php',
+	'wp-comments-post.php',
+	'wp-cron.php',
+	'wp-links-opml.php',
+	'wp-load.php',
+	'wp-login.php',
+	'wp-mail.php',
+	'wp-settings.php',
+	'wp-signup.php',
+	'wp-trackback.php',
+	'xmlrpc.php',
 );
-$root_files = array_filter(
-	$root_files,
-	static function ( string $path ): bool {
-		return 'wp-config.php' !== basename( $path );
+
+$root_files = array();
+foreach ( $root_entrypoints as $entrypoint ) {
+	$path = $wordpress_dir . '/' . $entrypoint;
+	if ( is_file( $path ) ) {
+		$root_files[] = $path;
 	}
-);
+}
+
 if ( array() !== $root_files ) {
 	$scan_targets[] = new ArrayIterator(
 		array_map(

--- a/tools/generate-wp-function-since-data.php
+++ b/tools/generate-wp-function-since-data.php
@@ -43,10 +43,20 @@ foreach ( $scan_dirs as $scan_dir ) {
 	);
 }
 
-// Root-level core files (e.g. wp-signup.php, wp-cron.php, xmlrpc.php).
-// Scanned non-recursively so wp-content plugins/themes are excluded.
-$root_files = glob( $wordpress_dir . '/*.php' );
-if ( is_array( $root_files ) && array() !== $root_files ) {
+// Root-level core entrypoints (e.g. wp-signup.php, wp-cron.php, xmlrpc.php).
+// Restricted to core file names and scanned non-recursively so site-specific
+// files (wp-config.php, custom root scripts, wp-content) do not pollute the dataset.
+$root_files = array_merge(
+	glob( $wordpress_dir . '/wp-*.php' ) ?: array(),
+	glob( $wordpress_dir . '/xmlrpc.php' ) ?: array()
+);
+$root_files = array_filter(
+	$root_files,
+	static function ( string $path ): bool {
+		return 'wp-config.php' !== basename( $path );
+	}
+);
+if ( array() !== $root_files ) {
 	$scan_targets[] = new ArrayIterator(
 		array_map(
 			static function ( string $path ): SplFileInfo {

--- a/tools/generate-wp-function-since-data.php
+++ b/tools/generate-wp-function-since-data.php
@@ -35,11 +35,29 @@ foreach ( $scan_dirs as $scan_dir ) {
 
 $function_since = array();
 
+$scan_targets = array();
+
 foreach ( $scan_dirs as $scan_dir ) {
-	$iterator = new RecursiveIteratorIterator(
+	$scan_targets[] = new RecursiveIteratorIterator(
 		new RecursiveDirectoryIterator( $scan_dir, FilesystemIterator::SKIP_DOTS )
 	);
+}
 
+// Root-level core files (e.g. wp-signup.php, wp-cron.php, xmlrpc.php).
+// Scanned non-recursively so wp-content plugins/themes are excluded.
+$root_files = glob( $wordpress_dir . '/*.php' );
+if ( is_array( $root_files ) && array() !== $root_files ) {
+	$scan_targets[] = new ArrayIterator(
+		array_map(
+			static function ( string $path ): SplFileInfo {
+				return new SplFileInfo( $path );
+			},
+			$root_files
+		)
+	);
+}
+
+foreach ( $scan_targets as $iterator ) {
 	foreach ( $iterator as $file_info ) {
 		/** @var SplFileInfo $file_info */
 		if ( 'php' !== strtolower( $file_info->getExtension() ) ) {
@@ -203,7 +221,9 @@ function extract_since_version( string $doc_comment ): string {
 		return '';
 	}
 
-	if ( preg_match( '/@since\s+([0-9]+(?:\.[0-9]+){1,2})/i', $doc_comment, $matches ) ) {
+	// Matches a plain "@since 3.0.0" tag or the frozen "@since MU (3.0.0)" form used by
+	// functions ported from WordPress MU (per the core inline documentation standards).
+	if ( preg_match( '/@since\s+(?:MU\s+\()?([0-9]+(?:\.[0-9]+){1,2})/i', $doc_comment, $matches ) ) {
 		return $matches[1];
 	}
 


### PR DESCRIPTION
Fixes https://github.com/WordPress/plugin-check/issues/1398

## Summary

`tools/generate-wp-function-since-data.php` was silently dropping valid WordPress core functions

## Fixes

- **`@since MU (3.0.0)` docblocks not matched** — the regex required digits right after `@since`, so functions using the frozen `MU (x.y.z)` form (`get_active_blog_for_user`, `wpmu_activate_signup`, `domain_exists`, …) were skipped. 
- **Root-level core files not scanned** — only `wp-includes/` and `wp-admin/` were scanned, missing global functions in `wp-signup.php` (`confirm_blog_signup`), `wp-cron.php`, and `xmlrpc.php`. 
- Other points mentioned in the related Issue is invalid.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fwp-admin%2Ftools.php%3Fpage%3Dplugin-check%22%2C%22phpExtensionBundles%22%3A%5B%22kitchen-sink%22%5D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginZipFile%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fplugin-check%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-1411-13960dacd2de326c876693ee886d2eefd302b7fd.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->