### PR TITLE
fix(traits): collapse File_Editor_URL to a single filter

### DIFF
--- a/includes/Traits/File_Editor_URL.php
+++ b/includes/Traits/File_Editor_URL.php
@@ -25,6 +25,9 @@ trait File_Editor_URL {
 	 * @param string       $filename Error file name.
 	 * @param int          $line     Optional. Line number of error. Default 0 (no specific line).
 	 * @return string|null File editor URL or null if not available.
+	 *
+	 * @SuppressWarnings(PHPMD.NPathComplexity)
+	 * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
 	 */
 	protected function get_file_editor_url( Check_Result $result, $filename, $line = 0 ) {
 

--- a/includes/Traits/File_Editor_URL.php
+++ b/includes/Traits/File_Editor_URL.php
@@ -33,67 +33,65 @@ trait File_Editor_URL {
 		$plugin_path = $result->plugin()->path( '/' );
 		$plugin_slug = $result->plugin()->slug();
 		$filename    = str_replace( $plugin_path, '', $filename );
-		/**
-		 * Filters the template for the URL for linking to an external editor to open a file for editing.
-		 *
-		 * Users of IDEs that support opening files in via web protocols can use this filter to override
-		 * the edit link to result in their editor opening rather than the plugin editor.
-		 *
-		 * The initial filtered value is null, requiring extension plugins to supply the URL template
-		 * string themselves. If no template string is provided, links to the plugin editors will
-		 * be provided if available. For example, for an extension plugin to cause file edit links to
-		 * open in an IDE, the following filters can be used:
-		 *
-		 * # PhpStorm
-		 * add_filter( 'wp_plugin_check_validation_error_source_file_editor_url_template', function () {
-		 *     return 'phpstorm://open?file={{file}}&line={{line}}';
-		 * } );
-		 *
-		 * # VS Code
-		 * add_filter( 'wp_plugin_check_validation_error_source_file_editor_url_template', function () {
-		 *     return 'vscode://file/{{file}}:{{line}}';
-		 * } );
-		 *
-		 * For a template to be considered, the string '{{file}}' must be present in the filtered value.
-		 *
-		 * @since 1.0.0
-		 *
-		 * @param string|null $editor_url_template Editor URL template. default null.
-		 */
-		$editor_url_template = apply_filters( 'wp_plugin_check_validation_error_source_file_editor_url_template', null );
 
-		// Supply the file path to the editor template.
-		if ( is_string( $editor_url_template ) && str_contains( $editor_url_template, '{{file}}' ) ) {
-			$file_path = WP_PLUGIN_DIR . '/' . $plugin_slug;
-			if ( $plugin_slug !== $filename ) {
-				$file_path .= '/' . $filename;
-			}
+		$file_path = WP_PLUGIN_DIR . '/' . $plugin_slug;
+		if ( $plugin_slug !== $filename ) {
+			$file_path .= '/' . $filename;
+		}
 
-			if ( file_exists( $file_path ) ) {
-				/**
-				 * Filters the file path to be opened in an external editor for a given PHPCS error source.
-				 *
-				 * This is useful to map the file path from inside of a Docker container or VM to the host machine.
-				 *
-				 * @since 1.0.0
-				 *
-				 * @param string|null $editor_url_template Editor URL template.
-				 * @param array       $source              Source information.
-				 */
-				$file_path = apply_filters( 'wp_plugin_check_validation_error_source_file_path', $file_path, array( $plugin_slug, $filename, $line ) );
-				if ( $file_path ) {
-					$edit_url = str_replace(
-						array(
-							'{{file}}',
-							'{{line}}',
-						),
-						array(
-							rawurlencode( $file_path ),
-							$line,
-						),
-						$editor_url_template
-					);
-				}
+		if ( file_exists( $file_path ) ) {
+			/**
+			 * Filters the URL for linking to an external editor to open a file for editing.
+			 *
+			 * Users of IDEs that support opening files via web protocols can use this filter to
+			 * override the edit link so it opens in their editor rather than the plugin editor.
+			 *
+			 * The initial filtered value is null, requiring extension plugins to supply the URL
+			 * themselves. If no URL is provided, links to the plugin editor are used if available.
+			 * Returning a string that contains `{{file}}` or `{{line}}` placeholders causes them
+			 * to be substituted with the raw filesystem path and the integer line number
+			 * respectively. Returning a string without placeholders uses it verbatim.
+			 *
+			 * For example, to cause file edit links to open in an IDE:
+			 *
+			 * # PhpStorm
+			 * add_filter( 'wp_plugin_check_validation_error_source_url', function ( $url, $source ) {
+			 *     return 'phpstorm://open?file=' . rawurlencode( $source['file'] ) . '&line=' . (int) $source['line'];
+			 * }, 10, 2 );
+			 *
+			 * # VS Code (using placeholders)
+			 * add_filter( 'wp_plugin_check_validation_error_source_url', function ( $url ) {
+			 *     return 'vscode://file/{{file}}:{{line}}';
+			 * } );
+			 *
+			 * @since 2.0.0
+			 *
+			 * @param string|null $url    Editor URL. Default null.
+			 * @param array       $source Source information: file, line, plugin, filename.
+			 */
+			$url = apply_filters(
+				'wp_plugin_check_validation_error_source_url',
+				null,
+				array(
+					'file'     => $file_path,
+					'line'     => $line,
+					'plugin'   => $plugin_slug,
+					'filename' => $filename,
+				)
+			);
+
+			if ( is_string( $url ) && '' !== $url ) {
+				$edit_url = str_replace(
+					array(
+						'{{file}}',
+						'{{line}}',
+					),
+					array(
+						$file_path,
+						(int) $line,
+					),
+					$url
+				);
 			}
 		}
 

--- a/includes/Traits/File_Editor_URL.php
+++ b/includes/Traits/File_Editor_URL.php
@@ -29,6 +29,7 @@ trait File_Editor_URL {
 	protected function get_file_editor_url( Check_Result $result, $filename, $line = 0 ) {
 
 		$edit_url = null;
+		$line     = (int) $line;
 
 		$plugin_path = $result->plugin()->path( '/' );
 		$plugin_slug = $result->plugin()->slug();
@@ -39,59 +40,112 @@ trait File_Editor_URL {
 			$file_path .= '/' . $filename;
 		}
 
-		if ( file_exists( $file_path ) ) {
-			/**
-			 * Filters the URL for linking to an external editor to open a file for editing.
-			 *
-			 * Users of IDEs that support opening files via web protocols can use this filter to
-			 * override the edit link so it opens in their editor rather than the plugin editor.
-			 *
-			 * The initial filtered value is null, requiring extension plugins to supply the URL
-			 * themselves. If no URL is provided, links to the plugin editor are used if available.
-			 * Returning a string that contains `{{file}}` or `{{line}}` placeholders causes them
-			 * to be substituted with the raw filesystem path and the integer line number
-			 * respectively. Returning a string without placeholders uses it verbatim.
-			 *
-			 * For example, to cause file edit links to open in an IDE:
-			 *
-			 * # PhpStorm
-			 * add_filter( 'wp_plugin_check_validation_error_source_url', function ( $url, $source ) {
-			 *     return 'phpstorm://open?file=' . rawurlencode( $source['file'] ) . '&line=' . (int) $source['line'];
-			 * }, 10, 2 );
-			 *
-			 * # VS Code (using placeholders)
-			 * add_filter( 'wp_plugin_check_validation_error_source_url', function ( $url ) {
-			 *     return 'vscode://file/{{file}}:{{line}}';
-			 * } );
-			 *
-			 * @since 2.0.0
-			 *
-			 * @param string|null $url    Editor URL. Default null.
-			 * @param array       $source Source information: file, line, plugin, filename.
-			 */
-			$url = apply_filters(
-				'wp_plugin_check_validation_error_source_url',
-				null,
+		$source = array(
+			'file'     => $file_path,
+			'line'     => $line,
+			'plugin'   => $plugin_slug,
+			'filename' => $filename,
+		);
+
+		/**
+		 * Filters the URL for linking to an external editor to open a file for editing.
+		 *
+		 * Users of IDEs that support opening files via web protocols can use this filter to
+		 * override the edit link so it opens in their editor rather than the plugin editor.
+		 *
+		 * The initial filtered value is null, requiring extension plugins to supply the URL
+		 * themselves. If no URL is provided, links to the plugin editor are used if available.
+		 * Returning a string that contains `{{file}}` or `{{line}}` placeholders causes them
+		 * to be substituted with the raw filesystem path and the integer line number
+		 * respectively. Returning a string without placeholders uses it verbatim.
+		 *
+		 * For example, to cause file edit links to open in an IDE:
+		 *
+		 * # PhpStorm
+		 * add_filter( 'wp_plugin_check_validation_error_source_url', function ( $url, $source ) {
+		 *     return 'phpstorm://open?file=' . rawurlencode( $source['file'] ) . '&line=' . (int) $source['line'];
+		 * }, 10, 2 );
+		 *
+		 * # VS Code (using placeholders)
+		 * add_filter( 'wp_plugin_check_validation_error_source_url', function ( $url ) {
+		 *     return 'vscode://file/{{file}}:{{line}}';
+		 * } );
+		 *
+		 * @since 2.1.0
+		 *
+		 * @param string|null $url    Editor URL. Default null.
+		 * @param array       $source Source information: file, line, plugin, filename.
+		 */
+		$url = apply_filters( 'wp_plugin_check_validation_error_source_url', null, $source );
+
+		if ( is_string( $url ) && '' !== $url && file_exists( $file_path ) ) {
+			$edit_url = str_replace(
 				array(
-					'file'     => $file_path,
-					'line'     => $line,
-					'plugin'   => $plugin_slug,
-					'filename' => $filename,
-				)
+					'{{file}}',
+					'{{line}}',
+				),
+				array(
+					$file_path,
+					$line,
+				),
+				$url
+			);
+		}
+
+		// Backward compatibility for the two-filter chain that this single filter replaces.
+		if ( ! $edit_url && has_filter( 'wp_plugin_check_validation_error_source_file_editor_url_template' ) ) {
+			/**
+			 * Filters the template for the URL for linking to an external editor to open a file for editing.
+			 *
+			 * Users of IDEs that support opening files via web protocols can use this filter to override
+			 * the edit link to result in their editor opening rather than the plugin editor.
+			 *
+			 * @deprecated 2.1.0 Use the `wp_plugin_check_validation_error_source_url` filter instead.
+			 *
+			 * @since 1.0.0
+			 *
+			 * @param string|null $editor_url_template Editor URL template. Default null.
+			 */
+			$editor_url_template = apply_filters_deprecated(
+				'wp_plugin_check_validation_error_source_file_editor_url_template',
+				array( null ),
+				'2.1.0',
+				'wp_plugin_check_validation_error_source_url'
 			);
 
-			if ( is_string( $url ) && '' !== $url ) {
-				$edit_url = str_replace(
-					array(
-						'{{file}}',
-						'{{line}}',
-					),
-					array(
-						$file_path,
-						(int) $line,
-					),
-					$url
+			// Supply the file path to the editor template.
+			if ( is_string( $editor_url_template ) && str_contains( $editor_url_template, '{{file}}' ) && file_exists( $file_path ) ) {
+				/**
+				 * Filters the file path to be opened in an external editor for a given PHPCS error source.
+				 *
+				 * This is useful to map the file path from inside of a Docker container or VM to the host machine.
+				 *
+				 * @deprecated 2.1.0 Use the `wp_plugin_check_validation_error_source_url` filter instead.
+				 *
+				 * @since 1.0.0
+				 *
+				 * @param string|null $file_path File path to be opened in the external editor.
+				 * @param array       $source    Source information.
+				 */
+				$file_path = apply_filters_deprecated(
+					'wp_plugin_check_validation_error_source_file_path',
+					array( $file_path, array( $plugin_slug, $filename, $line ) ),
+					'2.1.0',
+					'wp_plugin_check_validation_error_source_url'
 				);
+				if ( $file_path ) {
+					$edit_url = str_replace(
+						array(
+							'{{file}}',
+							'{{line}}',
+						),
+						array(
+							rawurlencode( $file_path ),
+							$line,
+						),
+						$editor_url_template
+					);
+				}
 			}
 		}
 

--- a/tests/phpunit/tests/Traits/File_Editor_URL_Tests.php
+++ b/tests/phpunit/tests/Traits/File_Editor_URL_Tests.php
@@ -31,6 +31,16 @@ class File_Editor_URL_Tests extends WP_UnitTestCase {
 	private $cap_callbacks = array();
 
 	/**
+	 * User IDs granted super-admin status, so tear_down can revoke them.
+	 *
+	 * Multisite `map_meta_cap('edit_plugins')` requires `is_super_admin()`,
+	 * which a `user_has_cap` filter bypass cannot satisfy.
+	 *
+	 * @var int[]
+	 */
+	private $super_admin_ids = array();
+
+	/**
 	 * Symlink path inside WP_PLUGIN_DIR for the testdata fixture.
 	 *
 	 * @var string|null
@@ -71,6 +81,11 @@ class File_Editor_URL_Tests extends WP_UnitTestCase {
 		}
 		$this->cap_callbacks = array();
 
+		foreach ( $this->super_admin_ids as $id ) {
+			revoke_super_admin( $id );
+		}
+		$this->super_admin_ids = array();
+
 		parent::tear_down();
 	}
 
@@ -102,6 +117,32 @@ class File_Editor_URL_Tests extends WP_UnitTestCase {
 	private function add_cap_filter( $callback ) {
 		add_filter( 'user_has_cap', $callback, 10, 1 );
 		$this->cap_callbacks[] = $callback;
+	}
+
+	/**
+	 * Sets the current user so `current_user_can('edit_plugins')` returns true.
+	 *
+	 * On multisite, WP core requires `is_super_admin()` for the `edit_plugins`
+	 * cap (see WP capabilities.php `map_meta_cap`). A `user_has_cap` filter
+	 * bypasses that check on single-site only, so the test must escalate the
+	 * user with `grant_super_admin()` when multisite is active.
+	 */
+	private function switch_to_editor_user() {
+		$user_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
+
+		if ( is_multisite() ) {
+			grant_super_admin( $user_id );
+			$this->super_admin_ids[] = $user_id;
+		} else {
+			$this->add_cap_filter(
+				static function ( $caps ) {
+					$caps['edit_plugins'] = true;
+					return $caps;
+				}
+			);
+		}
+
+		wp_set_current_user( $user_id );
 	}
 
 	/**
@@ -201,12 +242,7 @@ class File_Editor_URL_Tests extends WP_UnitTestCase {
 	 * When `$line === 0`, the fallback URL must omit the `line` query arg entirely.
 	 */
 	public function test_fallback_to_plugin_editor_when_no_filter() {
-		$this->add_cap_filter(
-			static function ( $caps ) {
-				$caps['edit_plugins'] = true;
-				return $caps;
-			}
-		);
+		$this->switch_to_editor_user();
 
 		$context = new Check_Context( $this->single_file_plugin_basename() );
 		$result  = new Check_Result( $context );
@@ -225,12 +261,7 @@ class File_Editor_URL_Tests extends WP_UnitTestCase {
 	 * Plugin-editor fallback includes `line` query arg when line is set.
 	 */
 	public function test_fallback_to_plugin_editor_includes_line_when_set() {
-		$this->add_cap_filter(
-			static function ( $caps ) {
-				$caps['edit_plugins'] = true;
-				return $caps;
-			}
-		);
+		$this->switch_to_editor_user();
 
 		$context = new Check_Context( $this->single_file_plugin_basename() );
 		$result  = new Check_Result( $context );

--- a/tests/phpunit/tests/Traits/File_Editor_URL_Tests.php
+++ b/tests/phpunit/tests/Traits/File_Editor_URL_Tests.php
@@ -31,9 +31,36 @@ class File_Editor_URL_Tests extends WP_UnitTestCase {
 	private $cap_callbacks = array();
 
 	/**
-	 * Removes only the filter callbacks this test class registered.
+	 * Symlink path inside WP_PLUGIN_DIR for the testdata fixture.
+	 *
+	 * @var string|null
+	 */
+	private $fixture_symlink = null;
+
+	/**
+	 * Sets up the test fixture symlink so file_exists passes inside wp-env.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		$this->fixture_symlink = WP_PLUGIN_DIR . '/test-plugin-external-admin-menu-links-without-errors';
+		$target                = UNIT_TESTS_PLUGIN_DIR . 'test-plugin-external-admin-menu-links-without-errors';
+
+		if ( ! file_exists( $this->fixture_symlink ) && is_dir( $target ) ) {
+			symlink( $target, $this->fixture_symlink );
+		}
+	}
+
+	/**
+	 * Removes the test fixture symlink and filter callbacks.
 	 */
 	public function tear_down() {
+		// Remove symlink created in set_up.
+		if ( null !== $this->fixture_symlink && file_exists( $this->fixture_symlink ) && is_link( $this->fixture_symlink ) ) {
+			unlink( $this->fixture_symlink );
+		}
+		$this->fixture_symlink = null;
+
 		foreach ( $this->url_callbacks as $cb ) {
 			remove_filter( 'wp_plugin_check_validation_error_source_url', $cb, 10 );
 		}
@@ -48,12 +75,12 @@ class File_Editor_URL_Tests extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Single-file test plugin fixture basename (load.php in fixture dir).
+	 * Absolute path to the single-file test plugin fixture (load.php in fixture dir).
 	 *
 	 * @return string
 	 */
 	private function single_file_plugin_basename() {
-		return 'test-plugin-external-admin-menu-links-without-errors/load.php';
+		return WP_PLUGIN_DIR . '/test-plugin-external-admin-menu-links-without-errors/load.php';
 	}
 
 	/**
@@ -191,7 +218,7 @@ class File_Editor_URL_Tests extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'plugin', $query_args );
 		$this->assertArrayHasKey( 'file', $query_args );
 		$this->assertArrayNotHasKey( 'line', $query_args );
-		$this->assertSame( 'plugin-editor.php', wp_parse_url( $url, PHP_URL_PATH ) );
+		$this->assertSame( 'plugin-editor.php', basename( (string) wp_parse_url( $url, PHP_URL_PATH ) ) );
 	}
 
 	/**
@@ -213,6 +240,6 @@ class File_Editor_URL_Tests extends WP_UnitTestCase {
 		$this->assertIsString( $url );
 		parse_str( (string) wp_parse_url( $url, PHP_URL_QUERY ), $query_args );
 		$this->assertSame( '42', $query_args['line'] );
-		$this->assertSame( 'plugin-editor.php', wp_parse_url( $url, PHP_URL_PATH ) );
+		$this->assertSame( 'plugin-editor.php', basename( (string) wp_parse_url( $url, PHP_URL_PATH ) ) );
 	}
 }

--- a/tests/phpunit/tests/Traits/File_Editor_URL_Tests.php
+++ b/tests/phpunit/tests/Traits/File_Editor_URL_Tests.php
@@ -41,11 +41,25 @@ class File_Editor_URL_Tests extends WP_UnitTestCase {
 	private $super_admin_ids = array();
 
 	/**
+	 * Legacy filter callbacks registered by each test, removed in tear_down.
+	 *
+	 * @var array[]
+	 */
+	private $legacy_callbacks = array();
+
+	/**
 	 * Symlink path inside WP_PLUGIN_DIR for the testdata fixture.
 	 *
 	 * @var string|null
 	 */
 	private $fixture_symlink = null;
+
+	/**
+	 * Whether the testdata fixture symlink could be created inside WP_PLUGIN_DIR.
+	 *
+	 * @var bool
+	 */
+	private $fixture_symlink_ready = false;
 
 	/**
 	 * Sets up the test fixture symlink so file_exists passes inside wp-env.
@@ -56,8 +70,23 @@ class File_Editor_URL_Tests extends WP_UnitTestCase {
 		$this->fixture_symlink = WP_PLUGIN_DIR . '/test-plugin-external-admin-menu-links-without-errors';
 		$target                = UNIT_TESTS_PLUGIN_DIR . 'test-plugin-external-admin-menu-links-without-errors';
 
-		if ( ! file_exists( $this->fixture_symlink ) && is_dir( $target ) ) {
-			symlink( $target, $this->fixture_symlink );
+		if ( is_link( $this->fixture_symlink ) ) {
+			$this->fixture_symlink_ready = true;
+		} elseif ( is_dir( $target ) && ! file_exists( $this->fixture_symlink ) && symlink( $target, $this->fixture_symlink ) ) {
+			$this->fixture_symlink_ready = true;
+		}
+	}
+
+	/**
+	 * Skips the test when the fixture symlink could not be created.
+	 *
+	 * The symlink is required so the trait's `file_exists()` check passes for the
+	 * external-editor filter branch. Without it the related tests error out in a
+	 * confusing way instead of skipping cleanly.
+	 */
+	private function require_fixture_symlink() {
+		if ( ! $this->fixture_symlink_ready ) {
+			$this->markTestSkipped( 'Fixture symlink unavailable; cannot place plugin fixture under WP_PLUGIN_DIR.' );
 		}
 	}
 
@@ -75,6 +104,13 @@ class File_Editor_URL_Tests extends WP_UnitTestCase {
 			remove_filter( 'wp_plugin_check_validation_error_source_url', $cb, 10 );
 		}
 		$this->url_callbacks = array();
+
+		foreach ( $this->legacy_callbacks as $legacy ) {
+			remove_filter( $legacy['hook'], $legacy['callback'], 10 );
+		}
+		$this->legacy_callbacks = array();
+
+		remove_filter( 'deprecated_hook_trigger_error', '__return_false' );
 
 		foreach ( $this->cap_callbacks as $cb ) {
 			remove_filter( 'user_has_cap', $cb, 10 );
@@ -107,6 +143,21 @@ class File_Editor_URL_Tests extends WP_UnitTestCase {
 	private function add_url_filter( $callback, $accepted_args = 1 ) {
 		add_filter( 'wp_plugin_check_validation_error_source_url', $callback, 10, $accepted_args );
 		$this->url_callbacks[] = $callback;
+	}
+
+	/**
+	 * Registers a legacy (deprecated) filter callback and tracks it for cleanup.
+	 *
+	 * @param string   $hook     Legacy filter hook.
+	 * @param callable $callback Filter callback.
+	 * @param int      $args     Number of accepted args.
+	 */
+	private function add_legacy_filter( $hook, $callback, $args = 1 ) {
+		add_filter( $hook, $callback, 10, $args );
+		$this->legacy_callbacks[] = array(
+			'hook'     => $hook,
+			'callback' => $callback,
+		);
 	}
 
 	/**
@@ -167,6 +218,8 @@ class File_Editor_URL_Tests extends WP_UnitTestCase {
 	 * correctly. `{{line}}` is replaced with the integer line number.
 	 */
 	public function test_filter_url_with_placeholders_substituted() {
+		$this->require_fixture_symlink();
+
 		$this->add_url_filter(
 			static function ( $url ) {
 				return 'vscode://file/{{file}}:{{line}}';
@@ -188,6 +241,8 @@ class File_Editor_URL_Tests extends WP_UnitTestCase {
 	 * Filter returning a string without placeholders is used verbatim.
 	 */
 	public function test_filter_url_without_placeholders_used_verbatim() {
+		$this->require_fixture_symlink();
+
 		$this->add_url_filter(
 			static function ( $url, $source ) {
 				return 'phpstorm://open?file=' . rawurlencode( $source['file'] ) . '&line=' . (int) $source['line'];
@@ -210,6 +265,8 @@ class File_Editor_URL_Tests extends WP_UnitTestCase {
 	 * Filter receives the $source array with file, line, plugin, filename keys.
 	 */
 	public function test_filter_receives_source_array() {
+		$this->require_fixture_symlink();
+
 		$captured = null;
 
 		$this->add_url_filter(
@@ -272,5 +329,41 @@ class File_Editor_URL_Tests extends WP_UnitTestCase {
 		parse_str( (string) wp_parse_url( $url, PHP_URL_QUERY ), $query_args );
 		$this->assertSame( '42', $query_args['line'] );
 		$this->assertSame( 'plugin-editor.php', basename( (string) wp_parse_url( $url, PHP_URL_PATH ) ) );
+	}
+
+	/**
+	 * Legacy two-filter chain still works through the deprecation shims.
+	 *
+	 * Registers the old `..._file_editor_url_template` and `..._file_path` filters
+	 * and asserts the URL is computed from the remapped path and the line number,
+	 * matching the pre-refactor behavior.
+	 */
+	public function test_legacy_filters_work_via_deprecated_shim() {
+		$this->require_fixture_symlink();
+		add_filter( 'deprecated_hook_trigger_error', '__return_false' );
+
+		$this->add_legacy_filter(
+			'wp_plugin_check_validation_error_source_file_editor_url_template',
+			static function () {
+				return 'vscode://file/{{file}}:{{line}}';
+			}
+		);
+		$this->add_legacy_filter(
+			'wp_plugin_check_validation_error_source_file_path',
+			static function ( $path, $source ) {
+				return '/host/mapped' . $path;
+			},
+			2
+		);
+
+		$context = new Check_Context( $this->single_file_plugin_basename() );
+		$result  = new Check_Result( $context );
+
+		$root = WP_PLUGIN_DIR . '/test-plugin-external-admin-menu-links-without-errors/load.php';
+
+		$this->assertSame(
+			'vscode://file/' . rawurlencode( '/host/mapped' . $root ) . ':9',
+			$this->get_file_editor_url( $result, 'load.php', 9 )
+		);
 	}
 }

--- a/tests/phpunit/tests/Traits/File_Editor_URL_Tests.php
+++ b/tests/phpunit/tests/Traits/File_Editor_URL_Tests.php
@@ -337,6 +337,9 @@ class File_Editor_URL_Tests extends WP_UnitTestCase {
 	 * Registers the old `..._file_editor_url_template` and `..._file_path` filters
 	 * and asserts the URL is computed from the remapped path and the line number,
 	 * matching the pre-refactor behavior.
+	 *
+	 * @expectedDeprecated wp_plugin_check_validation_error_source_file_editor_url_template
+	 * @expectedDeprecated wp_plugin_check_validation_error_source_file_path
 	 */
 	public function test_legacy_filters_work_via_deprecated_shim() {
 		$this->require_fixture_symlink();

--- a/tests/phpunit/tests/Traits/File_Editor_URL_Tests.php
+++ b/tests/phpunit/tests/Traits/File_Editor_URL_Tests.php
@@ -1,0 +1,218 @@
+<?php
+/**
+ * Tests for the File_Editor_URL trait.
+ *
+ * @package plugin-check
+ */
+
+use WordPress\Plugin_Check\Checker\Check_Context;
+use WordPress\Plugin_Check\Checker\Check_Result;
+use WordPress\Plugin_Check\Traits\File_Editor_URL;
+
+class File_Editor_URL_Tests extends WP_UnitTestCase {
+
+	use File_Editor_URL;
+
+	/**
+	 * URL filter callbacks registered by each test, removed in tear_down.
+	 *
+	 * Anonymous closures cannot be removed via remove_filter without the callable
+	 * reference, so each test stores every callback it added and removes them by reference.
+	 *
+	 * @var callable[]
+	 */
+	private $url_callbacks = array();
+
+	/**
+	 * User cap filter callbacks registered by each test, removed in tear_down.
+	 *
+	 * @var callable[]
+	 */
+	private $cap_callbacks = array();
+
+	/**
+	 * Removes only the filter callbacks this test class registered.
+	 */
+	public function tear_down() {
+		foreach ( $this->url_callbacks as $cb ) {
+			remove_filter( 'wp_plugin_check_validation_error_source_url', $cb, 10 );
+		}
+		$this->url_callbacks = array();
+
+		foreach ( $this->cap_callbacks as $cb ) {
+			remove_filter( 'user_has_cap', $cb, 10 );
+		}
+		$this->cap_callbacks = array();
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Single-file test plugin fixture basename (load.php in fixture dir).
+	 *
+	 * @return string
+	 */
+	private function single_file_plugin_basename() {
+		return 'test-plugin-external-admin-menu-links-without-errors/load.php';
+	}
+
+	/**
+	 * Registers a url filter callback and tracks it for cleanup.
+	 *
+	 * @param callable $callback      Filter callback.
+	 * @param int      $accepted_args Number of args the callback accepts.
+	 */
+	private function add_url_filter( $callback, $accepted_args = 1 ) {
+		add_filter( 'wp_plugin_check_validation_error_source_url', $callback, 10, $accepted_args );
+		$this->url_callbacks[] = $callback;
+	}
+
+	/**
+	 * Registers a user_has_cap callback and tracks it for cleanup.
+	 *
+	 * @param callable $callback Filter callback.
+	 */
+	private function add_cap_filter( $callback ) {
+		add_filter( 'user_has_cap', $callback, 10, 1 );
+		$this->cap_callbacks[] = $callback;
+	}
+
+	/**
+	 * When no filter is registered and the user lacks edit_plugins cap, returns null.
+	 */
+	public function test_returns_null_without_filter_and_without_caps() {
+		wp_set_current_user( 0 );
+
+		$context = new Check_Context( $this->single_file_plugin_basename() );
+		$result  = new Check_Result( $context );
+
+		$url = $this->get_file_editor_url( $result, 'load.php', 42 );
+
+		$this->assertNull( $url );
+	}
+
+	/**
+	 * Filter returning a template with placeholders gets them substituted verbatim.
+	 *
+	 * `{{file}}` is replaced with the raw filesystem path (no URL encoding) so that
+	 * editor URI schemes like `vscode://file/{{file}}:{{line}}` interpret the path
+	 * correctly. `{{line}}` is replaced with the integer line number.
+	 */
+	public function test_filter_url_with_placeholders_substituted() {
+		$this->add_url_filter(
+			static function ( $url ) {
+				return 'vscode://file/{{file}}:{{line}}';
+			}
+		);
+
+		$context = new Check_Context( $this->single_file_plugin_basename() );
+		$result  = new Check_Result( $context );
+
+		$root = WP_PLUGIN_DIR . '/test-plugin-external-admin-menu-links-without-errors/load.php';
+
+		$this->assertSame(
+			'vscode://file/' . $root . ':7',
+			$this->get_file_editor_url( $result, 'load.php', 7 )
+		);
+	}
+
+	/**
+	 * Filter returning a string without placeholders is used verbatim.
+	 */
+	public function test_filter_url_without_placeholders_used_verbatim() {
+		$this->add_url_filter(
+			static function ( $url, $source ) {
+				return 'phpstorm://open?file=' . rawurlencode( $source['file'] ) . '&line=' . (int) $source['line'];
+			},
+			2
+		);
+
+		$context = new Check_Context( $this->single_file_plugin_basename() );
+		$result  = new Check_Result( $context );
+
+		$expected = 'phpstorm://open?file=' . rawurlencode( WP_PLUGIN_DIR . '/test-plugin-external-admin-menu-links-without-errors/load.php' ) . '&line=9';
+
+		$this->assertSame(
+			$expected,
+			$this->get_file_editor_url( $result, 'load.php', 9 )
+		);
+	}
+
+	/**
+	 * Filter receives the $source array with file, line, plugin, filename keys.
+	 */
+	public function test_filter_receives_source_array() {
+		$captured = null;
+
+		$this->add_url_filter(
+			static function ( $url, $source ) use ( &$captured ) {
+				$captured = $source;
+				return 'noop://handler';
+			},
+			2
+		);
+
+		$context = new Check_Context( $this->single_file_plugin_basename() );
+		$result  = new Check_Result( $context );
+
+		$this->get_file_editor_url( $result, 'load.php', 5 );
+
+		$this->assertIsArray( $captured );
+		$this->assertArrayHasKey( 'file', $captured );
+		$this->assertArrayHasKey( 'line', $captured );
+		$this->assertArrayHasKey( 'plugin', $captured );
+		$this->assertArrayHasKey( 'filename', $captured );
+		$this->assertSame( 5, $captured['line'] );
+		$this->assertSame( 'test-plugin-external-admin-menu-links-without-errors', $captured['plugin'] );
+		$this->assertSame( 'load.php', $captured['filename'] );
+		$this->assertSame( WP_PLUGIN_DIR . '/test-plugin-external-admin-menu-links-without-errors/load.php', $captured['file'] );
+	}
+
+	/**
+	 * Plugin-editor fallback is used when filter is not registered and user has edit_plugins cap.
+	 *
+	 * When `$line === 0`, the fallback URL must omit the `line` query arg entirely.
+	 */
+	public function test_fallback_to_plugin_editor_when_no_filter() {
+		$this->add_cap_filter(
+			static function ( $caps ) {
+				$caps['edit_plugins'] = true;
+				return $caps;
+			}
+		);
+
+		$context = new Check_Context( $this->single_file_plugin_basename() );
+		$result  = new Check_Result( $context );
+
+		$url = $this->get_file_editor_url( $result, 'load.php', 0 );
+
+		$this->assertIsString( $url );
+		parse_str( (string) wp_parse_url( $url, PHP_URL_QUERY ), $query_args );
+		$this->assertArrayHasKey( 'plugin', $query_args );
+		$this->assertArrayHasKey( 'file', $query_args );
+		$this->assertArrayNotHasKey( 'line', $query_args );
+		$this->assertSame( 'plugin-editor.php', wp_parse_url( $url, PHP_URL_PATH ) );
+	}
+
+	/**
+	 * Plugin-editor fallback includes `line` query arg when line is set.
+	 */
+	public function test_fallback_to_plugin_editor_includes_line_when_set() {
+		$this->add_cap_filter(
+			static function ( $caps ) {
+				$caps['edit_plugins'] = true;
+				return $caps;
+			}
+		);
+
+		$context = new Check_Context( $this->single_file_plugin_basename() );
+		$result  = new Check_Result( $context );
+
+		$url = $this->get_file_editor_url( $result, 'load.php', 42 );
+
+		$this->assertIsString( $url );
+		parse_str( (string) wp_parse_url( $url, PHP_URL_QUERY ), $query_args );
+		$this->assertSame( '42', $query_args['line'] );
+		$this->assertSame( 'plugin-editor.php', wp_parse_url( $url, PHP_URL_PATH ) );
+	}
+}


### PR DESCRIPTION
## What?
Closes #314

The `File_Editor_URL` trait previously exposed two filters (`..._file_editor_url_template` and `..._file_path`) that consumers had to register together to override the editor link. This refactor collapses them into a single filter, `wp_plugin_check_validation_error_source_url`, that receives a `$source` array and returns either a URL string or `null` to fall back to the plugin editor.

## Why?
Felix Arntz called out in PR #298 review that the two-filter chain is overly complex for IDE integrations. This PR addresses the followup explicitly filed as issue #314.

The `{{file}}` placeholder is now substituted with the raw filesystem path (no URL encoding) so URI schemes like `vscode://file/{{file}}:{{line}}` resolve correctly. `{{line}}` is substituted with the integer line number. Returning a string without placeholders is used verbatim.

## How?
- Replaced the two `apply_filters` calls with a single `apply_filters( 'wp_plugin_check_validation_error_source_url', null, $source )` that gives the consumer everything it needs in one callback.
- Inline-substitute `{{file}}` and `{{line}}` inside the trait from the same `$source` array.
- The plugin-editor fallback path is unchanged; `line=` is still only appended when `$line > 0`.
- Public method signature `get_file_editor_url( Check_Result $result, $filename, $line = 0 )` is unchanged. No callsite updates needed.
- Added `tests/phpunit/tests/Traits/File_Editor_URL_Tests.php` covering: filter returning a placeholder template (with raw-path substitution), filter returning a fully formed URL, the `$source` payload, fallback with line omitted when `$line === 0`, fallback including line when `$line > 0`, and the no-filter / no-cap path returning `null`.

## Backward Compatibility
The two old filters are deprecated in 2.1.0 but still work via `apply_filters_deprecated()` shims that map them onto the new single filter. Existing integrations do not need changes. New integrations should use `wp_plugin_check_validation_error_source_url` and read `$source['line']` (already an integer) and `$source['file']` (the raw filesystem path). Consumers using query-parameter editor schemes (for example PhpStorm) must URL-encode the path themselves, for example `'phpstorm://open?file=' . rawurlencode( $source['file'] )`.

## Testing Instructions
1. `composer install` (or `composer update` if vendor is stale).
2. `composer test` — confirm green for `File_Editor_URL_Tests`. PHPUnit requires `WP_TESTS_DIR` to be set (CI handles this).
3. `composer lint` — PHPCS clean.
4. `composer phpstan` — zero errors.
5. Manual smoke: install the built zip, run a check that produces a file-line message (e.g. Plugin Header Fields Check), confirm the editor link falls back to `wp-admin/plugin-editor.php?plugin=...&file=...&line=...` correctly when no filter is registered.

## AI Usage Disclosure
- [ ] This PR was created without the help of AI tools
- [x] This PR includes AI-assisted code or content

If AI tools were used, please describe how they were used:
AI-assisted scaffolding of the PHPUnit test file. The trait refactor (filter contract, placeholder substitution, fallback path) was implemented manually and verified against the linked issue.

## Screenshots or screencast <!-- if applicable -->

Utility trait change, no user-facing UI change.

| Before | After |
| ------ | ----- |
| Two filter hooks (`..._file_editor_url_template`, `..._file_path`) | Single filter hook `wp_plugin_check_validation_error_source_url` |

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fwp-admin%2Ftools.php%3Fpage%3Dplugin-check%22%2C%22phpExtensionBundles%22%3A%5B%22kitchen-sink%22%5D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginZipFile%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fplugin-check%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-1417-36763f9bbb935d2a1d28f1a46a861120d6dd1071.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->
