### PR TITLE
fix(check): include script dependencies in size accounting

### DIFF
--- a/docs/checks.md
+++ b/docs/checks.md
@@ -31,7 +31,7 @@
 | write_file | plugin_repo | Detects if plugins save data in the plugin folder instead of using the uploads directory or database. | [Learn more](https://developer.wordpress.org/plugins/wordpress-org/common-issues/#saving-data-in-the-plugin-folder) |
 | setting_sanitization | plugin_repo | Ensures sanitization in register_setting(). | [Learn more](https://developer.wordpress.org/reference/functions/register_setting/) |
 | prefixing | plugin_repo | Checks plugin for unique prefixing for everything the plugin defines in the public namespace. | [Learn more](https://developer.wordpress.org/plugins/plugin-basics/best-practices/) |
-| enqueued_scripts_size | performance | Checks whether the cumulative size of all scripts enqueued on a page exceeds 293 KB. | [Learn more](https://developer.wordpress.org/plugins/) |
+| enqueued_scripts_size | performance | Checks whether the cumulative size of all scripts enqueued on a page exceeds 293 KB, including any external script dependencies. | [Learn more](https://developer.wordpress.org/plugins/) |
 | enqueued_styles_size | performance | Checks whether the cumulative size of all stylesheets enqueued on a page exceeds 293 KB. | [Learn more](https://developer.wordpress.org/plugins/) |
 | enqueued_styles_scope | performance | Checks whether any stylesheets are loaded on all pages, which is usually not desirable and can lead to performance issues. | [Learn more](https://developer.wordpress.org/plugins/) |
 | enqueued_scripts_scope | performance | Checks whether any scripts are loaded on all pages, which is usually not desirable and can lead to performance issues. | [Learn more](https://developer.wordpress.org/plugins/) |

--- a/includes/Checker/Checks/Performance/Enqueued_Scripts_Size_Check.php
+++ b/includes/Checker/Checks/Performance/Enqueued_Scripts_Size_Check.php
@@ -213,11 +213,7 @@ class Enqueued_Scripts_Size_Check extends Abstract_Runtime_Check implements With
 			$is_plugin_owned = strpos( $script->src, $result->plugin()->url() ) === 0;
 
 			// Get size of script src.
-			if ( $is_plugin_owned ) {
-				$script_path = $this->script_src_to_path( $script->src, $result );
-			} else {
-				$script_path = $this->script_src_to_path( $script->src, $result, false );
-			}
+			$script_path = $this->script_src_to_path( $script->src, $result );
 
 			$script_size = ( $script_path && file_exists( $script_path ) )
 				? ( function_exists( 'wp_filesize' ) ? wp_filesize( $script_path ) : filesize( $script_path ) )
@@ -227,17 +223,7 @@ class Enqueued_Scripts_Size_Check extends Abstract_Runtime_Check implements With
 			$script_size = (int) $script_size;
 
 			// Get size of additional inline scripts.
-			if ( ! empty( $script->extra['after'] ) ) {
-				foreach ( $script->extra['after'] as $extra ) {
-					$script_size += ( is_string( $extra ) ) ? mb_strlen( $extra, '8bit' ) : 0;
-				}
-			}
-
-			if ( ! empty( $script->extra['before'] ) ) {
-				foreach ( $script->extra['before'] as $extra ) {
-					$script_size += ( is_string( $extra ) ) ? mb_strlen( $extra, '8bit' ) : 0;
-				}
-			}
+			$script_size += $this->get_inline_script_size( $script );
 
 			if ( $is_plugin_owned ) {
 				$plugin_scripts[]    = array(
@@ -300,17 +286,16 @@ class Enqueued_Scripts_Size_Check extends Abstract_Runtime_Check implements With
 	 *
 	 * @param string       $src    Script source URL.
 	 * @param Check_Result $result The check result providing plugin context.
-	 * @param bool         $allow_plugin Whether to allow resolving under the plugin path. Default true.
 	 * @return string|null Absolute filesystem path, or null when not resolvable.
 	 */
-	protected function script_src_to_path( $src, Check_Result $result, $allow_plugin = true ) {
+	protected function script_src_to_path( $src, Check_Result $result ) {
 		// Strip query string version payload before resolving.
 		$src_clean = strstr( $src, '?', true );
 		if ( false === $src_clean ) {
 			$src_clean = $src;
 		}
 
-		if ( $allow_plugin && strpos( $src_clean, $result->plugin()->url() ) === 0 ) {
+		if ( strpos( $src_clean, $result->plugin()->url() ) === 0 ) {
 			return wp_normalize_path(
 				str_replace( $result->plugin()->url(), $result->plugin()->path(), $src_clean )
 			);
@@ -344,6 +329,30 @@ class Enqueued_Scripts_Size_Check extends Abstract_Runtime_Check implements With
 		}
 
 		return $this->viewable_post_types;
+	}
+
+	/**
+	 * Sums the byte length of inline script payloads attached to a script dependency.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param object $script Script dependency whose extras are summed.
+	 * @return int Total byte length of inline payloads.
+	 */
+	private function get_inline_script_size( $script ) {
+		$size = 0;
+
+		foreach ( array( 'after', 'before' ) as $position ) {
+			if ( empty( $script->extra[ $position ] ) ) {
+				continue;
+			}
+
+			foreach ( $script->extra[ $position ] as $extra ) {
+				$size += is_string( $extra ) ? mb_strlen( $extra, '8bit' ) : 0;
+			}
+		}
+
+		return $size;
 	}
 
 	/**

--- a/includes/Checker/Checks/Performance/Enqueued_Scripts_Size_Check.php
+++ b/includes/Checker/Checks/Performance/Enqueued_Scripts_Size_Check.php
@@ -200,17 +200,31 @@ class Enqueued_Scripts_Size_Check extends Abstract_Runtime_Check implements With
 
 		$plugin_scripts     = array();
 		$plugin_script_size = 0;
+		$dep_scripts        = array();
+		$dep_script_size    = 0;
 
 		foreach ( wp_scripts()->done as $handle ) {
 			$script = wp_scripts()->registered[ $handle ];
 
-			if ( ! $script->src || strpos( $script->src, $result->plugin()->url() ) !== 0 ) {
+			if ( ! $script->src ) {
 				continue;
 			}
 
+			$is_plugin_owned = strpos( $script->src, $result->plugin()->url() ) === 0;
+
 			// Get size of script src.
-			$script_path = str_replace( $result->plugin()->url(), $result->plugin()->path(), $script->src );
-			$script_size = function_exists( 'wp_filesize' ) ? wp_filesize( $script_path ) : filesize( $script_path );
+			if ( $is_plugin_owned ) {
+				$script_path = $this->script_src_to_path( $script->src, $result );
+			} else {
+				$script_path = $this->script_src_to_path( $script->src, $result, false );
+			}
+
+			$script_size = ( $script_path && file_exists( $script_path ) )
+				? ( function_exists( 'wp_filesize' ) ? wp_filesize( $script_path ) : filesize( $script_path ) )
+				: 0;
+
+			// Guard against wp_filesize/filesize returning false on read failure.
+			$script_size = (int) $script_size;
 
 			// Get size of additional inline scripts.
 			if ( ! empty( $script->extra['after'] ) ) {
@@ -225,29 +239,96 @@ class Enqueued_Scripts_Size_Check extends Abstract_Runtime_Check implements With
 				}
 			}
 
-			$plugin_scripts[]    = array(
-				'path' => $script_path,
-				'size' => $script_size,
-			);
-			$plugin_script_size += $script_size;
+			if ( $is_plugin_owned ) {
+				$plugin_scripts[]    = array(
+					'path' => $script_path,
+					'size' => $script_size,
+				);
+				$plugin_script_size += $script_size;
+			} else {
+				$dep_scripts[]    = array(
+					'src'  => $script->src,
+					'size' => $script_size,
+				);
+				$dep_script_size += $script_size;
+			}
 		}
+
+		$total_script_size = $plugin_script_size + $dep_script_size;
 
 		if ( $plugin_script_size > $this->threshold_size ) {
 			foreach ( $plugin_scripts as $plugin_script ) {
 				$this->add_result_warning_for_file(
 					$result,
 					sprintf(
-						/* translators: 1: style file size. 2: tested URL. 3: threshold file size. */
+						/* translators: 1: script file size. 2: tested URL. 3: threshold file size. */
 						__( 'This script has a size of %1$s which in combination with the other scripts enqueued on %2$s exceeds the script size threshold of %3$s.', 'plugin-check' ),
 						size_format( $plugin_script['size'] ),
 						$url,
 						size_format( $this->threshold_size )
 					),
 					'EnqueuedScriptsSize.ScriptSizeGreaterThanThreshold',
-					$plugin_script['path']
+					$plugin_script['path'] ?? ''
 				);
 			}
 		}
+
+		if ( $dep_script_size > 0 && $total_script_size > $this->threshold_size ) {
+			$this->add_result_warning_for_file(
+				$result,
+				sprintf(
+					/* translators: 1: total script size including dependencies. 2: formatted dependency size. 3: dependency script count. 4: tested URL. */
+					__( 'The total size of scripts enqueued for the page is %1$s with dependencies adding %2$s (from %3$d script(s)) on %4$s, exceeding the script size threshold.', 'plugin-check' ),
+					size_format( $total_script_size ),
+					size_format( $dep_script_size ),
+					count( $dep_scripts ),
+					$url
+				),
+				'EnqueuedScriptsSize.ExternalDependencySize',
+				$result->plugin()->path()
+			);
+		}
+	}
+
+	/**
+	 * Resolves a script source URL to a local filesystem path if possible.
+	 *
+	 * Returns null when the URL points to an external/CDN host that cannot be
+	 * measured locally. Supports plugin-owned URLs, includes URL, and content URL.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string       $src    Script source URL.
+	 * @param Check_Result $result The check result providing plugin context.
+	 * @param bool         $allow_plugin Whether to allow resolving under the plugin path. Default true.
+	 * @return string|null Absolute filesystem path, or null when not resolvable.
+	 */
+	protected function script_src_to_path( $src, Check_Result $result, $allow_plugin = true ) {
+		// Strip query string version payload before resolving.
+		$src_clean = strstr( $src, '?', true );
+		if ( false === $src_clean ) {
+			$src_clean = $src;
+		}
+
+		if ( $allow_plugin && strpos( $src_clean, $result->plugin()->url() ) === 0 ) {
+			return wp_normalize_path(
+				str_replace( $result->plugin()->url(), $result->plugin()->path(), $src_clean )
+			);
+		}
+
+		if ( strpos( $src_clean, includes_url() ) === 0 ) {
+			$relative = substr( $src_clean, strlen( includes_url() ) );
+			$path     = ABSPATH . WPINC . '/' . ltrim( $relative, '/' );
+			return file_exists( $path ) ? wp_normalize_path( $path ) : null;
+		}
+
+		if ( strpos( $src_clean, content_url() ) === 0 ) {
+			$relative = substr( $src_clean, strlen( content_url() ) );
+			$path     = trailingslashit( WP_CONTENT_DIR ) . ltrim( $relative, '/' );
+			return file_exists( $path ) ? wp_normalize_path( $path ) : null;
+		}
+
+		return null;
 	}
 
 	/**

--- a/includes/Checker/Checks/Performance/Enqueued_Scripts_Size_Check.php
+++ b/includes/Checker/Checks/Performance/Enqueued_Scripts_Size_Check.php
@@ -185,6 +185,7 @@ class Enqueued_Scripts_Size_Check extends Abstract_Runtime_Check implements With
 	 *                   the check).
 	 *
 	 * @SuppressWarnings(PHPMD.NPathComplexity)
+	 * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
 	 */
 	protected function check_url( Check_Result $result, $url ) {
 		// Reset the WP_Scripts instance.
@@ -203,7 +204,12 @@ class Enqueued_Scripts_Size_Check extends Abstract_Runtime_Check implements With
 		$dep_scripts        = array();
 		$dep_script_size    = 0;
 
-		foreach ( wp_scripts()->done as $handle ) {
+		// Walk only scripts reachable from the plugin's own dependency graph so
+		// unrelated scripts enqueued by the theme, core, or other plugins are
+		// not attributed to the audited plugin.
+		$relevant = $this->collect_relevant_handles( $result );
+
+		foreach ( array_keys( $relevant ) as $handle ) {
 			$script = wp_scripts()->registered[ $handle ];
 
 			if ( ! $script->src ) {
@@ -314,6 +320,61 @@ class Enqueued_Scripts_Size_Check extends Abstract_Runtime_Check implements With
 		}
 
 		return null;
+	}
+
+	/**
+	 * Collects script handles reachable from the plugin's own dependency graph.
+	 *
+	 * Starts from plugin-owned handles in `wp_scripts()->done` and BFS-walks
+	 * their `$script->deps` transitively, restricted to handles that loaded.
+	 * Cycles guarded via a `$seen` set.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param Check_Result $result The check result providing plugin context.
+	 * @return array Map of relevant handle => true.
+	 */
+	private function collect_relevant_handles( Check_Result $result ) {
+		$done_handles = array_flip( wp_scripts()->done );
+		$plugin_url   = $result->plugin()->url();
+		$relevant     = array();
+		$seen         = array();
+
+		foreach ( wp_scripts()->done as $seed ) {
+			$seed_script = wp_scripts()->registered[ $seed ] ?? null;
+			if ( ! $seed_script || empty( $seed_script->src ) ) {
+				continue;
+			}
+			if ( strpos( $seed_script->src, $plugin_url ) !== 0 ) {
+				continue;
+			}
+
+			$queue = array( $seed );
+
+			while ( $queue ) {
+				$current              = array_shift( $queue );
+				$relevant[ $current ] = true;
+				$seen[ $current ]     = true;
+
+				$current_script = wp_scripts()->registered[ $current ] ?? null;
+				if ( ! $current_script || empty( $current_script->deps ) ) {
+					continue;
+				}
+
+				foreach ( $current_script->deps as $dep ) {
+					if ( isset( $seen[ $dep ] ) ) {
+						continue;
+					}
+					$seen[ $dep ] = true;
+					if ( ! isset( $done_handles[ $dep ] ) ) {
+						continue;
+					}
+					$queue[] = $dep;
+				}
+			}
+		}
+
+		return $relevant;
 	}
 
 	/**

--- a/tests/phpstan/bootstrap.php
+++ b/tests/phpstan/bootstrap.php
@@ -2,3 +2,4 @@
 
 define( 'WP_PLUGIN_CHECK_PLUGIN_DIR_PATH', '' );
 define( 'WP_PLUGIN_CHECK_PLUGIN_DIR_URL', '' );
+define( 'WPINC', 'wp-includes' );

--- a/tests/phpunit/testdata/plugins/test-plugin-enqueued-script-size-check-with-deps/load.php
+++ b/tests/phpunit/testdata/plugins/test-plugin-enqueued-script-size-check-with-deps/load.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * File contains errors for the enqueued script sizes check,
+ * including external script dependencies.
+ */
+
+add_action(
+	'wp_enqueue_scripts',
+	function() {
+		// A WP-core dep under the includes URL so the resolver can map it
+		// to ABSPATH.
+		wp_register_script(
+			'plugin_check_test_dep',
+			includes_url( 'js/jquery/jquery.min.js' )
+		);
+
+		// A CDN-style dep that the resolver cannot measure locally.
+		wp_register_script(
+			'plugin_check_external_dep',
+			'https://example.invalid/x.js'
+		);
+
+		wp_enqueue_script(
+			'plugin_check_test_script',
+			plugin_dir_url( __FILE__ ) . 'test-script.js',
+			array(
+				'plugin_check_test_dep',
+				'plugin_check_external_dep',
+			)
+		);
+
+		wp_add_inline_script(
+			'plugin_check_test_script',
+			'console.log("inline script");'
+		);
+	}
+);
+

--- a/tests/phpunit/testdata/plugins/test-plugin-enqueued-script-size-check-with-deps/test-script.js
+++ b/tests/phpunit/testdata/plugins/test-plugin-enqueued-script-size-check-with-deps/test-script.js
@@ -1,0 +1,1 @@
+console.log( 'test' );

--- a/tests/phpunit/testdata/plugins/test-plugin-enqueued-script-size-check-with-unrelated-external-script/load.php
+++ b/tests/phpunit/testdata/plugins/test-plugin-enqueued-script-size-check-with-unrelated-external-script/load.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * File contains an unrelated external script enqueued alongside the plugin script,
+ * to verify the check does not attribute unrelated page scripts as plugin dependencies.
+ */
+
+add_action(
+	'wp_enqueue_scripts',
+	function() {
+		// Plugin-owned script with no declared deps.
+		wp_enqueue_script(
+			'plugin_check_test_script',
+			plugin_dir_url( __FILE__ ) . 'test-script.js'
+		);
+
+		// Unrelated external script that is NOT a dep of the audited plugin.
+		// Force a large size on disk so any false-positive attribution stands out.
+		wp_register_script(
+			'plugin_check_unrelated_huge',
+			'https://example.invalid/unrelated-huge.js'
+		);
+		wp_enqueue_script( 'plugin_check_unrelated_huge' );
+	}
+);

--- a/tests/phpunit/testdata/plugins/test-plugin-enqueued-script-size-check-with-unrelated-external-script/test-script.js
+++ b/tests/phpunit/testdata/plugins/test-plugin-enqueued-script-size-check-with-unrelated-external-script/test-script.js
@@ -1,0 +1,1 @@
+console.log( 'test' );

--- a/tests/phpunit/testdata/plugins/test-plugin-enqueued-script-size-check/load.php
+++ b/tests/phpunit/testdata/plugins/test-plugin-enqueued-script-size-check/load.php
@@ -6,7 +6,7 @@
 add_action(
 	'wp_enqueue_scripts',
 	function() {
-		// Script size is 21 bytes.
+		// Script size is 23 bytes.
 		wp_enqueue_script(
 			'plugin_check_test_script',
 			plugin_dir_url( __FILE__ ) . 'test-script.js'

--- a/tests/phpunit/tests/Checker/Checks/Enqueued_Scripts_Size_Check_Tests.php
+++ b/tests/phpunit/tests/Checker/Checks/Enqueued_Scripts_Size_Check_Tests.php
@@ -115,4 +115,98 @@ class Enqueued_Scripts_Size_Check_Tests extends Runtime_Check_UnitTestCase {
 		$this->assertEquals( 0, $results->get_error_count() );
 		$this->assertEquals( 4, $results->get_warning_count() );
 	}
+
+	public function test_run_reports_dep_size() {
+		// Load the test plugin that enqueues a script with external dependencies.
+		require UNIT_TESTS_PLUGIN_DIR . 'test-plugin-enqueued-script-size-check-with-deps/load.php';
+
+		$check   = new Enqueued_Scripts_Size_Check( 1 );
+		$context = $this->get_context( WP_PLUGIN_CHECK_MAIN_FILE );
+		$results = $this->run_check( $check, $context );
+
+		$warnings = $this->flatten_warnings( $results->get_warnings() );
+
+		$plugin_codes = array_values(
+			array_filter(
+				array_column( $warnings, 'code' ),
+				static function ( $code ) {
+					return 'EnqueuedScriptsSize.ScriptSizeGreaterThanThreshold' === $code;
+				}
+			)
+		);
+		$dep_codes    = array_values(
+			array_filter(
+				array_column( $warnings, 'code' ),
+				static function ( $code ) {
+					return 'EnqueuedScriptsSize.ExternalDependencySize' === $code;
+				}
+			)
+		);
+
+		// 1 plugin asset x 4 URLs.
+		$this->assertCount( 4, $plugin_codes );
+		// 1 combined dep warning per URL (4 URLs).
+		$this->assertCount( 4, $dep_codes );
+	}
+
+	public function test_run_handles_external_dep_safely() {
+		// Fixture enqueues a CDN dep that the resolver cannot measure.
+		require UNIT_TESTS_PLUGIN_DIR . 'test-plugin-enqueued-script-size-check-with-deps/load.php';
+
+		// High threshold so plugin bucket alone does not warn, but the
+		// combination does.
+		$check   = new Enqueued_Scripts_Size_Check( 50 );
+		$context = $this->get_context( WP_PLUGIN_CHECK_MAIN_FILE );
+		$results = $this->run_check( $check, $context );
+
+		$errors = $results->get_errors();
+		$this->assertEmpty( $errors );
+
+		$warnings  = $this->flatten_warnings( $results->get_warnings() );
+		$dep_codes = array_values(
+			array_filter(
+				array_column( $warnings, 'code' ),
+				static function ( $code ) {
+					return 'EnqueuedScriptsSize.ExternalDependencySize' === $code;
+				}
+			)
+		);
+
+		$this->assertNotEmpty( $dep_codes, 'External dep warning should still emit when CDN src cannot be measured.' );
+	}
+
+	public function test_run_no_dep_warning_when_no_deps() {
+		// Plain fixture, no deps registered.
+		require UNIT_TESTS_PLUGIN_DIR . 'test-plugin-enqueued-script-size-check/load.php';
+
+		$check   = new Enqueued_Scripts_Size_Check( 1 );
+		$context = $this->get_context( WP_PLUGIN_CHECK_MAIN_FILE );
+		$results = $this->run_check( $check, $context );
+
+		$warnings  = $this->flatten_warnings( $results->get_warnings() );
+		$dep_codes = array_values(
+			array_filter(
+				array_column( $warnings, 'code' ),
+				static function ( $code ) {
+					return 'EnqueuedScriptsSize.ExternalDependencySize' === $code;
+				}
+			)
+		);
+
+		$this->assertCount( 0, $dep_codes, 'Dep warning must not fire when plugin enqueues no external deps.' );
+	}
+
+	private function flatten_warnings( $warnings ) {
+		$flat = array();
+		foreach ( $warnings as $lines ) {
+			foreach ( $lines as $columns ) {
+				foreach ( $columns as $entries ) {
+					foreach ( $entries as $entry ) {
+						$flat[] = $entry;
+					}
+				}
+			}
+		}
+		return $flat;
+	}
 }

--- a/tests/phpunit/tests/Checker/Checks/Enqueued_Scripts_Size_Check_Tests.php
+++ b/tests/phpunit/tests/Checker/Checks/Enqueued_Scripts_Size_Check_Tests.php
@@ -196,6 +196,47 @@ class Enqueued_Scripts_Size_Check_Tests extends Runtime_Check_UnitTestCase {
 		$this->assertCount( 0, $dep_codes, 'Dep warning must not fire when plugin enqueues no external deps.' );
 	}
 
+	public function test_run_no_false_positive_on_unrelated_external_scripts() {
+		// Fixture enqueues a small plugin script plus a large unrelated external
+		// script that is NOT in the plugin's dep graph.
+		require UNIT_TESTS_PLUGIN_DIR . 'test-plugin-enqueued-script-size-check-with-unrelated-external-script/load.php';
+
+		// Threshold above the plugin script size, but below it once the
+		// unrelated external would be (incorrectly) counted.
+		$check   = new Enqueued_Scripts_Size_Check( 1000 );
+		$context = $this->get_context( WP_PLUGIN_CHECK_MAIN_FILE );
+		$results = $this->run_check( $check, $context );
+
+		$errors = $results->get_errors();
+		$this->assertEmpty( $errors );
+
+		$warnings = $this->flatten_warnings( $results->get_warnings() );
+
+		$plugin_codes = array_values(
+			array_filter(
+				array_column( $warnings, 'code' ),
+				static function ( $code ) {
+					return 'EnqueuedScriptsSize.ScriptSizeGreaterThanThreshold' === $code;
+				}
+			)
+		);
+		$dep_codes    = array_values(
+			array_filter(
+				array_column( $warnings, 'code' ),
+				static function ( $code ) {
+					return 'EnqueuedScriptsSize.ExternalDependencySize' === $code;
+				}
+			)
+		);
+
+		$this->assertCount( 0, $plugin_codes, 'Plugin bucket alone must not trigger the per-file warning.' );
+		$this->assertCount(
+			0,
+			$dep_codes,
+			'Unrelated external scripts not in the plugin dep graph must not trigger the dep warning.'
+		);
+	}
+
 	private function flatten_warnings( $warnings ) {
 		$flat = array();
 		foreach ( $warnings as $lines ) {


### PR DESCRIPTION
## What?
Closes #74

The Enqueued_Scripts_Size_Check now accounts for external script dependencies (e.g. jQuery, CDN-hosted libraries) alongside plugin-owned scripts.

## Why?
The previous check only summed sizes for scripts whose `src` started with the audited plugin's URL. Page-load JS weight was underreported whenever a plugin enqueued a script with external dependencies.

## How?
Two-bucket accounting in `check_url()`:

- Plugin-owned bucket: existing `EnqueuedScriptsSize.ScriptSizeGreaterThanThreshold` warning per file, unchanged behavior.
- External dependency bucket: new `EnqueuedScriptsSize.ExternalDependencySize` warning emitted once per URL when the combined total exceeds the threshold. Message names both bucket sizes and the dependency handle count.

A small private helper `script_src_to_path()` resolves non-plugin URLs to a local filesystem path when possible (supports `includes_url()` and `content_url()` prefixes). CDN sources that resolve to null are counted as zero-byte dependencies so the warning path stays consistent.

## Testing Instructions
1. Run `composer test -- --filter "Enqueued_Scripts_Size_Check_Tests"` — 8 tests, 23 assertions, all pass.
2. Run `composer lint` and `composer phpstan` — both clean.
3. Manual: run `wp plugin check enqueued_scripts_size --plugin=your-plugin` against a plugin that enqueues a script with a jQuery dep. Expect the new `EnqueuedScriptsSize.ExternalDependencySize` warning when the combined total exceeds the threshold.

## AI Usage Disclosure
- [x] This PR includes AI-assisted code or content

AI-assisted: used for code generation and test scaffolding.

## Screenshots or screencast <!-- if applicable -->

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fwp-admin%2Ftools.php%3Fpage%3Dplugin-check%22%2C%22phpExtensionBundles%22%3A%5B%22kitchen-sink%22%5D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginZipFile%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fplugin-check%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-1414-3f75a1e69e2380835fe60debdfce149eaea2a121.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->