### PR TITLE
Preserve Unicode characters in results exports

### DIFF
--- a/includes/Utilities/Results_Exporter.php
+++ b/includes/Utilities/Results_Exporter.php
@@ -200,7 +200,8 @@ final class Results_Exporter {
 			'results'      => $grouped_results,
 		);
 
-		return wp_json_encode( $payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES );
+		return wp_json_encode( $payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE );
+
 	}
 
 	/**
@@ -236,7 +237,8 @@ final class Results_Exporter {
 			),
 		);
 
-		return wp_json_encode( $payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES );
+		return wp_json_encode( $payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE );
+
 	}
 
 	/**

--- a/includes/Utilities/Results_Exporter.php
+++ b/includes/Utilities/Results_Exporter.php
@@ -201,7 +201,6 @@ final class Results_Exporter {
 		);
 
 		return wp_json_encode( $payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE );
-
 	}
 
 	/**
@@ -238,7 +237,6 @@ final class Results_Exporter {
 		);
 
 		return wp_json_encode( $payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE );
-
 	}
 
 	/**


### PR DESCRIPTION
Preserve Unicode characters in results exports

This change updates Results_Exporter.php to preserve readable UTF-8 text in exported JSON reports.

Previously, localized messages could be escaped as Unicode sequences such as \u067e..., which made Persian and other non-Latin text harder to read in exported output.

By adding JSON_UNESCAPED_UNICODE to the JSON encoding flags, human-readable localized messages are kept intact while the report remains valid JSON.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fwp-admin%2Ftools.php%3Fpage%3Dplugin-check%22%2C%22phpExtensionBundles%22%3A%5B%22kitchen-sink%22%5D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginZipFile%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fplugin-check%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-1424-f501e457c15e041ac20af39497ea5d75cd745ba3.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->